### PR TITLE
refactor(edition): move sheet viewer nav into separate component

### DIFF
--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-nav/edition-svg-sheet-viewer-nav.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-nav/edition-svg-sheet-viewer-nav.component.html
@@ -1,0 +1,8 @@
+<div class="awg-edition-svg-sheet-viewer-nav">
+    <div class="prev" (click)="browseSvgSheet(-1)">
+        <span>&#10094;</span>
+    </div>
+    <div class="next" (click)="browseSvgSheet(1)">
+        <span>&#10095;</span>
+    </div>
+</div>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-nav/edition-svg-sheet-viewer-nav.component.scss
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-nav/edition-svg-sheet-viewer-nav.component.scss
@@ -1,0 +1,36 @@
+@import '/src/assets/themes/scss/shared';
+
+.awg-edition-svg-sheet-viewer-nav {
+    > .prev,
+    .next {
+        cursor: pointer;
+        position: absolute;
+        height: 100%;
+        top: 0;
+        width: auto;
+        padding: 8px;
+        user-select: none;
+
+        &:hover {
+            background-color: #dddddd;
+        }
+
+        span {
+            position: relative;
+            top: 45%;
+            font-weight: bold;
+            font-size: 18px;
+            transition: 0.6s ease;
+            color: $link-color;
+        }
+    }
+
+    > .prev {
+        border-right: 1px solid #dddddd;
+    }
+
+    > .next {
+        right: 0;
+        border-left: 1px solid #dddddd;
+    }
+}

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-nav/edition-svg-sheet-viewer-nav.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-nav/edition-svg-sheet-viewer-nav.component.spec.ts
@@ -1,0 +1,155 @@
+import { DOCUMENT } from '@angular/common';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
+
+import Spy = jasmine.Spy;
+
+import { cleanStylesFromDOM } from '@testing/clean-up-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
+import { expectSpyCall, expectToBe, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+
+import { EditionSvgSheetViewerNavComponent } from './edition-svg-sheet-viewer-nav.component';
+
+describe('EditionSvgSheetViewerNavComponent', () => {
+    let component: EditionSvgSheetViewerNavComponent;
+    let fixture: ComponentFixture<EditionSvgSheetViewerNavComponent>;
+    let compDe: DebugElement;
+
+    let mockDocument: Document;
+
+    let browseSvgSheetSpy: Spy;
+    let browseSvgSheetRequestEmitSpy: Spy;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [EditionSvgSheetViewerNavComponent],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(EditionSvgSheetViewerNavComponent);
+        component = fixture.componentInstance;
+        compDe = fixture.debugElement;
+
+        mockDocument = TestBed.inject(DOCUMENT);
+
+        // Spies on component functions
+        // `.and.callThrough` will track the spy down the nested describes, see
+        // https://jasmine.github.io/2.0/introduction.html#section-Spies:_%3Ccode%3Eand.callThrough%3C/code%3E
+        browseSvgSheetSpy = spyOn(component, 'browseSvgSheet').and.callThrough();
+        browseSvgSheetRequestEmitSpy = spyOn(component.browseSvgSheetRequest, 'emit').and.callThrough();
+    });
+
+    afterAll(() => {
+        cleanStylesFromDOM();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    describe('BEFORE initial data binding', () => {
+        describe('VIEW', () => {
+            it('... should contain one div.awg-edition-svg-sheet-viewer-nav', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-viewer-nav', 1, 1);
+            });
+
+            it('... should contain 1 div.prev and 1 div.next in div.awg-edition-svg-sheet-viewer-nav', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-viewer-nav > div', 2, 2);
+
+                const sheetViewerNavDe = getAndExpectDebugElementByCss(
+                    compDe,
+                    'div.awg-edition-svg-sheet-viewer-nav',
+                    1,
+                    1
+                );
+
+                getAndExpectDebugElementByCss(sheetViewerNavDe[0], 'div.prev', 1, 1);
+                getAndExpectDebugElementByCss(sheetViewerNavDe[0], 'div.next', 1, 1);
+            });
+
+            it('... should display left arrow in div.prev', () => {
+                const divPrevDe = getAndExpectDebugElementByCss(compDe, 'div.prev', 1, 1);
+
+                const spanDe = getAndExpectDebugElementByCss(divPrevDe[0], 'span', 1, 1);
+                const spanEl = spanDe[0].nativeElement;
+
+                // Process HTML expression of expected text content
+                const expectedHtmlTextContent = mockDocument.createElement('span');
+                expectedHtmlTextContent.innerHTML = '&#10094;';
+
+                expectToBe(spanEl.textContent, expectedHtmlTextContent.textContent);
+            });
+
+            it('... should display right arrow in div.next', () => {
+                const divNextDe = getAndExpectDebugElementByCss(compDe, 'div.next', 1, 1);
+
+                const spanDe = getAndExpectDebugElementByCss(divNextDe[0], 'span', 1, 1);
+                const spanEl = spanDe[0].nativeElement;
+
+                // Process HTML expression of expected text content
+                const expectedHtmlTextContent = mockDocument.createElement('span');
+                expectedHtmlTextContent.innerHTML = '&#10095;';
+
+                expectToBe(spanEl.textContent, expectedHtmlTextContent.textContent);
+            });
+        });
+    });
+
+    describe('AFTER initial data binding', () => {
+        beforeEach(() => {
+            // Trigger initial data binding
+            fixture.detectChanges();
+        });
+
+        describe('#browseSvgSheet()', () => {
+            it('... should have a method `browseSvgSheet`  ', () => {
+                expect(component.browseSvgSheet).toBeDefined();
+            });
+
+            it('... should trigger on click on div.prev', fakeAsync(() => {
+                const divPrevDe = getAndExpectDebugElementByCss(compDe, 'div.prev', 1, 1);
+                const expectedDirection = -1;
+
+                // Trigger click with click helper & wait for changes
+                clickAndAwaitChanges(divPrevDe[0], fixture);
+
+                expectSpyCall(browseSvgSheetRequestEmitSpy, 1, expectedDirection);
+            }));
+
+            it('... should trigger on click on div.next', fakeAsync(() => {
+                const divNextDe = getAndExpectDebugElementByCss(compDe, 'div.next', 1, 1);
+                const expectedDirection = 1;
+
+                // Trigger click with click helper & wait for changes
+                clickAndAwaitChanges(divNextDe[0], fixture);
+
+                expectSpyCall(browseSvgSheetRequestEmitSpy, 1, expectedDirection);
+            }));
+
+            it('... should not emit anything if no direction is provided', () => {
+                const expectedDirection = undefined;
+                component.browseSvgSheet(expectedDirection);
+
+                expectSpyCall(browseSvgSheetRequestEmitSpy, 0, expectedDirection);
+            });
+
+            it('... should emit a given direction', () => {
+                const expectedDirection = 1;
+                component.browseSvgSheet(expectedDirection);
+
+                expectSpyCall(browseSvgSheetRequestEmitSpy, 1, expectedDirection);
+            });
+
+            it('... should emit the correct direction', () => {
+                let expectedDirection = 1;
+                component.browseSvgSheet(expectedDirection);
+
+                expectSpyCall(browseSvgSheetRequestEmitSpy, 1, expectedDirection);
+
+                expectedDirection = -1;
+                component.browseSvgSheet(expectedDirection);
+
+                expectSpyCall(browseSvgSheetRequestEmitSpy, 2, expectedDirection);
+            });
+        });
+    });
+});

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-nav/edition-svg-sheet-viewer-nav.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-nav/edition-svg-sheet-viewer-nav.component.ts
@@ -1,0 +1,39 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Output } from '@angular/core';
+
+/**
+ * The EditionSvgSheetViewerNav component.
+ *
+ * It contains the navigation panel for the edition svg sheet viewer.
+ */
+@Component({
+    selector: 'awg-edition-svg-sheet-viewer-nav',
+    templateUrl: './edition-svg-sheet-viewer-nav.component.html',
+    styleUrl: './edition-svg-sheet-viewer-nav.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EditionSvgSheetViewerNavComponent {
+    /**
+     * Output variable: browseSvgSheetRequest.
+     *
+     * It keeps an event emitter for the next or pevious index of an svg sheet.
+     */
+    @Output()
+    browseSvgSheetRequest: EventEmitter<number> = new EventEmitter();
+
+    /**
+     * Public method: browseSvgSheet.
+     *
+     * It emits a given direction to the {@link browseSvgSheetRequest}
+     * to browse to the previous or next sheet of the selected svg sheet.
+     *
+     * @param {number} direction A number indicating the direction of navigation. -1 for previous and 1 for next.
+     *
+     * @returns {void} Emits the direction.
+     */
+    browseSvgSheet(direction: number): void {
+        if (!direction) {
+            return;
+        }
+        this.browseSvgSheetRequest.emit(direction);
+    }
+}

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-nav/index.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer-nav/index.ts
@@ -1,0 +1,1 @@
+export * from './edition-svg-sheet-viewer-nav.component';

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.html
@@ -27,7 +27,9 @@
                 <svg #svgSheetElement id="awg-edition-svg-sheet">
                     <g #svgSheetRootGroup id="awg-edition-svg-sheet-root-group"></g>
                 </svg>
+
                 <awg-license></awg-license>
+
                 @if (hasAvailableTkaOverlays || suppliedClasses.size > 0) {
                     <awg-edition-svg-sheet-viewer-switch
                         [id]="selectedSvgSheet.id"
@@ -39,15 +41,10 @@
                         "></awg-edition-svg-sheet-viewer-switch>
                 }
             </div>
+
             <!-- Next and previous buttons -->
-            <div class="awg-edition-svg-sheet-viewer-nav">
-                <div class="prev" (click)="browseSvgSheet(-1)">
-                    <span>&#10094;</span>
-                </div>
-                <div class="next" (click)="browseSvgSheet(1)">
-                    <span>&#10095;</span>
-                </div>
-            </div>
+            <awg-edition-svg-sheet-viewer-nav
+                (browseSvgSheetRequest)="browseSvgSheet($event)"></awg-edition-svg-sheet-viewer-nav>
         </div>
     </div>
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.scss
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.scss
@@ -15,44 +15,6 @@
         box-shadow: 5px 5px 6px rgba(204, 204, 204, 1); /* rgba converted HEX #cccccc */
         border: 1px solid $border-grey;
     }
