### PR TITLE
fix(edition): fix direction of arrows in SheetFooter

### DIFF
--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.html
@@ -3,7 +3,7 @@
         <p (click)="toggleTextcritics()" style="cursor: pointer">
             @if (selectedTextcritics.description && utils.isNotEmptyArray(selectedTextcritics.description)) {
                 <span>
-                    <fa-icon [icon]="showTextcritics ? faChevronUp : faChevronRight"></fa-icon>
+                    <fa-icon [icon]="showTextcritics ? faChevronDown : faChevronRight"></fa-icon>
                     &nbsp;
                 </span>
             }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.spec.ts
@@ -4,7 +4,7 @@ import Spy = jasmine.Spy;
 
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import { faChevronRight, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
@@ -60,7 +60,7 @@ class EditionTkaTableStubComponent {
     selectSvgSheetRequest: EventEmitter<{ complexId: string; sheetId: string }> = new EventEmitter();
 }
 
-describe('EditionSvgSheetFooterComponent (DONE)', () => {
+fdescribe('EditionSvgSheetFooterComponent (DONE)', () => {
     let component: EditionSvgSheetFooterComponent;
     let fixture: ComponentFixture<EditionSvgSheetFooterComponent>;
     let compDe: DebugElement;
@@ -84,8 +84,8 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
     let expectedShowTka: boolean;
     let expectedModalSnippet: string;
 
+    let expectedChevronDownIcon: IconDefinition;
     let expectedChevronRightIcon: IconDefinition;
-    let expectedChevronUpIcon: IconDefinition;
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -117,8 +117,8 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
         expectedSelectedTextcriticalComments = expectedSelectedTextcritics.comments;
         expectedShowTka = true;
 
+        expectedChevronDownIcon = faChevronDown;
         expectedChevronRightIcon = faChevronRight;
-        expectedChevronUpIcon = faChevronUp;
 
         // Spies on component functions
         // `.and.callThrough` will track the spy down the nested describes, see
@@ -152,9 +152,8 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
         });
 
         it('... should have fontawesome icons', () => {
+            expectToEqual(component.faChevronDown, expectedChevronDownIcon);
             expectToEqual(component.faChevronRight, expectedChevronRightIcon);
-
-            expectToEqual(component.faChevronUp, expectedChevronUpIcon);
         });
 
         it('... should have `ref`', () => {
@@ -230,7 +229,7 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 expect(iconDes[0].children[0].classes['fa-chevron-right']).toBeTrue();
             });
 
-            it('... should contain fa-icon with chevronUp in p in evaluation div if showTextcritics = true', () => {
+            it('... should contain fa-icon with chevronDown in p in evaluation div if showTextcritics = true', () => {
                 component.showTextcritics = true;
                 detectChangesOnPush(fixture);
 
@@ -246,7 +245,7 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
 
                 expect(iconDes[0].children[0]).toBeTruthy();
                 expect(iconDes[0].children[0].classes).toBeTruthy();
-                expect(iconDes[0].children[0].classes['fa-chevron-up']).toBeTrue();
+                expect(iconDes[0].children[0].classes['fa-chevron-down']).toBeTrue();
             });
 
             it('... should contain a span.smallcaps in p with first EditionTkaLabelComponent', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
-import { faChevronRight, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 
 import { UtilityService } from '@awg-app/core/services';
 import { TextcriticalComment, Textcritics } from '@awg-app/views/edition-view/models';
@@ -76,11 +76,11 @@ export class EditionSvgSheetFooterComponent {
     faChevronRight = faChevronRight;
 
     /**
-     * Public variable: faChevronRight.
+     * Public variable: faChevronDown.
      *
-     * It instantiates fontawesome's faChevronRight icon.
+     * It instantiates fontawesome's faChevronDown icon.
      */
-    faChevronUp = faChevronUp;
+    faChevronDown = faChevronDown;
 
     /**
      * Self-referring variable needed for CompileHtml library.


### PR DESCRIPTION
This PR changes the up arrow to down arrow in the SvgSheetFooterComponent. This makes the behaviour more consistent with other (similar) elements.