### PR TITLE
ci(gh-actions): remove existing files when updating dev (II)

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -153,16 +153,22 @@ jobs:
                   name: dist
                   path: ${{ github.workspace }}/${{ env.DIST_DIR }}
 
-            - name: Copy artifacts to gh-pages
-              run: |
-                  cp -r ${{ env.DIST_DIR }}/awg-app/. ${{ env.DEV_GH_PAGES_DIR }}/dev/
-
             - name: Configure git
               working-directory: ${{ env.DEV_GH_PAGES_DIR }}
               run: |
                   echo "Configuring git"
                   git config user.name "github-actions"
                   git config user.email "github-actions@users.noreply.github.com"
+
+            - name: Remove existing files from dev
+              working-directory: ${{ env.DEV_GH_PAGES_DIR }}
+              run: |
+                  echo "Removing existing files from dev"
+                  git rm -r dev/* || true
+
+            - name: Copy artifacts to gh-pages
+              run: |
+                  cp -r ${{ env.DIST_DIR }}/awg-app/. ${{ env.DEV_GH_PAGES_DIR }}/dev/
 
             - name: Commit files
               working-directory: ${{ env.DEV_GH_PAGES_DIR }}


### PR DESCRIPTION
This PR introduces a step in the dev build process to remove existing files prior to updating the folder. Previously, new files were merely added, resulting in an accumulation of outdated files.

Second try since #1604 went wrong and deleted the complete gh-pages folder.