-
-    /* Next & previous buttons */
-    .awg-edition-svg-sheet-viewer-nav {
-        > .prev,
-        .next {
-            cursor: pointer;
-            position: absolute;
-            height: 100%;
-            top: 0;
-            width: auto;
-            padding: 8px;
-            user-select: none;
-
-            /* On hover, add a black background color with a little bit see-through */
-            &:hover {
-                background-color: #dddddd;
-            }
-
-            span {
-                position: relative;
-                top: 45%;
-                font-weight: bold;
-                font-size: 18px;
-                transition: 0.6s ease;
-                color: $link-color;
-            }
-        }
-
-        > .prev {
-            border-right: 1px solid #dddddd;
-        }
-
-        /* Position the "next button" to the right */
-        > .next {
-            right: 0;
-            border-left: 1px solid #dddddd;
-        }
-    }
 }
 
 /* slider */

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.spec.ts
@@ -43,6 +43,12 @@ import * as D3_SELECTION from 'd3-selection';
 @Component({ selector: 'awg-license', template: '' })
 class LicenseStubComponent {}
 
+@Component({ selector: 'awg-edition-svg-sheet-viewer-nav', template: '' })
+class EditionSvgSheetViewerNavStubComponent {
+    @Output()
+    browseSvgSheetRequest: EventEmitter<number> = new EventEmitter();
+}
+
 @Component({ selector: 'awg-edition-svg-sheet-viewer-switch', template: '' })
 class EditionSvgSheetViewerSwitchStubComponent {
     @Input() id?: string;
@@ -125,6 +131,7 @@ describe('EditionSvgSheetViewerComponent', () => {
             imports: [FontAwesomeTestingModule, FormsModule],
             declarations: [
                 EditionSvgSheetViewerComponent,
+                EditionSvgSheetViewerNavStubComponent,
                 EditionSvgSheetViewerSwitchStubComponent,
                 LicenseStubComponent,
             ],
@@ -323,13 +330,12 @@ describe('EditionSvgSheetViewerComponent', () => {
                 getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-viewer', 1, 1);
             });
 
-            it('... should contain 1 icon-bar, 1 sheet-container and 1 sheet-viewer-nav as direct child divs in outer div', () => {
+            it('... should contain 1 icon-bar and 1 sheet-container as direct child divs in outer div', () => {
                 const sheetViewerDe = getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-viewer', 1, 1);
-                getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-viewer > div', 3, 3);
+                getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-viewer > div', 2, 2);
 
                 getAndExpectDebugElementByCss(sheetViewerDe[0], 'div.awg-edition-svg-icon-bar', 1, 1);
                 getAndExpectDebugElementByCss(sheetViewerDe[0], 'div.awg-edition-svg-sheet-container', 1, 1);
-                getAndExpectDebugElementByCss(sheetViewerDe[0], 'div.awg-edition-svg-sheet-viewer-nav', 1, 1);
             });
 
             describe('awg-edition-svg-icon-bar', () => {
@@ -583,50 +589,15 @@ describe('EditionSvgSheetViewerComponent', () => {
             });
 
             describe('awg-edition-svg-sheet-viewer-nav', () => {
-                it('... should contain 1 div.prev and 1 div.next in div.awg-edition-svg-sheet-viewer-nav', () => {
+                it('... should contain 1 awg-edition-svg-sheet-viewer-nav component (stubbed)', () => {
                     const sheetViewerDe = getAndExpectDebugElementByCss(
                         compDe,
                         'div.awg-edition-svg-sheet-viewer',
                         1,
                         1
                     );
-                    getAndExpectDebugElementByCss(sheetViewerDe[0], 'div.awg-edition-svg-sheet-viewer-nav > div', 2, 2);
 
-                    const sheetViewerNavDe = getAndExpectDebugElementByCss(
-                        sheetViewerDe[0],
-                        'div.awg-edition-svg-sheet-viewer-nav',
-                        1,
-                        1
-                    );
-
-                    getAndExpectDebugElementByCss(sheetViewerNavDe[0], 'div.prev', 1, 1);
-                    getAndExpectDebugElementByCss(sheetViewerNavDe[0], 'div.next', 1, 1);
-                });
-
-                it('... should display left arrow in div.prev', () => {
-                    const divPrevDe = getAndExpectDebugElementByCss(compDe, 'div.prev', 1, 1);
-
-                    const spanDe = getAndExpectDebugElementByCss(divPrevDe[0], 'span', 1, 1);
-                    const spanEl = spanDe[0].nativeElement;
-
-                    // Process HTML expression of expected text content
-                    const expectedHtmlTextContent = mockDocument.createElement('span');
-                    expectedHtmlTextContent.innerHTML = '&#10094;';
-
-                    expectToBe(spanEl.textContent, expectedHtmlTextContent.textContent);
-                });
-
-                it('... should display right arrow in div.next', () => {
-                    const divNextDe = getAndExpectDebugElementByCss(compDe, 'div.next', 1, 1);
-
-                    const spanDe = getAndExpectDebugElementByCss(divNextDe[0], 'span', 1, 1);
-                    const spanEl = spanDe[0].nativeElement;
-
-                    // Process HTML expression of expected text content
-                    const expectedHtmlTextContent = mockDocument.createElement('span');
-                    expectedHtmlTextContent.innerHTML = '&#10095;';
-
-                    expectToBe(spanEl.textContent, expectedHtmlTextContent.textContent);
+                    getAndExpectDebugElementByDirective(sheetViewerDe[0], EditionSvgSheetViewerNavStubComponent, 1, 1);
                 });
             });
         });
@@ -636,25 +607,22 @@ describe('EditionSvgSheetViewerComponent', () => {
                 expect(component.browseSvgSheet).toBeDefined();
             });
 
-            it('... should trigger on click on div.prev', fakeAsync(() => {
-                const divPrevDe = getAndExpectDebugElementByCss(compDe, 'div.prev', 1, 1);
-                const expectedDirection = -1;
+            it('... should trigger on event from EditionSvgSheetViewerNavComponent', () => {
+                const navDes = getAndExpectDebugElementByDirective(compDe, EditionSvgSheetViewerNavStubComponent, 1, 1);
+                const navCmp = navDes[0].injector.get(
+                    EditionSvgSheetViewerNavStubComponent
+                ) as EditionSvgSheetViewerNavStubComponent;
 
-                // Trigger click with click helper & wait for changes
-                clickAndAwaitChanges(divPrevDe[0], fixture);
+                // Direction -1
+                navCmp.browseSvgSheetRequest.emit(-1);
 
-                expectSpyCall(browseSvgSheetRequestEmitSpy, 1, expectedDirection);
-            }));
+                expectSpyCall(browseSvgSheetSpy, 1, -1);
 
-            it('... should trigger on click on div.next', fakeAsync(() => {
-                const divNextDe = getAndExpectDebugElementByCss(compDe, 'div.next', 1, 1);
-                const expectedDirection = 1;
+                // Direction 1
+                navCmp.browseSvgSheetRequest.emit(1);
 
-                // Trigger click with click helper & wait for changes
-                clickAndAwaitChanges(divNextDe[0], fixture);
-
-                expectSpyCall(browseSvgSheetRequestEmitSpy, 1, expectedDirection);
-            }));
+                expectSpyCall(browseSvgSheetSpy, 2, 1);
+            });
 
             it('... should not emit anything if no direction is provided', () => {
                 const expectedDirection = undefined;

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.module.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.module.ts
@@ -3,6 +3,7 @@ import { SharedModule } from '@awg-shared/shared.module';
 
 import { EditionTkaModule } from '../../../edition-tka/edition-tka.module';
 
+import { EditionSvgSheetViewerNavComponent } from './edition-svg-sheet-viewer-nav';
 import { EditionSvgSheetViewerSwitchComponent } from './edition-svg-sheet-viewer-switch';
 import { EditionSvgSheetViewerComponent } from './edition-svg-sheet-viewer.component';
 
@@ -10,12 +11,17 @@ import { EditionSvgSheetViewerComponent } from './edition-svg-sheet-viewer.compo
  * The edition svg sheet viewer module.
  *
  * It embeds the {@link EditionSvgSheetViewerComponent},
+ * {@link EditionSvgSheetViewerNavComponent},
  * {@link EditionSvgSheetViewerSwitchComponent}
  * as well as the {@link SharedModule}.
  */
 @NgModule({
     imports: [SharedModule, EditionTkaModule],
-    declarations: [EditionSvgSheetViewerComponent, EditionSvgSheetViewerSwitchComponent],
-    exports: [EditionSvgSheetViewerComponent, EditionSvgSheetViewerSwitchComponent],
+    declarations: [
+        EditionSvgSheetViewerComponent,
+        EditionSvgSheetViewerNavComponent,
+        EditionSvgSheetViewerSwitchComponent,
+    ],
+    exports: [EditionSvgSheetViewerComponent, EditionSvgSheetViewerNavComponent, EditionSvgSheetViewerSwitchComponent],
 })
 export class EditionSvgSheetViewerModule {}


### PR DESCRIPTION
This PR separates the logic for the navigation panels of the svg sheet viewer into a separate component.