### PR TITLE
ci(gh-actions): bring back test build on any branch

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -93,18 +93,18 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-            - name: Test build from develop for GH Pages
+            - name: Test build for GH Pages (all but develop)
+              if: github.ref != 'refs/heads/develop'
+              run: |
+                  yarn run build:gh
+
+            - name: Test build for GH Pages (develop)
               if: github.ref == 'refs/heads/develop'
               run: |
                   echo "Updating dev-version"
                   yarn run pre-release --release-as ${{ steps.get-sha.outputs.SHA }} --skip.changelog --skip.commit --skip.tag
                   echo "Building dev-version"
                   yarn run build:dev
-
-            - name: Test build for GH Pages (except develop)
-              if: github.ref != 'refs/heads/develop'
-              run: |
-                  yarn run build:gh
 
             - name: Upload build artifacts (main && develop)
               # upload build artifacts for current node version and main or develop branch only

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -101,13 +101,14 @@ jobs:
                   echo "Building dev-version"
                   yarn run build:dev
 
-            - name: Test build from main for GH Pages
-              if: github.ref == 'refs/heads/main'
+            - name: Test build for GH Pages (except develop)
+              if: github.ref != 'refs/heads/develop'
               run: |
                   yarn run build:gh
 
-            - name: Upload build artifacts
-              if: matrix.node-version == 20.13 # upload build artifacts for current node version only
+            - name: Upload build artifacts (main && develop)
+              # upload build artifacts for current node version and main or develop branch only
+              if: matrix.node-version == 20.13 && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
               uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # ratchet:actions/upload-artifact@v4.3.3
               with:
                   name: dist


### PR DESCRIPTION
This PR brings back the test build on any branch. Recently, the test build was only executed on dev and main.