### PR TITLE
refactor(edition): refactor application of textcritic labels

### DIFF
--- a/src/app/core/services/utility-service/utility.service.spec.ts
+++ b/src/app/core/services/utility-service/utility.service.spec.ts
@@ -78,4 +78,48 @@ describe('UtilityService (DONE)', () => {
             expect(utils.isNotEmptyObject(checkObj)).toBeFalse();
         });
     });
+
+    describe('#isSketchId()', () => {
+        it('... should have a method `isSketchId`', () => {
+            expect(utils.isSketchId).toBeDefined();
+        });
+
+        describe('... should return false if', () => {
+            it('... id is undefined', () => {
+                const result = utils.isSketchId(undefined);
+
+                expect(result).toBeFalse();
+            });
+
+            it('... id is null', () => {
+                const result = utils.isSketchId(null);
+
+                expect(result).toBeFalse();
+            });
+
+            it('... id does not include `_Sk`', () => {
+                const id = 'test-1';
+
+                const result = utils.isSketchId(id);
+
+                expect(result).toBeFalse();
+            });
+        });
+
+        it('... should return true if id includes `_Sk`', () => {
+            const id = 'test-1_Sk1';
+
+            const result = utils.isSketchId(id);
+
+            expect(result).toBeTrue();
+        });
+
+        it('... should return true if id includes `SkRT`', () => {
+            const id = 'SkRT';
+
+            const result = utils.isSketchId(id);
+
+            expect(result).toBeTrue();
+        });
+    });
 });

--- a/src/app/core/services/utility-service/utility.service.ts
+++ b/src/app/core/services/utility-service/utility.service.ts
@@ -42,4 +42,17 @@ export class UtilityService {
         }
         return false;
     }
