### PR TITLE
fix(edition): fix colons in system units of source descriptions

### DIFF
--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.html
@@ -353,7 +353,7 @@
                                                                                 (system.measure &&
                                                                                     !firstSystemGroup &&
                                                                                     folio.folio.length === 2),
-                                                                            doubletab_two:
+                                                                            doubletab_extended:
                                                                                 (system.row &&
                                                                                     !firstSystemGroup &&
                                                                                     firstSystem &&

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.html
@@ -370,10 +370,15 @@
                                                                     ></span>
                                                                 }
                                                                 <ng-template #systemTemplate let-system
-                                                                    >&nbsp;&nbsp;System&nbsp;{{
-                                                                        system
-                                                                    }}:&nbsp;</ng-template
+                                                                    >&nbsp;&nbsp;System&nbsp;{{ system }}</ng-template
                                                                 >
+                                                                @if (
+                                                                    system.systemDescription ||
+                                                                    system.measure ||
+                                                                    system.row
+                                                                ) {
+                                                                    <span>:&nbsp;</span>
+                                                                }
                                                                 @if (system.systemDescription) {
                                                                     <span
                                                                         class="awg-source-description-content-item-system-description">

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.html
@@ -1,6 +1,6 @@
 @if (sourceDescriptionListData) {
     <div class="awg-source-description-list">
-        @for (sourceDescription of sourceDescriptionListData.sources; track sourceDescription) {
+        @for (sourceDescription of sourceDescriptionListData.sources; track sourceDescription.id) {
             <div class="awg-source-description card mb-2" [id]="sourceDescription.id">
                 <div class="card-body">
                     <div class="awg-source-description-head">
@@ -68,7 +68,7 @@
 
                                     @for (
                                         writingMaterial of sourceDescription?.description?.writingMaterial;
-                                        track writingMaterial;
+                                        track $index;
                                         let lastWritingMaterial = $last
                                     ) {
                                         @if (writingMaterial.paperType) {
@@ -115,7 +115,7 @@
                                                     >&nbsp;
                                                 }
                                             </span>
-                                            @for (location of writingMaterial.firmSign.location; track location) {
+                                            @for (location of writingMaterial.firmSign.location; track $index) {
                                                 <span [innerHTML]="getWritingMaterialItemLocation(location)"></span>
                                             }
                                         } @else {
@@ -133,7 +133,7 @@
                                                     >&nbsp;
                                                 }
                                             </span>
-                                            @for (location of writingMaterial.watermark.location; track location) {
+                                            @for (location of writingMaterial.watermark.location; track $index) {
                                                 <span [innerHTML]="getWritingMaterialItemLocation(location)"></span>
                                             }
                                             <span>&nbsp;lesbar</span>
@@ -220,7 +220,7 @@
                             @if (utils.isNotEmptyArray(sourceDescription.description.content)) {
                                 <div class="awg-source-description-content">
                                     <p class="no-para"><span class="smallcaps">Inhalt:</span></p>
-                                    @for (content of sourceDescription.description.content; track content) {
+                                    @for (content of sourceDescription.description.content; track $index) {
                                         <p class="half-para">
                                             <!-- content.itemDescription -->
                                             @if (content.item || content.itemDescription) {
@@ -254,7 +254,7 @@
                                             }
                                             <!-- content.folios -->
                                             @if (utils.isNotEmptyArray(content.folios)) {
-                                                @for (folio of content.folios; track folio; let lastFolio = $last) {
+                                                @for (folio of content.folios; track $index; let lastFolio = $last) {
                                                     @if (folio.folio) {
                                                         <span
                                                             class="awg-source-description-content-item-folio"
@@ -320,14 +320,14 @@
                                                     @if (utils.isNotEmptyArray(folio.systemGroups)) {
                                                         @for (
                                                             systemGroup of folio.systemGroups;
-                                                            track systemGroup;
+                                                            track $index;
                                                             let firstSystemGroup = $first;
                                                             let lastSystemGroup = $last
                                                         ) {
                                                             @for (
                                                                 system of systemGroup;
-                                                                track system;
-                                                                let i = $index;
+                                                                track $index;
+                                                                let systemIndex = $index;
                                                                 let firstSystem = $first;
                                                                 let lastSystem = $last
                                                             ) {
@@ -467,7 +467,9 @@
                                                                 } @else {
                                                                     <span
                                                                         >;
-                                                                        @if ((i + 1) % systemGroup.length === 0) {
+                                                                        @if (
+                                                                            (systemIndex + 1) % systemGroup.length === 0
+                                                                        ) {
                                                                             <br />
                                                                         }
                                                                     </span>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.spec.ts
@@ -954,7 +954,7 @@ describe('SourceDescriptionComponent (DONE)', () => {
                                 const systemEl = system.nativeElement;
 
                                 const expectedHtmlTextContent = mockDocument.createElement('span');
-                                expectedHtmlTextContent.innerHTML = `System&nbsp;${expectedSystems[index].system}:`;
+                                expectedHtmlTextContent.innerHTML = `System&nbsp;${expectedSystems[index].system}`;
 
                                 expectToBe(systemEl.textContent.trim(), expectedHtmlTextContent.textContent.trim());
                             });
@@ -992,6 +992,49 @@ describe('SourceDescriptionComponent (DONE)', () => {
                                 const expectedSystemDescText = expectedSystemDescriptions[index].systemDescription;
 
                                 expectToBe(systemDescEl.textContent.trim(), expectedSystemDescText);
+                            });
+                        });
+                    });
+
+                    it('... should display a colon after the systems if systemDescriptions, measures or rows are given, otherwise a dot.', () => {
+                        // Get number of all content items of mockdata
+                        const expectedContent = expectedSourceDescriptionListData.sources[1].description.content;
+                        const pDes = getAndExpectDebugElementByCss(
+                            compDe,
+                            'div.awg-source-description-body > div.awg-source-description-content > p.half-para',
+                            expectedContent.length,
+                            expectedContent.length
+                        );
+                        pDes.forEach((pDe, pIndex) => {
+                            // Get length of nested system groups array of all folios of 1st content item array of mockdata
+                            const systemGroups = [];
+                            expectedContent[pIndex].folios.forEach(folio => {
+                                systemGroups.push(folio.systemGroups.flat());
+                            });
+                            const expectedSystems = systemGroups.flat();
+
+                            // Get the direct sibling spans of system spans
+                            const spanDes = getAndExpectDebugElementByCss(
+                                pDe,
+                                'span.awg-source-description-content-item-system + span',
+                                expectedSystems.length,
+                                expectedSystems.length
+                            );
+                            spanDes.forEach((span, index) => {
+                                const spanEl = span.nativeElement;
+                                const expectedHtmlTextContent = mockDocument.createElement('span');
+
+                                if (
+                                    expectedSystems[index].systemDescription ||
+                                    expectedSystems[index].measure ||
+                                    expectedSystems[index].row
+                                ) {
+                                    expectedHtmlTextContent.innerHTML = `:&nbsp;`;
+                                } else {
+                                    expectedHtmlTextContent.innerHTML = `.`;
+                                }
+
+                                expectToBe(spanEl.textContent.trim(), expectedHtmlTextContent.textContent.trim());
                             });
                         });
                     });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.spec.ts
@@ -1121,7 +1121,7 @@ describe('SourceDescriptionComponent (DONE)', () => {
                         expect(systemEl5).not.toHaveClass('doubletab');
                     });
 
-                    it('... should have `doubletab_two` class if the folio label length is greater 2 and the system is not in the first systemGroup, and has measures', () => {
+                    it('... should have `doubletab_extended` class if the folio label length is greater 2 and the system is not in the first systemGroup, and has measures', () => {
                         // Get number of all content items of mockdata
                         const expectedContent = expectedSourceDescriptionListData.sources[1].description.content;
                         const pDes = getAndExpectDebugElementByCss(
@@ -1152,16 +1152,16 @@ describe('SourceDescriptionComponent (DONE)', () => {
                         const systemEl5 = systemDes[5].nativeElement;
 
                         // Bl. 1r
-                        expect(systemEl0).not.toHaveClass('doubletab_two');
-                        expect(systemEl1).not.toHaveClass('doubletab_two');
+                        expect(systemEl0).not.toHaveClass('doubletab_extended');
+                        expect(systemEl1).not.toHaveClass('doubletab_extended');
 
                         // Bl. 29v
-                        expect(systemEl2).not.toHaveClass('doubletab_two');
-                        expect(systemEl3).toHaveClass('doubletab_two');
+                        expect(systemEl2).not.toHaveClass('doubletab_extended');
+                        expect(systemEl3).toHaveClass('doubletab_extended');
 
                         // S. 2
-                        expect(systemEl4).not.toHaveClass('doubletab_two');
-                        expect(systemEl5).not.toHaveClass('doubletab_two');
+                        expect(systemEl4).not.toHaveClass('doubletab_extended');
+                        expect(systemEl5).not.toHaveClass('doubletab_extended');
                     });
 
                     it('... should have `tab` class if the system has rows and is not the first system', () => {
@@ -1319,7 +1319,7 @@ describe('SourceDescriptionComponent (DONE)', () => {
                         expect(systemEl11).not.toHaveClass('doubletab');
                     });
 
-                    it('... should have `doubletab_two` class if the system has rows, is first system, but not in the first systemGroup, and the folio length is greater 2', () => {
+                    it('... should have `doubletab_extended` class if the system has rows, is first system, but not in the first systemGroup, and the folio length is greater 2', () => {
                         const expectedContentLength =
                             expectedSourceDescriptionListData.sources[1].description.content.length;
                         const expectedSystemLength = 12;
@@ -1347,16 +1347,16 @@ describe('SourceDescriptionComponent (DONE)', () => {
                         const systemEl7 = systemDes[7].nativeElement;
 
                         // Bl. 1r
-                        expect(systemEl0).not.toHaveClass('doubletab_two');
-                        expect(systemEl1).not.toHaveClass('doubletab_two');
-                        expect(systemEl2).not.toHaveClass('doubletab_two');
-                        expect(systemEl3).not.toHaveClass('doubletab_two');
+                        expect(systemEl0).not.toHaveClass('doubletab_extended');
+                        expect(systemEl1).not.toHaveClass('doubletab_extended');
+                        expect(systemEl2).not.toHaveClass('doubletab_extended');
+                        expect(systemEl3).not.toHaveClass('doubletab_extended');
 
                         // Bl. 29v
-                        expect(systemEl4).not.toHaveClass('doubletab_two');
-                        expect(systemEl5).not.toHaveClass('doubletab_two');
-                        expect(systemEl6).toHaveClass('doubletab_two');
-                        expect(systemEl7).not.toHaveClass('doubletab_two');
+                        expect(systemEl4).not.toHaveClass('doubletab_extended');
+                        expect(systemEl5).not.toHaveClass('doubletab_extended');
+                        expect(systemEl6).toHaveClass('doubletab_extended');
+                        expect(systemEl7).not.toHaveClass('doubletab_extended');
                     });
                 });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.html
@@ -1,45 +1,51 @@
 <div class="awg-edition-svg-sheet-footer mt-4">
-    <div class="awg-edition-svg-sheet-footer-evaluation">
-        <p (click)="toggleTextcritics()" style="cursor: pointer">
-            @if (selectedTextcritics.description && utils.isNotEmptyArray(selectedTextcritics.description)) {
-                <span>
-                    <fa-icon [icon]="showTextcritics ? faChevronDown : faChevronRight"></fa-icon>
-                    &nbsp;
-                </span>
-            }
+    @if (utils.isNotEmptyObject(selectedTextcritics)) {
+        <div class="awg-edition-svg-sheet-footer-evaluation">
+            <p (click)="toggleTextcritics()" style="cursor: pointer">
+                @if (utils.isNotEmptyArray(selectedTextcritics.description)) {
+                    <span>
+                        <fa-icon [icon]="showTextcritics ? faChevronDown : faChevronRight"></fa-icon>
+                        &nbsp;
+                    </span>
+                }
 
-            <span class="smallcaps"
-                ><awg-edition-tka-label [id]="selectedTextcritics.id" [labelType]="'evaluation'"></awg-edition-tka-label
-                >:</span
-            >
-            @if (selectedTextcritics.description && !utils.isNotEmptyArray(selectedTextcritics.description)) {
-                <span>&nbsp;---</span>
-            }
-        </p>
-        @if (
-            showTextcritics && selectedTextcritics.description && utils.isNotEmptyArray(selectedTextcritics.description)
-        ) {
-            <awg-edition-tka-description
-                [textcriticalDescriptions]="selectedTextcritics.description"
-                (navigateToReportFragmentRequest)="navigateToReportFragment($event)"
-                (openModalRequest)="openModal($event)"
-                (selectSvgSheetRequest)="selectSvgSheet($event)">
-            </awg-edition-tka-description>
-        }
-    </div>
-    @if (showTkA) {
-        <div class="awg-edition-svg-sheet-footer-textcritics">
-            <p class="smallcaps">
-                <awg-edition-tka-label [id]="selectedTextcritics.id" [labelType]="'comment'"></awg-edition-tka-label>:
+                <span class="smallcaps"
+                    ><awg-edition-tka-label
+                        [id]="selectedTextcritics?.id"
+                        [labelType]="'evaluation'"></awg-edition-tka-label
+                    >:</span
+                >
+
+                @if (!utils.isNotEmptyArray(selectedTextcritics.description)) {
+                    <span>&nbsp;---</span>
+                }
             </p>
-            <awg-edition-tka-table
-                [textcriticalComments]="selectedTextcriticalComments"
-                [isRowTable]="selectedTextcritics.rowtable"
-                [isSketchId]="utils.isSketchId(selectedTextcritics.id)"
-                (navigateToReportFragmentRequest)="navigateToReportFragment($event)"
-                (openModalRequest)="openModal($event)"
-                (selectSvgSheetRequest)="selectSvgSheet($event)">
-            </awg-edition-tka-table>
+            @if (showTextcritics && utils.isNotEmptyArray(selectedTextcritics.description)) {
+                <awg-edition-tka-description
+                    [textcriticalDescriptions]="selectedTextcritics.description"
+                    (navigateToReportFragmentRequest)="navigateToReportFragment($event)"
+                    (openModalRequest)="openModal($event)"
+                    (selectSvgSheetRequest)="selectSvgSheet($event)">
+                </awg-edition-tka-description>
+            }
         </div>
+        @if (showTkA) {
+            <div class="awg-edition-svg-sheet-footer-textcritics">
+                <p class="smallcaps">
+                    <awg-edition-tka-label
+                        [id]="selectedTextcritics?.id"
+                        [labelType]="'comment'"></awg-edition-tka-label
+                    >:
+                </p>
+                <awg-edition-tka-table
+                    [textcriticalComments]="selectedTextcriticalComments"
+                    [isRowTable]="selectedTextcritics?.rowtable"
+                    [isSketchId]="utils.isSketchId(selectedTextcritics?.id)"
+                    (navigateToReportFragmentRequest)="navigateToReportFragment($event)"
+                    (openModalRequest)="openModal($event)"
+                    (selectSvgSheetRequest)="selectSvgSheet($event)">
+                </awg-edition-tka-table>
+            </div>
+        }
     }
 </div>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.spec.ts
@@ -169,10 +169,10 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-footer', 1, 1);
             });
 
-            it('... should contain one evaluation div, but no textcritics div in outer div yet', () => {
+            it('... should contain no evaluation div and no textcritics div in outer div yet', () => {
                 const divDe = getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-footer', 1, 1);
 
-                getAndExpectDebugElementByCss(divDe[0], 'div.awg-edition-svg-sheet-footer-evaluation', 1, 1);
+                getAndExpectDebugElementByCss(divDe[0], 'div.awg-edition-svg-sheet-footer-evaluation', 0, 0);
                 getAndExpectDebugElementByCss(divDe[0], 'div.awg-edition-svg-sheet-footer-textcritics', 0, 0);
             });
         });
@@ -202,95 +202,105 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
         });
 
         describe('VIEW', () => {
+            it('... should not contain anything in outer div.awg-edition-svg-sheet-footer if selectedTextcritics is undefined', () => {
+                component.selectedTextcritics = undefined;
+                detectChangesOnPush(fixture);
+
+                const divDe = getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-footer', 1, 1);
+
+                getAndExpectDebugElementByCss(divDe[0], 'div.awg-edition-svg-sheet-footer-evaluation', 0, 0);
+                getAndExpectDebugElementByCss(divDe[0], 'div.awg-edition-svg-sheet-footer-textcritics', 0, 0);
+            });
+
+            it('... should contain one evaluation div if selectedTextcritics is defined', () => {
+                const divDe = getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-footer', 1, 1);
+
+                getAndExpectDebugElementByCss(divDe[0], 'div.awg-edition-svg-sheet-footer-evaluation', 1, 1);
+            });
+
             it('... should contain one paragraph in evaluation div', () => {
-                const divDes = getAndExpectDebugElementByCss(
+                const divDe = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-evaluation',
                     1,
                     1
                 );
 
-                getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
+                getAndExpectDebugElementByCss(divDe[0], 'p', 1, 1);
             });
 
-            it('... should contain fa-icon with chevronRight in p in evaluation div if showTextcritics = false', () => {
-                const divDes = getAndExpectDebugElementByCss(
+            it('... should contain fa-icon with chevronRight in evaluation paragraph if showTextcritics = false', () => {
+                const pDe = getAndExpectDebugElementByCss(
                     compDe,
-                    'div.awg-edition-svg-sheet-footer-evaluation',
+                    'div.awg-edition-svg-sheet-footer-evaluation > p:first-child',
                     1,
                     1
                 );
+                const iconDe = getAndExpectDebugElementByCss(pDe[0], 'fa-icon', 1, 1);
 
-                const pDes = getAndExpectDebugElementByCss(divDes[0], 'p:first-child', 1, 1);
-                const iconDes = getAndExpectDebugElementByCss(pDes[0], 'fa-icon', 1, 1);
-
-                expect(iconDes[0].children[0]).toBeTruthy();
-                expect(iconDes[0].children[0].classes).toBeTruthy();
-                expect(iconDes[0].children[0].classes['fa-chevron-right']).toBeTrue();
+                expect(iconDe[0].children[0]).toBeTruthy();
+                expect(iconDe[0].children[0].classes).toBeTruthy();
+                expect(iconDe[0].children[0].classes['fa-chevron-right']).toBeTrue();
             });
 
-            it('... should contain fa-icon with chevronDown in p in evaluation div if showTextcritics = true', () => {
+            it('... should contain fa-icon with chevronDown in evaluation paragraph if showTextcritics = true', () => {
                 component.showTextcritics = true;
                 detectChangesOnPush(fixture);
 
-                const divDes = getAndExpectDebugElementByCss(
+                const pDe = getAndExpectDebugElementByCss(
                     compDe,
-                    'div.awg-edition-svg-sheet-footer-evaluation',
+                    'div.awg-edition-svg-sheet-footer-evaluation > p:first-child',
                     1,
                     1
                 );
+                const iconDe = getAndExpectDebugElementByCss(pDe[0], 'fa-icon', 1, 1);
 
-                const pDes = getAndExpectDebugElementByCss(divDes[0], 'p:first-child', 1, 1);
-                const iconDes = getAndExpectDebugElementByCss(pDes[0], 'fa-icon', 1, 1);
-
-                expect(iconDes[0].children[0]).toBeTruthy();
-                expect(iconDes[0].children[0].classes).toBeTruthy();
-                expect(iconDes[0].children[0].classes['fa-chevron-down']).toBeTrue();
+                expect(iconDe[0].children[0]).toBeTruthy();
+                expect(iconDe[0].children[0].classes).toBeTruthy();
+                expect(iconDe[0].children[0].classes['fa-chevron-down']).toBeTrue();
             });
 
-            it('... should contain a span.smallcaps in p with first EditionTkaLabelComponent', () => {
-                const divDes = getAndExpectDebugElementByCss(
+            it('... should contain a span.smallcaps in evaluation paragraph with first EditionTkaLabelComponent', () => {
+                const pDe = getAndExpectDebugElementByCss(
                     compDe,
-                    'div.awg-edition-svg-sheet-footer-evaluation',
+                    'div.awg-edition-svg-sheet-footer-evaluation > p',
                     1,
                     1
                 );
+                const spanDe = getAndExpectDebugElementByCss(pDe[0], 'span.smallcaps', 1, 1);
 
-                const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
-                const spanDes = getAndExpectDebugElementByCss(pDes[0], 'span.smallcaps', 1, 1);
-
-                getAndExpectDebugElementByDirective(spanDes[0], EditionTkaLabelStubComponent, 1, 1);
+                getAndExpectDebugElementByDirective(spanDe[0], EditionTkaLabelStubComponent, 1, 1);
             });
 
             it('... should pass down `id` data to first EditionTkaLabelComponent (stubbed)', () => {
-                const divDes = getAndExpectDebugElementByCss(
+                const divDe = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-evaluation',
                     1,
                     1
                 );
 
-                const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
-                const spanDes = getAndExpectDebugElementByCss(pDes[0], 'span.smallcaps', 1, 1);
+                const pDe = getAndExpectDebugElementByCss(divDe[0], 'p', 1, 1);
+                const spanDe = getAndExpectDebugElementByCss(pDe[0], 'span.smallcaps', 1, 1);
 
-                const labelDes = getAndExpectDebugElementByDirective(spanDes[0], EditionTkaLabelStubComponent, 1, 1);
+                const labelDes = getAndExpectDebugElementByDirective(spanDe[0], EditionTkaLabelStubComponent, 1, 1);
                 const labelCmp = labelDes[0].injector.get(EditionTkaLabelStubComponent) as EditionTkaLabelStubComponent;
 
                 expectToBe(labelCmp.id, expectedSelectedTextcritics.id);
             });
 
             it('... should pass down `labelType` data to first EditionTkaLabelComponent (stubbed)', () => {
-                const divDes = getAndExpectDebugElementByCss(
+                const divDe = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-evaluation',
                     1,
                     1
                 );
 
-                const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
-                const spanDes = getAndExpectDebugElementByCss(pDes[0], 'span.smallcaps', 1, 1);
+                const pDe = getAndExpectDebugElementByCss(divDe[0], 'p', 1, 1);
+                const spanDe = getAndExpectDebugElementByCss(pDe[0], 'span.smallcaps', 1, 1);
 
-                const labelDes = getAndExpectDebugElementByDirective(spanDes[0], EditionTkaLabelStubComponent, 1, 1);
+                const labelDes = getAndExpectDebugElementByDirective(spanDe[0], EditionTkaLabelStubComponent, 1, 1);
                 const labelCmp = labelDes[0].injector.get(EditionTkaLabelStubComponent) as EditionTkaLabelStubComponent;
 
                 expectToBe(labelCmp.labelType, 'evaluation');
@@ -300,16 +310,16 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 component.selectedTextcritics = mockEditionData.mockTextcriticsData.textcritics[0];
                 detectChangesOnPush(fixture);
 
-                const divDes = getAndExpectDebugElementByCss(
+                const divDe = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-evaluation',
                     1,
                     1
                 );
 
-                const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
-                const spanDes = getAndExpectDebugElementByCss(pDes[0], 'span', 2, 2);
-                const spanEl = spanDes[1].nativeElement;
+                const pDe = getAndExpectDebugElementByCss(divDe[0], 'p', 1, 1);
+                const spanDe = getAndExpectDebugElementByCss(pDe[0], 'span', 2, 2);
+                const spanEl = spanDe[1].nativeElement;
 
                 expectToBe(spanEl.textContent.trim(), `---`);
             });
@@ -332,33 +342,28 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 component.showTextcritics = true;
                 detectChangesOnPush(fixture);
 
-                const divDes = getAndExpectDebugElementByCss(
+                const divDe = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-evaluation',
                     1,
                     1
                 );
 
-                getAndExpectDebugElementByDirective(divDes[0], EditionTkaDescriptionStubComponent, 1, 1);
+                getAndExpectDebugElementByDirective(divDe[0], EditionTkaDescriptionStubComponent, 1, 1);
             });
 
             it('... should pass down `description` data to the EditionTkaDescriptionComponent if showTextcritics = true', () => {
                 component.showTextcritics = true;
                 detectChangesOnPush(fixture);
 
-                const divDes = getAndExpectDebugElementByCss(
+                const divDe = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-evaluation',
                     1,
                     1
                 );
 
-                const descDes = getAndExpectDebugElementByDirective(
-                    divDes[0],
-                    EditionTkaDescriptionStubComponent,
-                    1,
-                    1
-                );
+                const descDes = getAndExpectDebugElementByDirective(divDe[0], EditionTkaDescriptionStubComponent, 1, 1);
                 const descCmp = descDes[0].injector.get(
                     EditionTkaDescriptionStubComponent
                 ) as EditionTkaDescriptionStubComponent;
@@ -370,71 +375,75 @@ describe('EditionSvgSheetFooterComponent (DONE)', () => {
                 component.showTkA = false;
                 detectChangesOnPush(fixture);
 
-                getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-footer-textcritics', 0, 0);
+                const divDe = getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-footer', 1, 1);
+
+                getAndExpectDebugElementByCss(divDe[0], 'div.awg-edition-svg-sheet-footer-textcritics', 0, 0);
             });
 
-            it('... should contain one textcritics div if showTka is true', () => {
+            it('... should contain one textcritics div if showTka is true (and selectedTextcritics is defined)', () => {
                 component.showTkA = true;
                 detectChangesOnPush(fixture);
 
-                getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-footer-textcritics', 1, 1);
+                const divDe = getAndExpectDebugElementByCss(compDe, 'div.awg-edition-svg-sheet-footer', 1, 1);
+
+                getAndExpectDebugElementByCss(divDe[0], 'div.awg-edition-svg-sheet-footer-textcritics', 1, 1);
             });
 
             it('... should contain one p.smallcaps header in textcritics div', () => {
-                const divDes = getAndExpectDebugElementByCss(
+                const divDe = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-textcritics',
                     1,
                     1
                 );
-                getAndExpectDebugElementByCss(divDes[0], 'p.smallcaps', 1, 1);
+                getAndExpectDebugElementByCss(divDe[0], 'p.smallcaps', 1, 1);
             });
 
             it('... should contain second EditionTkaLabelComponent (stubbed) in textcritics div', () => {
-                const divDes = getAndExpectDebugElementByCss(
+                const divDe = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-textcritics',
                     1,
                     1
                 );
 
-                getAndExpectDebugElementByDirective(divDes[0], EditionTkaLabelStubComponent, 1, 1);
+                getAndExpectDebugElementByDirective(divDe[0], EditionTkaLabelStubComponent, 1, 1);
             });
 
             it('... should contain one EditionTkaTableComponent (stubbed) in textcritics div', () => {
-                const divDes = getAndExpectDebugElementByCss(
+                const divDe = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-textcritics',
                     1,
                     1
                 );
 
-                getAndExpectDebugElementByDirective(divDes[0], EditionTkaTableStubComponent, 1, 1);
+                getAndExpectDebugElementByDirective(divDe[0], EditionTkaTableStubComponent, 1, 1);
             });
 
             it('... should pass down `id` to the second EditionTkaLabelComponent', () => {
-                const divDes = getAndExpectDebugElementByCss(
+                const divDe = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-textcritics',
                     1,
                     1
                 );
 
-                const labelDes = getAndExpectDebugElementByDirective(divDes[0], EditionTkaLabelStubComponent, 1, 1);
+                const labelDes = getAndExpectDebugElementByDirective(divDe[0], EditionTkaLabelStubComponent, 1, 1);
                 const labelCmp = labelDes[0].injector.get(EditionTkaLabelStubComponent) as EditionTkaLabelStubComponent;
 
                 expectToBe(labelCmp.id, expectedSelectedTextcritics.id);
             });
 
             it('... should pass down `labelType` to the second EditionTkaLabelComponent', () => {
-                const divDes = getAndExpectDebugElementByCss(
+                const divDe = getAndExpectDebugElementByCss(
                     compDe,
                     'div.awg-edition-svg-sheet-footer-textcritics',
                     1,
                     1
                 );
 
-                const labelDes = getAndExpectDebugElementByDirective(divDes[0], EditionTkaLabelStubComponent, 1, 1);
+                const labelDes = getAndExpectDebugElementByDirective(divDe[0], EditionTkaLabelStubComponent, 1, 1);
                 const labelCmp = labelDes[0].injector.get(EditionTkaLabelStubComponent) as EditionTkaLabelStubComponent;
 
                 expectToBe(labelCmp.labelType, 'comment');

--- a/src/assets/themes/scss/main.scss
+++ b/src/assets/themes/scss/main.scss
@@ -392,7 +392,7 @@ span.facet-badge {
     @extend %inlineblock;
     margin-left: 60px;
 }
-.doubletab_two {
+.doubletab_extended {
     @extend %inlineblock;
     margin-left: 70px;
 }

--- a/src/testing/mock-data/mockEditionData.ts
+++ b/src/testing/mock-data/mockEditionData.ts
@@ -352,6 +352,20 @@ export const mockEditionData = {
                                         ],
                                     ],
                                 },
+                                {
+                                    folio: '100v',
+                                    folioLinkTo: '',
+                                    folioDescription: '',
+                                    systemGroups: [
+                                        [
+                                            {
+                                                system: '7–8',
+                                                measure: '',
+                                                linkTo: '',
+                                            },
+                                        ],
+                                    ],
+                                },
                             ],
                         },
                         {


### PR DESCRIPTION
This PR removes the colon after a system unit if no systemdescription, measure or row is given.

It also renames some css-classes and fixes track-by indices in SourceDescComponent.

It also refactors the display of the EvaluationLabel in the SvgSheetFooter.