### PR TITLE
fix(core): simplify conversion of full text search response

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -88,6 +88,12 @@
                         "modifiers": ["readonly"],
                         "format": ["UPPER_CASE"],
                         "trailingUnderscore": "allow"
+                    },
+                    {
+                        "selector": "objectLiteralProperty",
+                        "format": ["camelCase", "UPPER_CASE", "snake_case"],
+                        "leadingUnderscore": "allow",
+                        "trailingUnderscore": "allow"
                     }
                 ],
                 "@typescript-eslint/no-empty-function": "off",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,8 +2,7 @@
 import { Location } from '@angular/common';
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { Router, Routes } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, RouterModule, Routes } from '@angular/router';
 
 import Spy = jasmine.Spy;
 
@@ -60,7 +59,7 @@ describe('AppComponent (DONE)', () => {
         };
 
         TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes(MOCK_ROUTES)],
+            imports: [RouterModule.forRoot(MOCK_ROUTES)],
             declarations: [
                 AppComponent,
                 FooterStubComponent,

--- a/src/app/core/services/conversion-service/conversion.service.spec.ts
+++ b/src/app/core/services/conversion-service/conversion.service.spec.ts
@@ -317,7 +317,57 @@ describe('ConversionService', () => {
             expect((conversionService as any)._cleanSubjectValueLabels).toBeDefined();
         });
 
-        it('... should clean valuelabel and obj_id', () => {
+        describe('... should return default valuelabel and obj_id if', () => {
+            it('... values are undefined', () => {
+                const subject = {
+                    valuelabel: undefined,
+                    obj_id: undefined,
+                };
+
+                const result = (conversionService as any)._cleanSubjectValueLabels(subject);
+
+                expect(result.valuelabel).toBeUndefined();
+                expectToBe(result.obj_id, '');
+            });
+
+            it('... values are null', () => {
+                const subject = {
+                    valuelabel: null,
+                    obj_id: null,
+                };
+
+                const result = (conversionService as any)._cleanSubjectValueLabels(subject);
+
+                expect(result.valuelabel).toBeNull();
+                expectToBe(result.obj_id, '');
+            });
+
+            it('... values are empty', () => {
+                const subject = {
+                    valuelabel: [],
+                    obj_id: '',
+                };
+
+                const result = (conversionService as any)._cleanSubjectValueLabels(subject);
+
+                expectToEqual(result.valuelabel, []);
+                expectToBe(result.obj_id, '');
+            });
+        });
+
+        it('... should return original valuelabel and obj_id if no replacement is needed', () => {
+            const subject = {
+                valuelabel: ['Test2'],
+                obj_id: '245',
+            };
+
+            const result = (conversionService as any)._cleanSubjectValueLabels(subject);
+
+            expectToEqual(result.valuelabel, ['Test2']);
+            expectToBe(result.obj_id, '245');
+        });
+
+        it('... should clean up given valuelabel and obj_id', () => {
             const subject = {
                 valuelabel: ['Test (Richtext)'],
                 obj_id: '123_-_local',
@@ -325,7 +375,7 @@ describe('ConversionService', () => {
 
             const result = (conversionService as any)._cleanSubjectValueLabels(subject);
 
-            expectToBe(result.valuelabel[0], 'Test');
+            expectToEqual(result.valuelabel, ['Test']);
             expectToBe(result.obj_id, '123');
         });
 
@@ -338,7 +388,7 @@ describe('ConversionService', () => {
 
             const result = (conversionService as any)._cleanSubjectValueLabels(subject);
 
-            expectToBe(result.valuelabel[0], 'Test');
+            expectToEqual(result.valuelabel, ['Test']);
             expectToBe(result.obj_id, '123');
             expectToBe(result.otherProp, 'otherValue');
         });

--- a/src/app/core/services/conversion-service/conversion.service.spec.ts
+++ b/src/app/core/services/conversion-service/conversion.service.spec.ts
@@ -4,10 +4,11 @@ import { TestBed } from '@angular/core/testing';
 import Spy = jasmine.Spy;
 
 import { cleanStylesFromDOM } from '@testing/clean-up-helper';
-import { mockSearchResponseJson } from '@testing/mock-data';
 import { expectSpyCall, expectToBe, expectToEqual } from '@testing/expect-helper';
+import { mockSearchResponseJson } from '@testing/mock-data';
 
 import { AppModule } from '@awg-app/app.module';
+import { SearchResponseJson } from '@awg-shared/api-objects';
 import { SearchResponseWithQuery } from '@awg-views/data-view/models';
 
 import { ConversionService } from './conversion.service';
@@ -15,11 +16,14 @@ import { ConversionService } from './conversion.service';
 describe('ConversionService', () => {
     let conversionService: ConversionService;
 
+    let expectedSearchResponse: SearchResponseJson;
+
+    let cleanSubjectValuesSpy: Spy;
+    let cleanSubjectValueLabelsSpy: Spy;
     let convertStandoffToHTMLSpy: Spy;
+    let distinctSubjectsSpy: Spy;
     let replaceParagraphTagsSpy: Spy;
     let replaceSalsahLinkSpy: Spy;
-
-    // TODO: add APP_BASE_HREF , see https://angular.io/api/common/APP_BASE_HREF
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -28,11 +32,16 @@ describe('ConversionService', () => {
         });
         conversionService = TestBed.inject(ConversionService);
 
+        expectedSearchResponse = JSON.parse(JSON.stringify(mockSearchResponseJson));
+
         // Spies for service methods
         replaceParagraphTagsSpy = spyOn(ConversionService, 'replaceParagraphTags').and.callThrough();
 
-        replaceSalsahLinkSpy = spyOn<any>(conversionService, '_replaceSalsahLink').and.callThrough();
+        cleanSubjectValuesSpy = spyOn<any>(conversionService, '_cleanSubjectValues').and.callThrough();
+        cleanSubjectValueLabelsSpy = spyOn<any>(conversionService, '_cleanSubjectValueLabels').and.callThrough();
         convertStandoffToHTMLSpy = spyOn<any>(conversionService, '_convertStandoffToHTML').and.callThrough();
+        distinctSubjectsSpy = spyOn<any>(conversionService, '_distinctSubjects').and.callThrough();
+        replaceSalsahLinkSpy = spyOn<any>(conversionService, '_replaceSalsahLink').and.callThrough();
     });
 
     afterAll(() => {
@@ -43,12 +52,123 @@ describe('ConversionService', () => {
         expect(conversionService).toBeTruthy();
     });
 
-    it('... should not have filteredOut before convertFullTextSearchResults call', () => {
+    it('... should not have `filteredOut` before call to `convertFullTextSearchResults`', () => {
         expect(conversionService.filteredOut).toBeUndefined();
 
-        conversionService.convertFullTextSearchResults(mockSearchResponseJson);
+        conversionService.convertFullTextSearchResults(expectedSearchResponse);
 
         expect(conversionService.filteredOut).toBeDefined();
+    });
+
+    describe('#convertFullTextSearchResults', () => {
+        it('... should have a method `convertFullTextSearchResults`', () => {
+            expect(conversionService.convertFullTextSearchResults).toBeDefined();
+        });
+
+        describe('... should return original search response if', () => {
+            it('... subjects are undefined', () => {
+                const searchResponse = expectedSearchResponse;
+                searchResponse.subjects = undefined;
+
+                const result = conversionService.convertFullTextSearchResults(searchResponse);
+
+                expect(result).toEqual(searchResponse);
+            });
+
+            it('... subjects are null', () => {
+                const searchResponse = expectedSearchResponse;
+                searchResponse.subjects = null;
+
+                const result = conversionService.convertFullTextSearchResults(searchResponse);
+
+                expect(result).toEqual(searchResponse);
+            });
+
+            it('... subjects are empty', () => {
+                const searchResponse = expectedSearchResponse;
+                searchResponse.subjects = [];
+
+                const result = conversionService.convertFullTextSearchResults(searchResponse);
+
+                expect(result).toEqual(searchResponse);
+            });
+        });
+
+        it('... should trigger `_cleanSubjectValueLabels`', () => {
+            const searchResponse = expectedSearchResponse;
+
+            conversionService.convertFullTextSearchResults(searchResponse);
+
+            expectSpyCall(cleanSubjectValueLabelsSpy, searchResponse.subjects.length);
+        });
+
+        it('... should trigger `_cleanSubjectValues`', () => {
+            const searchResponse = expectedSearchResponse;
+
+            conversionService.convertFullTextSearchResults(searchResponse);
+
+            expectSpyCall(cleanSubjectValuesSpy, searchResponse.subjects.length);
+        });
+
+        it('... should trigger `_distinctSubjects`', () => {
+            const searchResponse = expectedSearchResponse;
+
+            conversionService.convertFullTextSearchResults(searchResponse);
+
+            expectSpyCall(distinctSubjectsSpy, 1, [searchResponse.subjects]);
+        });
+
+        it('... should return a search response object', () => {
+            const searchResponse = expectedSearchResponse;
+
+            const result = conversionService.convertFullTextSearchResults(searchResponse);
+
+            expectToEqual(result, searchResponse);
+        });
+
+        it('... should return a search response object with cleaned and distinct subjects', () => {
+            const subject = {
+                valuelabel: ['Test (Richtext)'],
+                obj_id: '123_-_local',
+                valuetype_id: ['14'],
+                value: [
+                    {
+                        utf8str: `A test string.`,
+                        textattr: JSON.stringify({
+                            italic: [{ start: 2, end: 6 }],
+                            p: [{ start: 0, end: 14 }],
+                        }),
+                    },
+                ],
+                iconlabel: undefined,
+                iconsrc: undefined,
+                icontitle: undefined,
+                preview_path: undefined,
+                preview_nx: undefined,
+                preview_ny: undefined,
+                rights: undefined,
+            };
+            const searchResponse = {
+                ...expectedSearchResponse,
+                subjects: [subject, subject],
+            };
+
+            const expectedSubject = {
+                ...subject,
+                obj_id: '123',
+                valuelabel: ['Test'],
+                value: [`A <em>test</em> string.`],
+            };
+
+            const expectedResult = {
+                ...searchResponse,
+                subjects: [expectedSubject],
+            };
+
+            const result = conversionService.convertFullTextSearchResults(searchResponse);
+
+            expectToEqual(result, expectedResult);
+        });
     });
 
     describe('#replaceParagraphTags', () => {
@@ -91,10 +211,7 @@ describe('ConversionService', () => {
         describe('... should return an error message if', () => {
             it('... subjects are undefined', () => {
                 const searchUrl = 'http://example.com';
-                const emptySearchResponseWithQuery = new SearchResponseWithQuery(
-                    JSON.parse(JSON.stringify(mockSearchResponseJson)),
-                    'Test'
-                );
+                const emptySearchResponseWithQuery = new SearchResponseWithQuery(expectedSearchResponse, 'Test');
                 emptySearchResponseWithQuery.data.subjects = undefined;
                 const expected = `Die Abfrage ${searchUrl} ist leider fehlgeschlagen. Wiederholen Sie die Abfrage zu einem späteren Zeitpunkt oder überprüfen sie die Suchbegriffe.`;
 
@@ -108,10 +225,7 @@ describe('ConversionService', () => {
 
             it('... subjects are null', () => {
                 const searchUrl = 'http://example.com';
-                const emptySearchResponseWithQuery = new SearchResponseWithQuery(
-                    JSON.parse(JSON.stringify(mockSearchResponseJson)),
-                    'Test'
-                );
+                const emptySearchResponseWithQuery = new SearchResponseWithQuery(expectedSearchResponse, 'Test');
                 emptySearchResponseWithQuery.data.subjects = null;
                 const expected = `Die Abfrage ${searchUrl} ist leider fehlgeschlagen. Wiederholen Sie die Abfrage zu einem späteren Zeitpunkt oder überprüfen sie die Suchbegriffe.`;
 
@@ -126,10 +240,7 @@ describe('ConversionService', () => {
 
         it('... should return a string', () => {
             const searchUrl = 'http://example.com';
-            const searchResponseWithQuery = new SearchResponseWithQuery(
-                JSON.parse(JSON.stringify(mockSearchResponseJson)),
-                'Test'
-            );
+            const searchResponseWithQuery = new SearchResponseWithQuery(expectedSearchResponse, 'Test');
 
             const result = conversionService.prepareFullTextSearchResultText(searchResponseWithQuery, searchUrl);
 
@@ -139,10 +250,7 @@ describe('ConversionService', () => {
         describe('... should return correct text', () => {
             it('... for no results (default value for nhits = 0)', () => {
                 const searchUrl = 'http://example.com';
-                const searchResponseWithQuery = new SearchResponseWithQuery(
-                    JSON.parse(JSON.stringify(mockSearchResponseJson)),
-                    'Test'
-                );
+                const searchResponseWithQuery = new SearchResponseWithQuery(expectedSearchResponse, 'Test');
                 searchResponseWithQuery.data.subjects = [];
                 searchResponseWithQuery.data.nhits = undefined;
                 const subjectsLength = searchResponseWithQuery.data.subjects.length;
@@ -155,11 +263,8 @@ describe('ConversionService', () => {
 
             it('... for a single result', () => {
                 const searchUrl = 'http://example.com';
-                const searchResponseWithQuery = new SearchResponseWithQuery(
-                    JSON.parse(JSON.stringify(mockSearchResponseJson)),
-                    'Test'
-                );
-                searchResponseWithQuery.data.subjects = [mockSearchResponseJson.subjects[0]];
+                const searchResponseWithQuery = new SearchResponseWithQuery(expectedSearchResponse, 'Test');
+                searchResponseWithQuery.data.subjects = [expectedSearchResponse.subjects[0]];
                 searchResponseWithQuery.data.nhits = '1';
                 const expected = `1 / 1 Ergebnis`;
 
@@ -170,10 +275,7 @@ describe('ConversionService', () => {
 
             it('... for multiple results', () => {
                 const searchUrl = 'http://example.com';
-                const searchResponseWithQuery = new SearchResponseWithQuery(
-                    JSON.parse(JSON.stringify(mockSearchResponseJson)),
-                    'Test'
-                );
+                const searchResponseWithQuery = new SearchResponseWithQuery(expectedSearchResponse, 'Test');
                 const subjectsLength = searchResponseWithQuery.data.subjects.length;
                 const expected = `${subjectsLength} / ${searchResponseWithQuery.data.nhits} Ergebnisse`;
 
@@ -186,10 +288,7 @@ describe('ConversionService', () => {
                 conversionService.filteredOut = 1;
 
                 const searchUrl = 'http://example.com';
-                const searchResponseWithQuery = new SearchResponseWithQuery(
-                    JSON.parse(JSON.stringify(mockSearchResponseJson)),
-                    'Test'
-                );
+                const searchResponseWithQuery = new SearchResponseWithQuery(expectedSearchResponse, 'Test');
                 const subjectsLength = searchResponseWithQuery.data.subjects.length;
                 const expected = `${subjectsLength} / ${searchResponseWithQuery.data.nhits} Ergebnisse (1 Duplikat entfernt)`;
 
@@ -202,10 +301,7 @@ describe('ConversionService', () => {
                 conversionService.filteredOut = 2;
 
                 const searchUrl = 'http://example.com';
-                const searchResponseWithQuery = new SearchResponseWithQuery(
-                    JSON.parse(JSON.stringify(mockSearchResponseJson)),
-                    'Test'
-                );
+                const searchResponseWithQuery = new SearchResponseWithQuery(expectedSearchResponse, 'Test');
                 const subjectsLength = searchResponseWithQuery.data.subjects.length;
                 const expected = `${subjectsLength} / ${searchResponseWithQuery.data.nhits} Ergebnisse (2 Duplikate entfernt)`;
 
@@ -775,6 +871,82 @@ describe('ConversionService', () => {
             (conversionService as any)._distinctSubjects(subjectsWithoutDuplicate);
 
             expectToBe(conversionService.filteredOut, 0);
+        });
+    });
+
+    describe('#_getNodeIdFromAttributes', () => {
+        it('... should have a method `_getNodeIdFromAttributes`', () => {
+            expect((conversionService as any)._getNodeIdFromAttributes).toBeDefined();
+        });
+
+        describe('... should return undefined when', () => {
+            it('... attributes are undefined', () => {
+                const attributes = undefined;
+
+                const result = (conversionService as any)._getNodeIdFromAttributes(attributes);
+
+                expect(result).toBeUndefined();
+            });
+
+            it('... attributes are null', () => {
+                const attributes = null;
+
+                const result = (conversionService as any)._getNodeIdFromAttributes(attributes);
+
+                expect(result).toBeUndefined();
+            });
+
+            it('... attributes are empty', () => {
+                const attributes = '';
+
+                const result = (conversionService as any)._getNodeIdFromAttributes(attributes);
+
+                expect(result).toBeUndefined();
+            });
+
+            it('... attributes cannot be split', () => {
+                const attributes = 'selection';
+
+                const result = (conversionService as any)._getNodeIdFromAttributes(attributes);
+
+                expect(result).toBeUndefined();
+            });
+        });
+
+        it('... should return the node id of hlist values', () => {
+            const attributes = 'hlist=123';
+            const expected = '123';
+
+            const result = (conversionService as any)._getNodeIdFromAttributes(attributes);
+
+            expectToBe(result, expected);
+        });
+
+        it('... should return the node id of selection values', () => {
+            const attributes = 'selection=456';
+            const expected = '456';
+
+            const result = (conversionService as any)._getNodeIdFromAttributes(attributes);
+
+            expectToBe(result, expected);
+        });
+
+        it('... should return the value after the first equals sign when attributes contains more than one equals sign', () => {
+            const attributes = 'hlist=123=456';
+            const expected = '123';
+
+            const result = (conversionService as any)._getNodeIdFromAttributes(attributes);
+
+            expectToBe(result, expected);
+        });
+
+        it('... should return an empty string when attributes contains an equals sign but no value after it', () => {
+            const attributes = 'hlist=';
+            const expected = '';
+
+            const result = (conversionService as any)._getNodeIdFromAttributes(attributes);
+
+            expectToBe(result, expected);
         });
     });
 

--- a/src/app/core/services/conversion-service/conversion.service.ts
+++ b/src/app/core/services/conversion-service/conversion.service.ts
@@ -536,7 +536,7 @@ export class ConversionService extends ApiService {
         const firstValueLabel = valuelabel?.[0];
 
         const modifiedValuelabel = firstValueLabel ? [firstValueLabel.replace(' (Richtext)', '')] : valuelabel;
-        const modifiedObjId = objId ? objId.replace('_-_local', '') : objId;
+        const modifiedObjId = objId ? objId?.replace('_-_local', '') : '';
 
         return { ...subject, valuelabel: modifiedValuelabel, obj_id: modifiedObjId };
     }

--- a/src/app/views/data-view/data-outlets/search-panel/search-result-list/search-result-list.component.spec.ts
+++ b/src/app/views/data-view/data-outlets/search-panel/search-result-list/search-result-list.component.spec.ts
@@ -2,7 +2,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 
 import { Observable, of as observableOf } from 'rxjs';
 import Spy = jasmine.Spy;
@@ -67,7 +67,7 @@ describe('SearchResultListComponent', () => {
         };
 
         TestBed.configureTestingModule({
-            imports: [FontAwesomeTestingModule, NgbPaginationModule, ReactiveFormsModule, RouterTestingModule],
+            imports: [FontAwesomeTestingModule, NgbPaginationModule, ReactiveFormsModule, RouterModule],
             declarations: [SearchResultListComponent, CompileHtmlComponent, TableStubComponent],
             providers: [
                 { provide: DataStreamerService, useValue: mockDataStreamerService },

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-complex.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-complex.component.spec.ts
@@ -1,7 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 
 import { Observable, ReplaySubject } from 'rxjs';
 import Spy = jasmine.Spy;
@@ -55,7 +54,7 @@ describe('EditionComplexComponent (DONE)', () => {
         mockActivatedRoute = new ActivatedRouteStub();
 
         await TestBed.configureTestingModule({
-            imports: [RouterTestingModule],
+            imports: [RouterModule],
             declarations: [EditionComplexComponent],
             providers: [
                 { provide: ActivatedRoute, useValue: mockActivatedRoute },

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/select-results/select-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/select-results/select-results.component.spec.ts
@@ -76,10 +76,10 @@ describe('SelectResultsComponent (DONE)', () => {
         compDe = fixture.debugElement;
 
         // Test data
-        const varKeys = ['Test', 'success'];
+        const varKeys = ['test', 'success'];
         const b = [
             {
-                Test: { type: 'test type', value: 'test value' },
+                test: { type: 'test type', value: 'test value' },
                 success: { type: 'success type', value: 'sucess value' },
             },
         ];

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-table/sparql-table.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-table/sparql-table.component.spec.ts
@@ -44,10 +44,10 @@ describe('SparqlTableComponent (DONE)', () => {
         compDe = fixture.debugElement;
 
         // Test data
-        const varKeys = ['Test', 'success'];
+        const varKeys = ['test', 'success'];
         const b = [
             {
-                Test: { type: 'test type', value: 'test value' },
+                test: { type: 'test type', value: 'test value' },
                 success: { type: 'success type', value: 'sucess value' },
             },
         ];

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-list/source-list.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-list/source-list.component.spec.ts
@@ -1,6 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 
 import Spy = jasmine.Spy;
 
@@ -30,7 +30,7 @@ describe('SourceListComponent (DONE)', () => {
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            imports: [RouterTestingModule],
+            imports: [RouterModule],
             declarations: [SourceListComponent, CompileHtmlComponent, RouterLinkStubDirective],
         }).compileComponents();
     }));

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-series-detail.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-series-detail.component.spec.ts
@@ -1,7 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 
 import { ActivatedRouteStub } from '@testing/router-stubs';
 
@@ -30,7 +29,7 @@ describe('EditionSeriesDetailComponent', () => {
         const mockActivatedRoute: ActivatedRouteStub = new ActivatedRouteStub();
 
         await TestBed.configureTestingModule({
-            imports: [RouterTestingModule],
+            imports: [RouterModule],
             declarations: [EditionSeriesDetailComponent],
             providers: [
                 { provide: ActivatedRoute, useValue: mockActivatedRoute },


### PR DESCRIPTION
This PR simplifies the conversion logic for the full text search response and adds tests for it.

It fixes some linting errors on the fly.