+
+    /**
+     * Public method: isSketchId.
+     *
+     * It checks if the given id refers to a sketch.
+     *
+     * @param {string} id The given id.
+     *
+     * @returns {boolean} The result of the check.
+     */
+    isSketchId(id: string): boolean {
+        return id?.includes('_Sk') || id?.includes('SkRT') || false;
+    }
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.html
@@ -19,11 +19,7 @@
                             @if (utils.isNotEmptyArray(textcritic.description)) {
                                 <div>
                                     <p class="smallcaps">
-                                        {{
-                                            isTextcriticsForSketch(textcritic)
-                                                ? 'Skizzenkommentar'
-                                                : 'Quellenbewertung'
-                                        }}:
+                                        {{ isSketchId(textcritic.id) ? 'Skizzenkommentar' : 'Quellenbewertung' }}:
                                     </p>
                                     <awg-edition-tka-description
                                         [textcriticalDescriptions]="textcritic.description"
@@ -36,7 +32,7 @@
                                 <div>
                                     <p class="smallcaps">
                                         {{
-                                            isTextcriticsForSketch(textcritic)
+                                            isSketchId(textcritic.id)
                                                 ? 'Textkritischer Kommentar'
                                                 : 'Textkritische Anmerkungen'
                                         }}:
@@ -44,7 +40,7 @@
                                     <awg-edition-tka-table
                                         [textcriticalComments]="textcritic.comments"
                                         [isRowTable]="textcritic.rowtable"
-                                        [isTextcriticsForSketch]="isTextcriticsForSketch(textcritic)"
+                                        [isSketchId]="isSketchId(textcritic.id)"
                                         (navigateToReportFragmentRequest)="navigateToReportFragment($event)"
                                         (openModalRequest)="openModal($event)"
                                         (selectSvgSheetRequest)="selectSvgSheet($event)">

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.html
@@ -1,48 +1,48 @@
 @if (textcriticsData) {
     <div ngbAccordion>
-        @for (textcritic of textcriticsData.textcritics; track textcritic) {
-            <div [ngbAccordionItem]="textcritic.id" [collapsed]="true">
+        @for (textcritics of textcriticsData.textcritics; track textcritics) {
+            <div [ngbAccordionItem]="textcritics.id" [collapsed]="true">
                 <div
                     ngbAccordionHeader
                     class="accordion-button awg-accordion-button-custom-header justify-content-between">
-                    <button ngbAccordionToggle class="btn btn-link text-start p-0">{{ textcritic.label }}</button>
+                    <button ngbAccordionToggle class="btn btn-link text-start p-0">{{ textcritics.label }}</button>
                     <button
                         type="button"
                         class="btn btn-sm btn-outline-info"
-                        (click)="selectSvgSheet({ complexId: '', sheetId: textcritic.id })">
+                        (click)="selectSvgSheet({ complexId: '', sheetId: textcritics.id })">
                         Zum edierten Notentext
                     </button>
                 </div>
                 <div ngbAccordionCollapse>
                     <div ngbAccordionBody>
                         <ng-template>
-                            @if (utils.isNotEmptyArray(textcritic.description)) {
+                            @if (utils.isNotEmptyArray(textcritics.description)) {
                                 <div>
                                     <p class="smallcaps">
                                         <awg-edition-tka-label
-                                            [id]="textcritic.id"
+                                            [id]="textcritics.id"
                                             [labelType]="'evaluation'"></awg-edition-tka-label
                                         >:
                                     </p>
                                     <awg-edition-tka-description
-                                        [textcriticalDescriptions]="textcritic.description"
+                                        [textcriticalDescriptions]="textcritics.description"
                                         (navigateToReportFragmentRequest)="navigateToReportFragment($event)"
                                         (openModalRequest)="openModal($event)"
                                         (selectSvgSheetRequest)="selectSvgSheet($event)"></awg-edition-tka-description>
                                 </div>
                             }
-                            @if (utils.isNotEmptyArray(textcritic.comments)) {
+                            @if (utils.isNotEmptyArray(textcritics.comments)) {
                                 <div>
                                     <p class="smallcaps">
                                         <awg-edition-tka-label
-                                            [id]="textcritic.id"
+                                            [id]="textcritics.id"
                                             [labelType]="'comment'"></awg-edition-tka-label
                                         >:
                                     </p>
                                     <awg-edition-tka-table
-                                        [textcriticalComments]="textcritic.comments"
-                                        [isRowTable]="textcritic.rowtable"
-                                        [isSketchId]="isSketchId(textcritic.id)"
+                                        [textcriticalComments]="textcritics.comments"
+                                        [isRowTable]="textcritics.rowtable"
+                                        [isSketchId]="utils.isSketchId(textcritics.id)"
                                         (navigateToReportFragmentRequest)="navigateToReportFragment($event)"
                                         (openModalRequest)="openModal($event)"
                                         (selectSvgSheetRequest)="selectSvgSheet($event)">

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.html
@@ -19,7 +19,10 @@
                             @if (utils.isNotEmptyArray(textcritic.description)) {
                                 <div>
                                     <p class="smallcaps">
-                                        {{ isSketchId(textcritic.id) ? 'Skizzenkommentar' : 'Quellenbewertung' }}:
+                                        <awg-edition-tka-label
+                                            [id]="textcritic.id"
+                                            [labelType]="'evaluation'"></awg-edition-tka-label
+                                        >:
                                     </p>
                                     <awg-edition-tka-description
                                         [textcriticalDescriptions]="textcritic.description"
@@ -31,11 +34,10 @@
                             @if (utils.isNotEmptyArray(textcritic.comments)) {
                                 <div>
                                     <p class="smallcaps">
-                                        {{
-                                            isSketchId(textcritic.id)
-                                                ? 'Textkritischer Kommentar'
-                                                : 'Textkritische Anmerkungen'
-                                        }}:
+                                        <awg-edition-tka-label
+                                            [id]="textcritic.id"
+                                            [labelType]="'comment'"></awg-edition-tka-label
+                                        >:
                                     </p>
                                     <awg-edition-tka-table
                                         [textcriticalComments]="textcritic.comments"

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.spec.ts
@@ -44,7 +44,7 @@ class EditionTkaTableStubComponent {
     @Input()
     isRowTable = false;
     @Input()
-    isTextcriticsForSketch = false;
+    isSketchId = false;
     @Output()
     navigateToReportFragmentRequest: EventEmitter<string> = new EventEmitter();
     @Output()
@@ -604,7 +604,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                     expectToEqual(editionTkaTableCmp.isRowTable, expectedTextcriticsData.textcritics[1].rowtable);
                 });
 
-                it('... should pass down `isTextcriticsForSketch` to EditionTkaTableComponent (stubbed)', () => {
+                it('... should pass down `isSketchId` to EditionTkaTableComponent (stubbed)', () => {
                     const editionTkaTableDes = getAndExpectDebugElementByDirective(
                         compDe,
                         EditionTkaTableStubComponent,
@@ -615,53 +615,50 @@ describe('TextcriticsListComponent (DONE)', () => {
                         EditionTkaTableStubComponent
                     ) as EditionTkaTableStubComponent;
 
-                    expectToEqual(editionTkaTableCmp.isTextcriticsForSketch, false);
+                    expectToEqual(editionTkaTableCmp.isSketchId, false);
                 });
             });
         });
 
-        describe('#isTextcriticsForSketch()', () => {
-            it('... should have a method `isTextcriticsForSketch`', () => {
-                expect(component.isTextcriticsForSketch).toBeDefined();
+        describe('#isSketchId()', () => {
+            it('... should have a method `isSketchId`', () => {
+                expect(component.isSketchId).toBeDefined();
             });
 
             describe('... should return false if', () => {
-                it('... selectedTextcritics is undefined', () => {
-                    const result = component.isTextcriticsForSketch(undefined);
+                it('... is undefined', () => {
+                    const result = component.isSketchId(undefined);
 
                     expect(result).toBeFalse();
                 });
 
-                it('... selectedTextcritics is null', () => {
-                    const result = component.isTextcriticsForSketch(null);
+                it('... id is null', () => {
+                    const result = component.isSketchId(null);
 
                     expect(result).toBeFalse();
                 });
 
-                it('... selectedTextcritics id does not include `_Sk`', () => {
-                    const textcritics = expectedTextcriticsData.textcritics[0];
-                    textcritics.id = 'test-1';
+                it('... id does not include `_Sk`', () => {
+                    const id = 'test-1';
 
-                    const result = component.isTextcriticsForSketch(textcritics);
+                    const result = component.isSketchId(id);
 
                     expect(result).toBeFalse();
                 });
             });
 
-            it('... should return true if selectedTextcritics id includes `_Sk`', () => {
-                const textcritics = expectedTextcriticsData.textcritics[0];
-                textcritics.id = 'test-1_Sk1';
+            it('... should return true if id includes `_Sk`', () => {
+                const id = 'test-1_Sk1';
 
-                const result = component.isTextcriticsForSketch(textcritics);
+                const result = component.isSketchId(id);
 
                 expect(result).toBeTrue();
             });
 
-            it('... should return true if selectedTextcritics id includes `SkRT`', () => {
-                const textcritics = expectedTextcriticsData.textcritics[0];
-                textcritics.id = 'SkRT';
+            it('... should return true if id includes `SkRT`', () => {
+                const id = 'SkRT';
 
-                const result = component.isTextcriticsForSketch(textcritics);
+                const result = component.isSketchId(id);
 
                 expect(result).toBeTrue();
             });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.spec.ts
@@ -35,6 +35,13 @@ class EditionTkaDescriptionStubComponent {
     selectSvgSheetRequest: EventEmitter<{ complexId: string; sheetId: string }> = new EventEmitter();
 }
 
+@Component({ selector: 'awg-edition-tka-label', template: '' })
+class EditionTkaLabelStubComponent {
+    @Input()
+    id: string;
+    @Input() labelType: 'evaluation' | 'comment';
+}
+
 @Component({ selector: 'awg-edition-tka-table', template: '' })
 class EditionTkaTableStubComponent {
     @Input()
@@ -91,6 +98,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                 TextcriticsListComponent,
                 CompileHtmlComponent,
                 EditionTkaDescriptionStubComponent,
+                EditionTkaLabelStubComponent,
                 EditionTkaTableStubComponent,
             ],
             providers: [UtilityService],
@@ -440,7 +448,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                     getAndExpectDebugElementByCss(bodyDes[0], 'div', 0, 0);
                 });
 
-                it('... should contain item body with div, small caps paragraph and EditionTkaDescriptionComponent if description array is not empty', () => {
+                it('... should contain item body with div, small caps paragraph, first EditionTkaLabelComponent and EditionTkaDescriptionComponent if description array is not empty', () => {
                     const textcritics = expectedTextcriticsData.textcritics[1];
 
                     const bodyDes = getAndExpectDebugElementByCss(
@@ -451,109 +459,49 @@ describe('TextcriticsListComponent (DONE)', () => {
                         'open'
                     );
                     const divDes = getAndExpectDebugElementByCss(bodyDes[0], 'div:first-child', 1, 1);
-                    getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
+                    const pDes = getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
 
-                    // EditionTkaDescriptionStubComponent
+                    getAndExpectDebugElementByDirective(pDes[0], EditionTkaLabelStubComponent, 1, 1);
+
                     getAndExpectDebugElementByDirective(divDes[0], EditionTkaDescriptionStubComponent, 1, 1);
                 });
 
-                it('... should display `Quellenbewertung:` in paragraph if no sketch id is given', () => {
-                    component.textcriticsData.textcritics[1].id = 'test-2';
-                    const textcritics = component.textcriticsData.textcritics[1];
-
-                    detectChangesOnPush(fixture);
-
+                it('... should pass down `id` data to first EditionTkaLabelComponent (stubbed)', () => {
                     const bodyDes = getAndExpectDebugElementByCss(
                         compDe,
-                        `div#${textcritics.id} > div.accordion-collapse > div.accordion-body`,
+                        `div#${expectedTextcriticsData.textcritics[1].id} > div.accordion-collapse > div.accordion-body`,
                         1,
                         1,
                         'open'
                     );
-
                     const divDes = getAndExpectDebugElementByCss(bodyDes[0], 'div:first-child', 1, 1);
                     const pDes = getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
-                    const pEl = pDes[0].nativeElement;
 
-                    expectToBe(pEl.textContent.trim(), 'Quellenbewertung:');
+                    const labelDes = getAndExpectDebugElementByDirective(pDes[0], EditionTkaLabelStubComponent, 1, 1);
+                    const labelCmp = labelDes[0].injector.get(
+                        EditionTkaLabelStubComponent
+                    ) as EditionTkaLabelStubComponent;
+
+                    expectToBe(labelCmp.id, expectedTextcriticsData.textcritics[1].id);
                 });
 
-                it('... should display `Skizzenkommentar:` in paragraph if sketch id is given', () => {
-                    component.textcriticsData.textcritics[1].id = 'test-2_Sk2';
-                    const textcritics = component.textcriticsData.textcritics[1];
-
-                    detectChangesOnPush(fixture);
-
+                it('... should pass down `labelType` data to first EditionTkaLabelComponent (stubbed)', () => {
                     const bodyDes = getAndExpectDebugElementByCss(
                         compDe,
-                        `div#${textcritics.id} > div.accordion-collapse > div.accordion-body`,
+                        `div#${expectedTextcriticsData.textcritics[1].id} > div.accordion-collapse > div.accordion-body`,
                         1,
                         1,
                         'open'
                     );
-
                     const divDes = getAndExpectDebugElementByCss(bodyDes[0], 'div:first-child', 1, 1);
                     const pDes = getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
-                    const pEl = pDes[0].nativeElement;
 
-                    expectToBe(pEl.textContent.trim(), 'Skizzenkommentar:');
-                });
+                    const labelDes = getAndExpectDebugElementByDirective(pDes[0], EditionTkaLabelStubComponent, 1, 1);
+                    const labelCmp = labelDes[0].injector.get(
+                        EditionTkaLabelStubComponent
+                    ) as EditionTkaLabelStubComponent;
 
-                it('... should contain item body with div, small caps paragraph and EditionTkaTableComponent if comments array is not empty', () => {
-                    const textcritics = expectedTextcriticsData.textcritics[1];
-
-                    const bodyDes = getAndExpectDebugElementByCss(
-                        compDe,
-                        `div#${textcritics.id} > div.accordion-collapse > div.accordion-body`,
-                        1,
-                        1,
-                        'open'
-                    );
-                    const divDes = getAndExpectDebugElementByCss(bodyDes[0], 'div:not(:first-child)', 1, 1);
-                    getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
-
-                    // EditionTkaTableStubComponent
-                    getAndExpectDebugElementByDirective(bodyDes[0], EditionTkaTableStubComponent, 1, 1);
-                });
-
-                it('... should display `Textkritische Anmerkungen:` in paragraph if no sketch id is given', () => {
-                    component.textcriticsData.textcritics[1].id = 'test-2';
-                    const textcritics = component.textcriticsData.textcritics[1];
-
-                    detectChangesOnPush(fixture);
-
-                    const bodyDes = getAndExpectDebugElementByCss(
-                        compDe,
-                        `div#${textcritics.id} > div.accordion-collapse > div.accordion-body`,
-                        1,
-                        1,
-                        'open'
-                    );
-                    const divDes = getAndExpectDebugElementByCss(bodyDes[0], 'div:not(:first-child)', 1, 1);
-                    const pDes = getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
-                    const pEl = pDes[0].nativeElement;
-
-                    expectToBe(pEl.textContent.trim(), 'Textkritische Anmerkungen:');
-                });
-
-                it('... should display `Textkritischer Kommentar:` in paragraph if sketch id is given', () => {
-                    component.textcriticsData.textcritics[1].id = 'test-2_Sk2';
-                    const textcritics = component.textcriticsData.textcritics[1];
-
-                    detectChangesOnPush(fixture);
-
-                    const bodyDes = getAndExpectDebugElementByCss(
-                        compDe,
-                        `div#${textcritics.id} > div.accordion-collapse > div.accordion-body`,
-                        1,
-                        1,
-                        'open'
-                    );
-                    const divDes = getAndExpectDebugElementByCss(bodyDes[0], 'div:not(:first-child)', 1, 1);
-                    const pDes = getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
-                    const pEl = pDes[0].nativeElement;
-
-                    expectToBe(pEl.textContent.trim(), 'Textkritischer Kommentar:');
+                    expectToBe(labelCmp.labelType, 'evaluation');
                 });
 
                 it('... should pass down `description` data to EditionTkaDescriptionComponent (stubbed)', () => {
@@ -571,6 +519,62 @@ describe('TextcriticsListComponent (DONE)', () => {
                         editionTkaDescriptionCmp.textcriticalDescriptions,
                         expectedTextcriticsData.textcritics[1].description
                     );
+                });
+
+                it('... should contain item body with div, small caps paragraph, second EditionTkaLabelComponent and EditionTkaTableComponent if comments array is not empty', () => {
+                    const textcritics = expectedTextcriticsData.textcritics[1];
+
+                    const bodyDes = getAndExpectDebugElementByCss(
+                        compDe,
+                        `div#${textcritics.id} > div.accordion-collapse > div.accordion-body`,
+                        1,
+                        1,
+                        'open'
+                    );
+                    const divDes = getAndExpectDebugElementByCss(bodyDes[0], 'div:not(:first-child)', 1, 1);
+                    const pDes = getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
+
+                    getAndExpectDebugElementByDirective(pDes[0], EditionTkaLabelStubComponent, 1, 1);
+
+                    getAndExpectDebugElementByDirective(divDes[0], EditionTkaTableStubComponent, 1, 1);
+                });
+
+                it('... should pass down `id` data to second EditionTkaLabelComponent (stubbed)', () => {
+                    const bodyDes = getAndExpectDebugElementByCss(
+                        compDe,
+                        `div#${expectedTextcriticsData.textcritics[1].id} > div.accordion-collapse > div.accordion-body`,
+                        1,
+                        1,
+                        'open'
+                    );
+                    const divDes = getAndExpectDebugElementByCss(bodyDes[0], 'div:not(:first-child)', 1, 1);
+                    const pDes = getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
+
+                    const labelDes = getAndExpectDebugElementByDirective(pDes[0], EditionTkaLabelStubComponent, 1, 1);
+                    const labelCmp = labelDes[0].injector.get(
+                        EditionTkaLabelStubComponent
+                    ) as EditionTkaLabelStubComponent;
+
+                    expectToBe(labelCmp.id, expectedTextcriticsData.textcritics[1].id);
+                });
+
+                it('... should pass down `labelType` data to second EditionTkaLabelComponent (stubbed)', () => {
+                    const bodyDes = getAndExpectDebugElementByCss(
+                        compDe,
+                        `div#${expectedTextcriticsData.textcritics[1].id} > div.accordion-collapse > div.accordion-body`,
+                        1,
+                        1,
+                        'open'
+                    );
+                    const divDes = getAndExpectDebugElementByCss(bodyDes[0], 'div:not(:first-child)', 1, 1);
+                    const pDes = getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
+
+                    const labelDes = getAndExpectDebugElementByDirective(pDes[0], EditionTkaLabelStubComponent, 1, 1);
+                    const labelCmp = labelDes[0].injector.get(
+                        EditionTkaLabelStubComponent
+                    ) as EditionTkaLabelStubComponent;
+
+                    expectToBe(labelCmp.labelType, 'comment');
                 });
 
                 it('... should pass down `comments` to EditionTkaTableComponent (stubbed)', () => {
@@ -617,50 +621,6 @@ describe('TextcriticsListComponent (DONE)', () => {
 
                     expectToEqual(editionTkaTableCmp.isSketchId, false);
                 });
-            });
-        });
-
-        describe('#isSketchId()', () => {
-            it('... should have a method `isSketchId`', () => {
-                expect(component.isSketchId).toBeDefined();
-            });
-
-            describe('... should return false if', () => {
-                it('... is undefined', () => {
-                    const result = component.isSketchId(undefined);
-
-                    expect(result).toBeFalse();
-                });
-
-                it('... id is null', () => {
-                    const result = component.isSketchId(null);
-
-                    expect(result).toBeFalse();
-                });
-
-                it('... id does not include `_Sk`', () => {
-                    const id = 'test-1';
-
-                    const result = component.isSketchId(id);
-
-                    expect(result).toBeFalse();
-                });
-            });
-
-            it('... should return true if id includes `_Sk`', () => {
-                const id = 'test-1_Sk1';
-
-                const result = component.isSketchId(id);
-
-                expect(result).toBeTrue();
-            });
-
-            it('... should return true if id includes `SkRT`', () => {
-                const id = 'SkRT';
-
-                const result = component.isSketchId(id);
-
-                expect(result).toBeTrue();
             });
         });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.ts
@@ -68,19 +68,6 @@ export class TextcriticsListComponent {
     }
 
     /**
-     * Public method: isSketchId.
-     *
-     * It checks if the given id refers to a sketch.
-     *
-     * @param {string} id The given id.
-     *
-     * @returns {boolean} The result of the check.
-     */
-    isSketchId(id: string): boolean {
-        return id?.includes('_Sk') || id?.includes('SkRT') || false;
-    }
-
-    /**
      * Public method: navigateToReportFragment.
      *
      * It emits a given id of a fragment of the edition report

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { UtilityService } from '@awg-core/services';
-import { Textcritics, TextcriticsList } from '@awg-views/edition-view/models';
+import { TextcriticsList } from '@awg-views/edition-view/models';
 
 /**
  * The TextcriticsList component.
@@ -68,16 +68,16 @@ export class TextcriticsListComponent {
     }
 
     /**
-     * Public method: isTextcriticsForSketch.
+     * Public method: isSketchId.
      *
-     * It checks if the selected textcritics id refers to a sketch.
+     * It checks if the given id refers to a sketch.
      *
-     * @param {Textcritics} selectedTextcritics The given selected textcritics.
+     * @param {string} id The given id.
      *
      * @returns {boolean} The result of the check.
      */
-    isTextcriticsForSketch(selectedTextcritics: Textcritics): boolean {
-        return selectedTextcritics?.id?.includes('_Sk') || selectedTextcritics?.id?.includes('SkRT') || false;
+    isSketchId(id: string): boolean {
+        return id?.includes('_Sk') || id?.includes('SkRT') || false;
     }
 
     /**

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.html
@@ -35,7 +35,7 @@
             <awg-edition-tka-table
                 [textcriticalComments]="selectedTextcriticalComments"
                 [isRowTable]="selectedTextcritics.rowtable"
-                [isSketchId]="isSketchId(selectedTextcritics.id)"
+                [isSketchId]="utils.isSketchId(selectedTextcritics.id)"
                 (navigateToReportFragmentRequest)="navigateToReportFragment($event)"
                 (openModalRequest)="openModal($event)"
                 (selectSvgSheetRequest)="selectSvgSheet($event)">

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.html
@@ -8,7 +8,7 @@
                 </span>
             }
             <span class="smallcaps"
-                >{{ isTextcriticsForSketch(selectedTextcritics) ? 'Skizzenkommentar' : 'Quellenbewertung' }}:</span
+                >{{ isSketchId(selectedTextcritics.id) ? 'Skizzenkommentar' : 'Quellenbewertung' }}:</span
             >
             @if (selectedTextcritics.description && !utils.isNotEmptyArray(selectedTextcritics.description)) {
                 <span>&nbsp;---</span>
@@ -28,16 +28,12 @@
     @if (showTkA) {
         <div class="awg-edition-svg-sheet-footer-textcritics">
             <p class="smallcaps">
-                {{
-                    isTextcriticsForSketch(selectedTextcritics)
-                        ? 'Textkritischer Kommentar'
-                        : 'Textkritische Anmerkungen'
-                }}:
+                {{ isSketchId(selectedTextcritics.id) ? 'Textkritischer Kommentar' : 'Textkritische Anmerkungen' }}:
             </p>
             <awg-edition-tka-table
                 [textcriticalComments]="selectedTextcriticalComments"
                 [isRowTable]="selectedTextcritics.rowtable"
-                [isTextcriticsForSketch]="isTextcriticsForSketch(selectedTextcritics)"
+                [isSketchId]="isSketchId(selectedTextcritics.id)"
                 (navigateToReportFragmentRequest)="navigateToReportFragment($event)"
                 (openModalRequest)="openModal($event)"
                 (selectSvgSheetRequest)="selectSvgSheet($event)">

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.html
@@ -7,8 +7,10 @@
                     &nbsp;
                 </span>
             }
+
             <span class="smallcaps"
-                >{{ isSketchId(selectedTextcritics.id) ? 'Skizzenkommentar' : 'Quellenbewertung' }}:</span
+                ><awg-edition-tka-label [id]="selectedTextcritics.id" [labelType]="'evaluation'"></awg-edition-tka-label
+                >:</span
             >
             @if (selectedTextcritics.description && !utils.isNotEmptyArray(selectedTextcritics.description)) {
                 <span>&nbsp;---</span>
@@ -28,7 +30,7 @@
     @if (showTkA) {
         <div class="awg-edition-svg-sheet-footer-textcritics">
             <p class="smallcaps">
-                {{ isSketchId(selectedTextcritics.id) ? 'Textkritischer Kommentar' : 'Textkritische Anmerkungen' }}:
+                <awg-edition-tka-label [id]="selectedTextcritics.id" [labelType]="'comment'"></awg-edition-tka-label>:
             </p>
             <awg-edition-tka-table
                 [textcriticalComments]="selectedTextcriticalComments"

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.spec.ts
@@ -34,6 +34,14 @@ class EditionTkaDescriptionStubComponent {
     @Output()
     selectSvgSheetRequest: EventEmitter<{ complexId: string; sheetId: string }> = new EventEmitter();
 }
+
+@Component({ selector: 'awg-edition-tka-label', template: '' })
+class EditionTkaLabelStubComponent {
+    @Input()
+    id: string;
+    @Input() labelType: 'evaluation' | 'comment';
+}
+
 @Component({ selector: 'awg-edition-tka-table', template: '' })
 class EditionTkaTableStubComponent {
     @Input()
@@ -86,6 +94,7 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 EditionSvgSheetFooterComponent,
                 CompileHtmlComponent,
                 EditionTkaDescriptionStubComponent,
+                EditionTkaLabelStubComponent,
                 EditionTkaTableStubComponent,
             ],
             providers: [UtilityService],
@@ -240,23 +249,7 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 expect(iconDes[0].children[0].classes['fa-chevron-up']).toBeTrue();
             });
 
-            it('... should contain a span.smallcaps in p with heading for evaluationString', () => {
-                const divDes = getAndExpectDebugElementByCss(
-                    compDe,
-                    'div.awg-edition-svg-sheet-footer-evaluation',
-                    1,
-                    1
-                );
-
-                const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
-                getAndExpectDebugElementByCss(pDes[0], 'span.smallcaps', 1, 1);
-            });
-
-            it('... should display `Quellenbewertung:` in paragraph if no sketch id is given', () => {
-                component.selectedTextcritics.id = 'test-1';
-
-                detectChangesOnPush(fixture);
-
+            it('... should contain a span.smallcaps in p with first EditionTkaLabelComponent', () => {
                 const divDes = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-evaluation',
@@ -266,16 +259,11 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
 
                 const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
                 const spanDes = getAndExpectDebugElementByCss(pDes[0], 'span.smallcaps', 1, 1);
-                const spanEl = spanDes[0].nativeElement;
 
-                expectToBe(spanEl.textContent.trim(), 'Quellenbewertung:');
+                getAndExpectDebugElementByDirective(spanDes[0], EditionTkaLabelStubComponent, 1, 1);
             });
 
-            it('... should display `Skizzenkommentar:` in paragraph if sketch id is given', () => {
-                component.selectedTextcritics.id = 'test-1_Sk1';
-
-                detectChangesOnPush(fixture);
-
+            it('... should pass down `id` data to first EditionTkaLabelComponent (stubbed)', () => {
                 const divDes = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-evaluation',
@@ -285,9 +273,28 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
 
                 const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
                 const spanDes = getAndExpectDebugElementByCss(pDes[0], 'span.smallcaps', 1, 1);
-                const spanEl = spanDes[0].nativeElement;
 
-                expectToBe(spanEl.textContent.trim(), 'Skizzenkommentar:');
+                const labelDes = getAndExpectDebugElementByDirective(spanDes[0], EditionTkaLabelStubComponent, 1, 1);
+                const labelCmp = labelDes[0].injector.get(EditionTkaLabelStubComponent) as EditionTkaLabelStubComponent;
+
+                expectToBe(labelCmp.id, expectedSelectedTextcritics.id);
+            });
+
+            it('... should pass down `labelType` data to first EditionTkaLabelComponent (stubbed)', () => {
+                const divDes = getAndExpectDebugElementByCss(
+                    compDe,
+                    'div.awg-edition-svg-sheet-footer-evaluation',
+                    1,
+                    1
+                );
+
+                const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
+                const spanDes = getAndExpectDebugElementByCss(pDes[0], 'span.smallcaps', 1, 1);
+
+                const labelDes = getAndExpectDebugElementByDirective(spanDes[0], EditionTkaLabelStubComponent, 1, 1);
+                const labelCmp = labelDes[0].injector.get(EditionTkaLabelStubComponent) as EditionTkaLabelStubComponent;
+
+                expectToBe(labelCmp.labelType, 'evaluation');
             });
 
             it('... should contain a second span in p with `---` if selectedTextcritics.description is empty', () => {
@@ -308,7 +315,7 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 expectToBe(spanEl.textContent.trim(), `---`);
             });
 
-            describe('... should contain no EditionTkaDescriptionComponent  if ...', () => {
+            describe('... should contain no EditionTkaDescriptionComponent if ...', () => {
                 it('... showTextcritics = false', () => {
                     getAndExpectDebugElementByCss(compDe, 'p.awg-edition-svg-sheet-footer-evaluation-desc', 0, 0);
                 });
@@ -336,6 +343,30 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 getAndExpectDebugElementByDirective(divDes[0], EditionTkaDescriptionStubComponent, 1, 1);
             });
 
+            it('... should pass down `description` data to the EditionTkaDescriptionComponent if showTextcritics = true', () => {
+                component.showTextcritics = true;
+                detectChangesOnPush(fixture);
+
+                const divDes = getAndExpectDebugElementByCss(
+                    compDe,
+                    'div.awg-edition-svg-sheet-footer-evaluation',
+                    1,
+                    1
+                );
+
+                const descDes = getAndExpectDebugElementByDirective(
+                    divDes[0],
+                    EditionTkaDescriptionStubComponent,
+                    1,
+                    1
+                );
+                const descCmp = descDes[0].injector.get(
+                    EditionTkaDescriptionStubComponent
+                ) as EditionTkaDescriptionStubComponent;
+
+                expectToBe(descCmp.textcriticalDescriptions, expectedSelectedTextcritics.description);
+            });
+
             it('... should contain no textcritics div if showTka is false', () => {
                 component.showTkA = false;
                 detectChangesOnPush(fixture);
@@ -360,11 +391,7 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
             });
 
-            it('... should display `Textkritische Anmerkungen:` in paragraph if no sketch id is given', () => {
-                component.selectedTextcritics.id = 'test-1';
-
-                detectChangesOnPush(fixture);
-
+            it('... should contain second EditionTkaLabelComponent (stubbed) in textcritics div', () => {
                 const divDes = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-textcritics',
@@ -372,28 +399,7 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                     1
                 );
 
-                const pDes = getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
-                const pEl = pDes[0].nativeElement;
-
-                expectToBe(pEl.textContent.trim(), 'Textkritische Anmerkungen:');
-            });
-
-            it('... should display `Textkritischer Kommentar:` in paragraph if sketch id is given', () => {
-                component.selectedTextcritics.id = 'test-1_Sk1';
-
-                detectChangesOnPush(fixture);
-
-                const divDes = getAndExpectDebugElementByCss(
-                    compDe,
-                    'div.awg-edition-svg-sheet-footer-textcritics',
-                    1,
-                    1
-                );
-
-                const pDes = getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
-                const pEl = pDes[0].nativeElement;
-
-                expectToBe(pEl.textContent.trim(), 'Textkritischer Kommentar:');
+                getAndExpectDebugElementByDirective(divDes[0], EditionTkaLabelStubComponent, 1, 1);
             });
 
             it('... should contain one EditionTkaTableComponent (stubbed) in textcritics div', () => {
@@ -405,6 +411,34 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 );
 
                 getAndExpectDebugElementByDirective(divDes[0], EditionTkaTableStubComponent, 1, 1);
+            });
+
+            it('... should pass down `id` to the second EditionTkaLabelComponent', () => {
+                const divDes = getAndExpectDebugElementByCss(
+                    compDe,
+                    'div.awg-edition-svg-sheet-footer-textcritics',
+                    1,
+                    1
+                );
+
+                const labelDes = getAndExpectDebugElementByDirective(divDes[0], EditionTkaLabelStubComponent, 1, 1);
+                const labelCmp = labelDes[0].injector.get(EditionTkaLabelStubComponent) as EditionTkaLabelStubComponent;
+
+                expectToBe(labelCmp.id, expectedSelectedTextcritics.id);
+            });
+
+            it('... should pass down `labelType` to the second EditionTkaLabelComponent', () => {
+                const divDes = getAndExpectDebugElementByCss(
+                    compDe,
+                    'div.awg-edition-svg-sheet-footer-textcritics',
+                    1,
+                    1
+                );
+
+                const labelDes = getAndExpectDebugElementByDirective(divDes[0], EditionTkaLabelStubComponent, 1, 1);
+                const labelCmp = labelDes[0].injector.get(EditionTkaLabelStubComponent) as EditionTkaLabelStubComponent;
+
+                expectToBe(labelCmp.labelType, 'comment');
             });
 
             it('... should pass down `selectedTextcriticalComments` to the EditionTkaTableComponent', () => {
@@ -426,50 +460,6 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 const tableCmp = tableDes[0].injector.get(EditionTkaTableStubComponent) as EditionTkaTableStubComponent;
 
                 expectToBe(tableCmp.isSketchId, false);
-            });
-        });
-
-        describe('#isSketchId()', () => {
-            it('... should have a method `isSketchId`', () => {
-                expect(component.isSketchId).toBeDefined();
-            });
-
-            describe('... should return false if', () => {
-                it('... id is undefined', () => {
-                    const result = component.isSketchId(undefined);
-
-                    expect(result).toBeFalse();
-                });
-
-                it('... id is null', () => {
-                    const result = component.isSketchId(null);
-
-                    expect(result).toBeFalse();
-                });
-
-                it('... id does not include `_Sk`', () => {
-                    const id = 'test-1';
-
-                    const result = component.isSketchId(id);
-
-                    expect(result).toBeFalse();
-                });
-            });
-
-            it('... should return true if id includes `_Sk`', () => {
-                const id = 'test-1_Sk1';
-
-                const result = component.isSketchId(id);
-
-                expect(result).toBeTrue();
-            });
-
-            it('... should return true if id includes `SkRT`', () => {
-                const id = 'SkRT';
-
-                const result = component.isSketchId(id);
-
-                expect(result).toBeTrue();
             });
         });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.spec.ts
@@ -43,7 +43,7 @@ class EditionTkaTableStubComponent {
     @Input()
     isRowTable = false;
     @Input()
-    isTextcriticsForSketch = false;
+    isSketchId = false;
     @Output()
     navigateToReportFragmentRequest: EventEmitter<string> = new EventEmitter();
     @Output()
@@ -421,56 +421,53 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 expectToBe(tableCmp.isRowTable, expectedSelectedTextcritics.rowtable);
             });
 
-            it('... should pass down `isTextcriticsForSketch` to the EditionTkaTableComponent', () => {
+            it('... should pass down `isSketchId` to the EditionTkaTableComponent', () => {
                 const tableDes = getAndExpectDebugElementByDirective(compDe, EditionTkaTableStubComponent, 1, 1);
                 const tableCmp = tableDes[0].injector.get(EditionTkaTableStubComponent) as EditionTkaTableStubComponent;
 
-                expectToBe(tableCmp.isTextcriticsForSketch, false);
+                expectToBe(tableCmp.isSketchId, false);
             });
         });
 
-        describe('#isTextcriticsForSketch()', () => {
-            it('... should have a method `isTextcriticsForSketch`', () => {
-                expect(component.isTextcriticsForSketch).toBeDefined();
+        describe('#isSketchId()', () => {
+            it('... should have a method `isSketchId`', () => {
+                expect(component.isSketchId).toBeDefined();
             });
 
             describe('... should return false if', () => {
-                it('... selectedTextcritics is undefined', () => {
-                    const result = component.isTextcriticsForSketch(undefined);
+                it('... id is undefined', () => {
+                    const result = component.isSketchId(undefined);
 
                     expect(result).toBeFalse();
                 });
 
-                it('... selectedTextcritics is null', () => {
-                    const result = component.isTextcriticsForSketch(null);
+                it('... id is null', () => {
+                    const result = component.isSketchId(null);
 
                     expect(result).toBeFalse();
                 });
 
-                it('... selectedTextcritics id does not include `_Sk`', () => {
-                    const textcritics = expectedSelectedTextcritics;
-                    textcritics.id = 'test-1';
+                it('... id does not include `_Sk`', () => {
+                    const id = 'test-1';
 
-                    const result = component.isTextcriticsForSketch(textcritics);
+                    const result = component.isSketchId(id);
 
                     expect(result).toBeFalse();
                 });
             });
 
-            it('... should return true if selectedTextcritics id includes `_Sk`', () => {
-                const textcritics = expectedSelectedTextcritics;
-                textcritics.id = 'test-1_Sk1';
+            it('... should return true if id includes `_Sk`', () => {
+                const id = 'test-1_Sk1';
 
-                const result = component.isTextcriticsForSketch(textcritics);
+                const result = component.isSketchId(id);
 
                 expect(result).toBeTrue();
             });
 
-            it('... should return true if selectedTextcritics id includes `SkRT`', () => {
-                const textcritics = expectedSelectedTextcritics;
-                textcritics.id = 'SkRT';
+            it('... should return true if id includes `SkRT`', () => {
+                const id = 'SkRT';
 
-                const result = component.isTextcriticsForSketch(textcritics);
+                const result = component.isSketchId(id);
 
                 expect(result).toBeTrue();
             });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.ts
@@ -107,19 +107,6 @@ export class EditionSvgSheetFooterComponent {
     }
 
     /**
-     * Public method: isSketchId.
-     *
-     * It checks if the given id refers to a sketch.
-     *
-     * @param {string} id The given id.
-     *
-     * @returns {boolean} The result of the check.
-     */
-    isSketchId(id: string): boolean {
-        return id?.includes('_Sk') || id?.includes('SkRT') || false;
-    }
-
-    /**
      * Public method: navigateToReportFragment.
      *
      * It emits a given id of a fragment of the edition report

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.ts
@@ -107,16 +107,16 @@ export class EditionSvgSheetFooterComponent {
     }
 
     /**
-     * Public method: isTextcriticsForSketch.
+     * Public method: isSketchId.
      *
-     * It checks if the selected textcritics id refers to a sketch.
+     * It checks if the given id refers to a sketch.
      *
-     * @param {Textcritics} selectedTextcritics The given selected textcritics.
+     * @param {string} id The given id.
      *
      * @returns {boolean} The result of the check.
      */
-    isTextcriticsForSketch(selectedTextcritics: Textcritics): boolean {
-        return selectedTextcritics?.id?.includes('_Sk') || selectedTextcritics?.id?.includes('SkRT') || false;
+    isSketchId(id: string): boolean {
+        return id?.includes('_Sk') || id?.includes('SkRT') || false;
     }
 
     /**

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-switch/edition-svg-sheet-viewer-switch.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-switch/edition-svg-sheet-viewer-switch.component.html
@@ -46,7 +46,9 @@
                             value=""
                             id="tkk"
                             (click)="toggleTkkClassesHighlight()" />
-                        <label class="form-check-label" for="tkk">Textkritische Kommentare</label>
+                        <label class="form-check-label" for="tkk">
+                            <awg-edition-tka-label [id]="id" [labelType]="'comment'"></awg-edition-tka-label
+                        ></label>
                     </div>
                 </div>
             }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-switch/edition-svg-sheet-viewer-switch.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-switch/edition-svg-sheet-viewer-switch.component.ts
@@ -21,6 +21,13 @@ import {
 })
 export class EditionSvgSheetViewerSwitchComponent implements OnChanges {
     /**
+     * Input variable: id.
+     *
+     * It keeps the id of the selected svg sheet
+     */
+    @Input() id: string;
+
+    /**
      * Input variable: suppliedClasses.
      *
      * It keeps the supplied classes as a map of class names and their visibility.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.html
@@ -30,6 +30,7 @@
                 <awg-license></awg-license>
                 @if (hasAvailableTkaOverlays || suppliedClasses.size > 0) {
                     <awg-edition-svg-sheet-viewer-switch
+                        [id]="selectedSvgSheet.id"
                         [suppliedClasses]="suppliedClasses"
                         [hasAvailableTkaOverlays]="hasAvailableTkaOverlays"
                         (toggleSuppliedClassesOpacityRequest)="onSuppliedClassesOpacityToggle($event)"

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.spec.ts
@@ -45,6 +45,7 @@ class LicenseStubComponent {}
 
 @Component({ selector: 'awg-edition-svg-sheet-viewer-switch', template: '' })
 class EditionSvgSheetViewerSwitchStubComponent {
+    @Input() id?: string;
     @Input() suppliedClasses?: Map<string, boolean>;
     @Input() hasAvailableTkaOverlays?: boolean;
 
@@ -518,6 +519,20 @@ describe('EditionSvgSheetViewerComponent', () => {
                             0,
                             0
                         );
+                    });
+
+                    it('... should pass the sheet id to the switch component', () => {
+                        const switchDes = getAndExpectDebugElementByDirective(
+                            compDe,
+                            EditionSvgSheetViewerSwitchStubComponent,
+                            1,
+                            1
+                        );
+                        const switchCmp = switchDes[0].injector.get(
+                            EditionSvgSheetViewerSwitchStubComponent
+                        ) as EditionSvgSheetViewerSwitchStubComponent;
+
+                        expectToEqual(switchCmp.id, expectedSvgSheet.id);
                     });
 
                     it('... should pass the correct suppliedClasses to the switch component', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.module.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { SharedModule } from '@awg-shared/shared.module';
 
+import { EditionTkaModule } from '../../../edition-tka/edition-tka.module';
+
 import { EditionSvgSheetViewerSwitchComponent } from './edition-svg-sheet-viewer-switch';
 import { EditionSvgSheetViewerComponent } from './edition-svg-sheet-viewer.component';
 
@@ -12,7 +14,7 @@ import { EditionSvgSheetViewerComponent } from './edition-svg-sheet-viewer.compo
  * as well as the {@link SharedModule}.
  */
 @NgModule({
-    imports: [SharedModule],
+    imports: [SharedModule, EditionTkaModule],
     declarations: [EditionSvgSheetViewerComponent, EditionSvgSheetViewerSwitchComponent],
     exports: [EditionSvgSheetViewerComponent, EditionSvgSheetViewerSwitchComponent],
 })

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.html
@@ -1,0 +1,5 @@
+@if (labelType === 'evaluation') {
+    <span>{{ isSketchId(id) ? 'Skizzenkommentar' : 'Quellenbewertung' }}</span>
+} @else if (labelType === 'comment') {
+    <span>{{ isSketchId(id) ? 'Textkritische Kommentare' : 'Textkritische Anmerkungen' }}</span>
+}

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.html
@@ -1,5 +1,5 @@
 @if (labelType === 'evaluation') {
-    <span>{{ isSketchId(id) ? 'Skizzenkommentar' : 'Quellenbewertung' }}</span>
+    <span>{{ utils.isSketchId(id) ? 'Skizzenkommentar' : 'Quellenbewertung' }}</span>
 } @else if (labelType === 'comment') {
-    <span>{{ isSketchId(id) ? 'Textkritische Kommentare' : 'Textkritische Anmerkungen' }}</span>
+    <span>{{ utils.isSketchId(id) ? 'Textkritische Kommentare' : 'Textkritische Anmerkungen' }}</span>
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditionTkaLabelComponent } from './edition-tka-label.component';
+
+describe('EditionTkaLabelComponent', () => {
+    let component: EditionTkaLabelComponent;
+    let fixture: ComponentFixture<EditionTkaLabelComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [EditionTkaLabelComponent],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(EditionTkaLabelComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.spec.ts
@@ -1,22 +1,144 @@
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import Spy = jasmine.Spy;
+
+import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
+import { expectSpyCall, expectToBe, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+
+import { UtilityService } from '@awg-core/services';
 
 import { EditionTkaLabelComponent } from './edition-tka-label.component';
 
-describe('EditionTkaLabelComponent', () => {
+describe('EditionTkaLabelComponent (DONE)', () => {
     let component: EditionTkaLabelComponent;
     let fixture: ComponentFixture<EditionTkaLabelComponent>;
+    let compDe: DebugElement;
+
+    let utils: UtilityService;
+
+    let isSketchIdSpy: Spy;
+
+    let expectedId: string;
+    let expectedLabelType: 'evaluation' | 'comment';
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [EditionTkaLabelComponent],
+            declarations: [EditionTkaLabelComponent],
+            providers: [UtilityService],
         }).compileComponents();
 
         fixture = TestBed.createComponent(EditionTkaLabelComponent);
         component = fixture.componentInstance;
-        fixture.detectChanges();
+        compDe = fixture.debugElement;
+
+        utils = TestBed.inject(UtilityService);
+
+        // Test data
+        expectedId = 'test-1';
+        expectedLabelType = 'evaluation';
+
+        // Spies on component functions
+        // `.and.callThrough` will track the spy down the nested describes, see
+        // https://jasmine.github.io/2.0/introduction.html#section-Spies:_%3Ccode%3Eand.callThrough%3C/code%3E
+        isSketchIdSpy = spyOn(utils, 'isSketchId').and.callThrough();
     });
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    describe('BEFORE initial data binding', () => {
+        it('... should not have `id`', () => {
+            expect(component.id).toBeUndefined();
+        });
+
+        it('... should not have `labelType`', () => {
+            expect(component.labelType).toBeUndefined();
+        });
+    });
+
+    describe('AFTER initial data binding', () => {
+        beforeEach(() => {
+            // Simulate the parent setting the input properties
+            component.id = expectedId;
+            component.labelType = expectedLabelType;
+
+            // Trigger initial data binding
+            fixture.detectChanges();
+        });
+
+        it('... should have `id`', () => {
+            expectToBe(component.id, expectedId);
+        });
+
+        it('... should have `labelType`', () => {
+            expectToBe(component.labelType, expectedLabelType);
+        });
+
+        it('... should have called `isSketchId` from UtilityService with given id', () => {
+            expectSpyCall(isSketchIdSpy, 1, expectedId);
+        });
+
+        describe('VIEW', () => {
+            describe('WHEN `labelType` is `evaluation`', () => {
+                beforeEach(() => {
+                    component.labelType = 'evaluation';
+
+                    detectChangesOnPush(fixture);
+                });
+
+                it('... should display `Quellenbewertung` in span if no sketch id is given', () => {
+                    component.id = 'test-1';
+
+                    detectChangesOnPush(fixture);
+
+                    const spanDes = getAndExpectDebugElementByCss(compDe, 'span', 1, 1);
+                    const spanEl = spanDes[0].nativeElement;
+
+                    expectToBe(spanEl.textContent.trim(), 'Quellenbewertung');
+                });
+
+                it('... should display `Skizzenkommentar` in span if sketch id is given', () => {
+                    component.id = 'test-1_Sk1';
+
+                    detectChangesOnPush(fixture);
+
+                    const spanDes = getAndExpectDebugElementByCss(compDe, 'span', 1, 1);
+                    const spanEl = spanDes[0].nativeElement;
+
+                    expectToBe(spanEl.textContent.trim(), 'Skizzenkommentar');
+                });
+            });
+
+            describe('WHEN `labelType` is `comment`', () => {
+                beforeEach(() => {
+                    component.labelType = 'comment';
+
+                    detectChangesOnPush(fixture);
+                });
+
+                it('... should display `Textkritische Anmerkungen` in span if no sketch id is given', () => {
+                    component.id = 'test-1';
+
+                    detectChangesOnPush(fixture);
+
+                    const spanDes = getAndExpectDebugElementByCss(compDe, 'span', 1, 1);
+                    const spanEl = spanDes[0].nativeElement;
+
+                    expectToBe(spanEl.textContent.trim(), 'Textkritische Anmerkungen');
+                });
+
+                it('... should display `Textkritische Kommentare` in span if sketch id is given', () => {
+                    component.id = 'test-1_Sk1';
+
+                    detectChangesOnPush(fixture);
+
+                    const spanDes = getAndExpectDebugElementByCss(compDe, 'span', 1, 1);
+                    const spanEl = spanDes[0].nativeElement;
+
+                    expectToBe(spanEl.textContent.trim(), 'Textkritische Kommentare');
+                });
+            });
+        });
     });
 });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
+import { UtilityService } from '@awg-core/services';
+
 /**
  * The EditionTkaLabel component.
  *
@@ -28,15 +30,11 @@ export class EditionTkaLabelComponent {
     @Input() labelType: 'evaluation' | 'comment';
 
     /**
-     * Public method: isSketchId.
+     * Constructor of the EditionTkaLabelComponent.
      *
-     * It checks if the given id refers to a sketch.
+     * It declares a public instance of the UtilityService.
      *
-     * @param {string} id The given id.
-     *
-     * @returns {boolean} The result of the check.
+     * @param {UtilityService} utils Instance of the UtilityService.
      */
-    isSketchId(id: string): boolean {
-        return id?.includes('_Sk') || id?.includes('SkRT') || false;
-    }
+    constructor(public utils: UtilityService) {}
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/edition-tka-label.component.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+/**
+ * The EditionTkaLabel component.
+ *
+ * It contains the label for the textcritical comments
+ * of the edition view of the app.
+ */
+@Component({
+    selector: 'awg-edition-tka-label',
+    templateUrl: './edition-tka-label.component.html',
+    styleUrl: './edition-tka-label.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EditionTkaLabelComponent {
+    /**
+     * Input variable: id.
+     *
+     * It keeps the id of the sheet or textcritics.
+     */
+    @Input() id: string;
+
+    /**
+     * Input variable: labelType.
+     *
+     * It keeps the type of the label.
+     */
+    @Input() labelType: 'evaluation' | 'comment';
+
+    /**
+     * Public method: isSketchId.
+     *
+     * It checks if the given id refers to a sketch.
+     *
+     * @param {string} id The given id.
+     *
+     * @returns {boolean} The result of the check.
+     */
+    isSketchId(id: string): boolean {
+        return id?.includes('_Sk') || id?.includes('SkRT') || false;
+    }
+}

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/index.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-label/index.ts
@@ -1,0 +1,1 @@
+export * from './edition-tka-label.component';

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-table/edition-tka-table.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-table/edition-tka-table.component.spec.ts
@@ -204,8 +204,8 @@ describe('EditionTkaTableComponent (DONE)', () => {
                 });
             });
 
-            it('... should display default table header with adjusted comment colum if `isTextcriticsForSketch` flag is true', () => {
-                component.isTextcriticsForSketch = true;
+            it('... should display default table header with adjusted comment colum if `isSketchId` flag is true', () => {
+                component.isSketchId = true;
                 detectChangesOnPush(fixture);
 
                 const expected = expectedTableHeaderStrings['default'];
@@ -344,7 +344,7 @@ describe('EditionTkaTableComponent (DONE)', () => {
 
                 expectSpyCall(getTableHeaderStringsSpy, 2);
 
-                component.isTextcriticsForSketch = true;
+                component.isSketchId = true;
                 detectChangesOnPush(fixture);
 
                 expectSpyCall(getTableHeaderStringsSpy, 3);
@@ -352,7 +352,7 @@ describe('EditionTkaTableComponent (DONE)', () => {
 
             it('... should return rowTable header if `isRowTable` flag is given', () => {
                 component.isRowTable = true;
-                component.isTextcriticsForSketch = false;
+                component.isSketchId = false;
                 detectChangesOnPush(fixture);
 
                 const tableHeaders = component.getTableHeaderStrings();
@@ -360,9 +360,9 @@ describe('EditionTkaTableComponent (DONE)', () => {
                 expectToEqual(tableHeaders, expectedTableHeaderStrings['rowTable']);
             });
 
-            it('... should return rowTable header with adjusted comment colum if `isTextcriticsForSketch` flag is true', () => {
+            it('... should return rowTable header with adjusted comment colum if `isSketchId` flag is true', () => {
                 component.isRowTable = true;
-                component.isTextcriticsForSketch = true;
+                component.isSketchId = true;
                 detectChangesOnPush(fixture);
 
                 const expected = expectedTableHeaderStrings['rowTable'];
@@ -375,7 +375,7 @@ describe('EditionTkaTableComponent (DONE)', () => {
 
             it('... should return corrections table header if `isCorrections` flag is given', () => {
                 component.isCorrections = true;
-                component.isTextcriticsForSketch = false;
+                component.isSketchId = false;
                 detectChangesOnPush(fixture);
 
                 const tableHeaders = component.getTableHeaderStrings();
@@ -383,9 +383,9 @@ describe('EditionTkaTableComponent (DONE)', () => {
                 expectToEqual(tableHeaders, expectedTableHeaderStrings['corrections']);
             });
 
-            it('... should not change corrections table header if `isTextcriticsForSketch` flag is true', () => {
+            it('... should not change corrections table header if `isSketchId` flag is true', () => {
                 component.isCorrections = true;
-                component.isTextcriticsForSketch = true;
+                component.isSketchId = true;
                 detectChangesOnPush(fixture);
 
                 const tableHeaders = component.getTableHeaderStrings();
@@ -396,7 +396,7 @@ describe('EditionTkaTableComponent (DONE)', () => {
             it('... should return default table header if `isRowTable` flag or `isCorrections` are not given', () => {
                 component.isRowTable = false;
                 component.isCorrections = false;
-                component.isTextcriticsForSketch = false;
+                component.isSketchId = false;
                 detectChangesOnPush(fixture);
 
                 const tableHeaders = component.getTableHeaderStrings();
@@ -404,10 +404,10 @@ describe('EditionTkaTableComponent (DONE)', () => {
                 expectToEqual(tableHeaders, expectedTableHeaderStrings['default']);
             });
 
-            it('... should return default table header with adjusted comment colum if `isTextcriticsForSketch` flag is true', () => {
+            it('... should return default table header with adjusted comment colum if `isSketchId` flag is true', () => {
                 component.isRowTable = false;
                 component.isCorrections = false;
-                component.isTextcriticsForSketch = true;
+                component.isSketchId = true;
                 detectChangesOnPush(fixture);
 
                 const expected = expectedTableHeaderStrings['default'];

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-table/edition-tka-table.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-table/edition-tka-table.component.ts
@@ -41,12 +41,12 @@ export class EditionTkaTableComponent {
     isRowTable = false;
 
     /**
-     * Input variable: isTextcriticsForSketch.
+     * Input variable: isSketchId.
      *
      * It keeps a boolean flag to indicate if the textcritics are related to a sketch.
      */
     @Input()
-    isTextcriticsForSketch = false;
+    isSketchId = false;
 
     /**
      * Output variable: navigateToReportFragment.
@@ -154,7 +154,7 @@ export class EditionTkaTableComponent {
         }
 
         // Adjust comment label for sketches, but not corrections
-        if (this.isTextcriticsForSketch && !this.isCorrections) {
+        if (this.isSketchId && !this.isCorrections) {
             selectedTableHeader = selectedTableHeader.map(item =>
                 item.reference === 'comment' ? { ...item, label: 'Kommentar' } : item
             );

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka.module.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka.module.ts
@@ -2,17 +2,18 @@ import { NgModule } from '@angular/core';
 import { SharedModule } from '@awg-shared/shared.module';
 
 import { EditionTkaDescriptionComponent } from './edition-tka-description/edition-tka-description.component';
+import { EditionTkaLabelComponent } from './edition-tka-label/edition-tka-label.component';
 import { EditionTkaTableComponent } from './edition-tka-table/edition-tka-table.component';
 
 /**
  * The edition TkA table module.
  *
- * It embeds the {@link EditionTkaTableComponent}, {@link EditionTkaDescriptionComponent}
- * as well as the {@link SharedModule}.
+ * It embeds the {@link EditionTkaTableComponent}, {@link EditionTkaLabelComponent},
+ * {@link EditionTkaDescriptionComponent} as well as the {@link SharedModule}.
  */
 @NgModule({
     imports: [SharedModule],
-    declarations: [EditionTkaDescriptionComponent, EditionTkaTableComponent],
-    exports: [EditionTkaDescriptionComponent, EditionTkaTableComponent],
+    declarations: [EditionTkaDescriptionComponent, EditionTkaLabelComponent, EditionTkaTableComponent],
+    exports: [EditionTkaDescriptionComponent, EditionTkaLabelComponent, EditionTkaTableComponent],
 })
 export class EditionTkaModule {}


### PR DESCRIPTION
This PRs refactors the way how the textritic labels are applied depending on the id of current sheet or textcritics: 

It moves all the logic into a separate tka label component which is then used in all the needed places. This way the logic does not need to be duplicated in different parts of the app.