### PR TITLE
feat(edition): add ScrollToTop button to edition view

### DIFF
--- a/src/app/core/navbar/navbar.component.spec.ts
+++ b/src/app/core/navbar/navbar.component.spec.ts
@@ -3,18 +3,6 @@ import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
 import { Router } from '@angular/router';
 
-import { cleanStylesFromDOM } from '@testing/clean-up-helper';
-import { click, clickAndAwaitChanges } from '@testing/click-helper';
-import {
-    expectSpyCall,
-    expectToBe,
-    expectToContain,
-    expectToEqual,
-    getAndExpectDebugElementByCss,
-    getAndExpectDebugElementByDirective,
-} from '@testing/expect-helper';
-import { RouterLinkStubDirective } from '@testing/router-stubs';
-
 import Spy = jasmine.Spy;
 
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
@@ -27,6 +15,18 @@ import {
     IconDefinition,
 } from '@fortawesome/free-solid-svg-icons';
 import { NgbCollapseModule, NgbConfig, NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
+
+import { cleanStylesFromDOM } from '@testing/clean-up-helper';
+import { click, clickAndAwaitChanges } from '@testing/click-helper';
+import {
+    expectSpyCall,
+    expectToBe,
+    expectToContain,
+    expectToEqual,
+    getAndExpectDebugElementByCss,
+    getAndExpectDebugElementByDirective,
+} from '@testing/expect-helper';
+import { RouterLinkStubDirective } from '@testing/router-stubs';
 
 import { LOGOSDATA } from '@awg-core/core-data';
 import { Logos } from '@awg-core/core-models';

--- a/src/app/shared/scroll-to-top/scroll-to-top.component.html
+++ b/src/app/shared/scroll-to-top/scroll-to-top.component.html
@@ -1,0 +1,5 @@
+@if (isScrolled) {
+    <button class="btn btn-info awg-scroll-to-top" (click)="scrollToTop()">
+        <fa-icon [icon]="faArrowUp"></fa-icon>
+    </button>
+}

--- a/src/app/shared/scroll-to-top/scroll-to-top.component.scss
+++ b/src/app/shared/scroll-to-top/scroll-to-top.component.scss
@@ -1,0 +1,13 @@
+.awg-scroll-to-top {
+    position: fixed;
+    bottom: 30px;
+    right: 30px;
+    text-align: right;
+    color: white;
+    z-index: 1000;
+
+    &:hover {
+        cursor: pointer;
+        color: #f0f0f0;
+    }
+}

--- a/src/app/shared/scroll-to-top/scroll-to-top.component.spec.ts
+++ b/src/app/shared/scroll-to-top/scroll-to-top.component.spec.ts
@@ -1,0 +1,198 @@
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
+
+import Spy = jasmine.Spy;
+
+import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
+import { faArrowUp, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+
+import { cleanStylesFromDOM } from '@testing/clean-up-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
+import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
+import { expectSpyCall, expectToBe, expectToEqual, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+
+import { ScrollToTopComponent } from './scroll-to-top.component';
+
+describe('ScrollToTopComponent (DONE)', () => {
+    let component: ScrollToTopComponent;
+    let fixture: ComponentFixture<ScrollToTopComponent>;
+    let compDe: DebugElement;
+
+    let scrollToTopSpy: Spy;
+
+    let expectedScrollThreshold: number;
+    let expectedArrowIcon: IconDefinition;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [FontAwesomeTestingModule],
+            declarations: [ScrollToTopComponent],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ScrollToTopComponent);
+        component = fixture.componentInstance;
+        compDe = fixture.debugElement;
+
+        // Trigger initial data binding
+        fixture.detectChanges();
+
+        // Test data
+        expectedScrollThreshold = 300;
+        expectedArrowIcon = faArrowUp;
+
+        // Spies on component functions
+        // `.and.callThrough` will track the spy down the nested describes, see
+        // https://jasmine.github.io/2.0/introduction.html#section-Spies:_%3Ccode%3Eand.callThrough%3C/code%3E
+        scrollToTopSpy = spyOn(component, 'scrollToTop').and.callThrough();
+    }));
+
+    afterAll(() => {
+        cleanStylesFromDOM();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('... should have `faArrowUp`', () => {
+        expectToEqual(component.faArrowUp, faArrowUp);
+    });
+
+    it('... should not have `isScrolled`', () => {
+        expect(component.isScrolled).toBeUndefined();
+    });
+
+    describe('#VIEW', () => {
+        describe('... should contain no button.awg-scroll-to-top if', () => {
+            it('... isScrolled is undefined', () => {
+                component.isScrolled = undefined;
+                detectChangesOnPush(fixture);
+
+                getAndExpectDebugElementByCss(compDe, 'button.awg-scroll-to-top', 0, 0);
+            });
+
+            it('... isScrolled is false', () => {
+                component.isScrolled = false;
+                detectChangesOnPush(fixture);
+
+                getAndExpectDebugElementByCss(compDe, 'button.awg-scroll-to-top', 0, 0);
+            });
+        });
+
+        describe('... with isScrolled set to true', () => {
+            beforeEach(() => {
+                component.isScrolled = true;
+                detectChangesOnPush(fixture);
+            });
+
+            it('... should contain one button.awg-scroll-to-top if isScrolled is true', () => {
+                getAndExpectDebugElementByCss(compDe, 'button.awg-scroll-to-top', 1, 1);
+            });
+
+            it('... should display arrow icon in scroll button ', () => {
+                const btnDes = getAndExpectDebugElementByCss(compDe, 'button.awg-scroll-to-top', 1, 1);
+                const faIconDes = getAndExpectDebugElementByCss(btnDes[0], 'fa-icon', 1, 1);
+                const faIconIns = faIconDes[0].componentInstance.icon;
+
+                expectToEqual(faIconIns, expectedArrowIcon);
+            });
+
+            it('... should trigger `scrollToTop` method on button click', fakeAsync(() => {
+                const btnDes = getAndExpectDebugElementByCss(compDe, 'button.awg-scroll-to-top', 1, 1);
+
+                // Trigger click with click helper & wait for changes
+                clickAndAwaitChanges(btnDes[0], fixture);
+
+                expectSpyCall(scrollToTopSpy, 1);
+            }));
+        });
+    });
+
+    describe('#Hostlistener checkScroll()', () => {
+        it('... should have a hostlistener `checkScroll`', () => {
+            expect(component.checkScroll).toBeDefined();
+        });
+
+        it('... should default to 0 if window.scrollY is undefined', () => {
+            const scrollEventBelowThreshold = new Event('scroll') as any;
+            Object.defineProperty(scrollEventBelowThreshold, 'currentTarget', {
+                value: { scrollY: undefined },
+                writable: true,
+            });
+            component.checkScroll(scrollEventBelowThreshold);
+
+            expectToBe(component.isScrolled, false);
+        });
+
+        it('... should set `isScrolled` to true if scrollY is above threshold', () => {
+            const scrollEventAboveThreshold = new Event('scroll') as any;
+            Object.defineProperty(scrollEventAboveThreshold, 'currentTarget', {
+                value: { scrollY: expectedScrollThreshold + 1 },
+                writable: true,
+            });
+            component.checkScroll(scrollEventAboveThreshold);
+
+            expectToBe(component.isScrolled, true);
+        });
+
+        it('... should set `isScrolled` to false if scrollY is below threshold', () => {
+            const scrollEventBelowThreshold = new Event('scroll') as any;
+            Object.defineProperty(scrollEventBelowThreshold, 'currentTarget', {
+                value: { scrollY: expectedScrollThreshold - 1 },
+                writable: true,
+            });
+            component.checkScroll(scrollEventBelowThreshold);
+
+            expectToBe(component.isScrolled, false);
+        });
+
+        it('... should toggle `isScrolled` based on scrollY position of scroll event', () => {
+            const scrollEventBelowThreshold = new Event('scroll') as any;
+            Object.defineProperty(scrollEventBelowThreshold, 'currentTarget', {
+                value: { scrollY: expectedScrollThreshold - 1 },
+                writable: true,
+            });
+            component.checkScroll(scrollEventBelowThreshold);
+
+            expectToBe(component.isScrolled, false);
+
+            const scrollEventAboveThreshold = new Event('scroll');
+            Object.defineProperty(scrollEventAboveThreshold, 'currentTarget', {
+                value: { scrollY: expectedScrollThreshold + 1 },
+                writable: true,
+            });
+            component.checkScroll(scrollEventAboveThreshold);
+
+            expectToBe(component.isScrolled, true);
+        });
+    });
+
+    describe('#scrollToTop()', () => {
+        it('... should have a method `scrollToTop`', () => {
+            expect(component.scrollToTop).toBeDefined();
+        });
+
+        it('... should trigger window:scrollTo with correct parameters', () => {
+            const scrollToSpy = spyOn(window, 'scrollTo');
+
+            component.scrollToTop();
+
+            expectSpyCall(scrollToSpy, 1, { top: 0, behavior: 'smooth' });
+        });
+
+        it('... should scroll to top of page', () => {
+            const scrollEventBelowThreshold = new Event('scroll') as any;
+            Object.defineProperty(scrollEventBelowThreshold, 'currentTarget', {
+                value: { scrollY: expectedScrollThreshold + 1 },
+                writable: true,
+            });
+            component.checkScroll(scrollEventBelowThreshold);
+
+            expectToBe(component.isScrolled, true);
+
+            component.scrollToTop();
+
+            expectToBe(window.scrollY, 0);
+        });
+    });
+});

--- a/src/app/shared/scroll-to-top/scroll-to-top.component.ts
+++ b/src/app/shared/scroll-to-top/scroll-to-top.component.ts
@@ -1,0 +1,56 @@
+import { ChangeDetectionStrategy, Component, HostListener } from '@angular/core';
+
+import { faArrowUp } from '@fortawesome/free-solid-svg-icons';
+
+/**
+ * The ScrollToTop component.
+ *
+ * It contains the scroll-to-top button
+ * that is provided via the {@link SharedModule}.
+ */
+@Component({
+    selector: 'awg-scroll-to-top',
+    templateUrl: './scroll-to-top.component.html',
+    styleUrl: './scroll-to-top.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ScrollToTopComponent {
+    /**
+     * Public variable: faArrowUp.
+     *
+     * It instantiates fontawesome's faArrowUp icon.
+     */
+    faArrowUp = faArrowUp;
+
+    /**
+     * Public variable: isScrolled.
+     *
+     * It keeps track of the visibility of the scroll-to-top button.
+     */
+    isScrolled: boolean;
+
+    /**
+     * HostListener: checkScroll.
+     *
+     * It checks the scroll position on the document and
+     * sets the visibility of the scroll-to-top button.
+     */
+    @HostListener('window:scroll', ['$event']) checkScroll(event: Event) {
+        const window = event.currentTarget as Window;
+        const scrollPosition = window.scrollY || 0;
+        const SCROLL_THRESHOLD = 300;
+
+        this.isScrolled = scrollPosition >= SCROLL_THRESHOLD;
+    }
+
+    /**
+     * Public method: scrollToTop.
+     *
+     * It scrolls to the top of the page.
+     *
+     * @returns {void} Scrolls to the top of the page.
+     */
+    scrollToTop(): void {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -21,6 +21,7 @@ import { LicenseComponent } from './license/license.component';
 import { ModalComponent } from './modal/modal.component';
 import { OpenStreetMapComponent } from './open-street-map/open-street-map.component';
 import { RouterLinkButtonGroupComponent } from './router-link-button-group/router-link-button-group.component';
+import { ScrollToTopComponent } from './scroll-to-top/scroll-to-top.component';
 import { TablePaginationComponent } from './table/table-pagination/table-pagination.component';
 import { TableComponent } from './table/table.component';
 import { ToastComponent } from './toast/toast.component';
@@ -61,6 +62,7 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
         ModalComponent,
         OpenStreetMapComponent,
         RouterLinkButtonGroupComponent,
+        ScrollToTopComponent,
         TableComponent,
         TablePaginationComponent,
         ToastComponent,
@@ -88,6 +90,7 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
         ModalComponent,
         OpenStreetMapComponent,
         RouterLinkButtonGroupComponent,
+        ScrollToTopComponent,
         TableComponent,
         ToastComponent,
         TwelveToneSpinnerComponent,

--- a/src/app/shared/table/table.component.spec.ts
+++ b/src/app/shared/table/table.component.spec.ts
@@ -165,8 +165,8 @@ describe('TableComponent', () => {
         });
 
         it('... should have faSortUp and faSortDown icons', () => {
-            expectToBe(component.faSortUp, faSortUp);
-            expectToBe(component.faSortDown, faSortDown);
+            expectToEqual(component.faSortUp, faSortUp);
+            expectToEqual(component.faSortDown, faSortDown);
         });
 
         it('... should have tableOptions', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-convolute.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-convolute.component.spec.ts
@@ -127,7 +127,7 @@ describe('EditionConvoluteComponent (DONE)', () => {
         });
 
         it('... should have faSquare', () => {
-            expectToBe(component.faSquare, faSquare);
+            expectToEqual(component.faSquare, faSquare);
         });
 
         it('... should have folioLegends', () => {

--- a/src/app/views/edition-view/edition-view.component.html
+++ b/src/app/views/edition-view/edition-view.component.html
@@ -1,6 +1,8 @@
 <!-- content: edition-view -->
 
 <div>
+    <awg-scroll-to-top />
+
     @if (isRowTableView$ | async; as isRowTableView) {
         <div class="awg-edition-row-tables para">
             <h6 class="awg-edition-info-breadcrumb">

--- a/src/app/views/edition-view/edition-view.component.spec.ts
+++ b/src/app/views/edition-view/edition-view.component.spec.ts
@@ -24,7 +24,7 @@ import { EditionService } from '@awg-views/edition-view/services';
 
 import { EditionViewComponent } from './edition-view.component';
 
-// Mock jumbotron component
+// Mock components
 @Component({ selector: 'awg-edition-jumbotron', template: '' })
 class EditionJumbotronStubComponent {
     @Input()
@@ -32,6 +32,9 @@ class EditionJumbotronStubComponent {
     @Input()
     jumbotronTitle: string;
 }
+
+@Component({ selector: 'awg-scroll-to-top', template: '' })
+class ScrollToTopStubComponent {}
 
 describe('EditionViewComponent (DONE)', () => {
     let component: EditionViewComponent;
@@ -88,6 +91,7 @@ describe('EditionViewComponent (DONE)', () => {
                 EditionJumbotronStubComponent,
                 RouterOutletStubComponent,
                 RouterLinkStubDirective,
+                ScrollToTopStubComponent,
             ],
             providers: [
                 { provide: EditionService, useValue: mockEditionService },
@@ -167,6 +171,10 @@ describe('EditionViewComponent (DONE)', () => {
         });
 
         describe('VIEW', () => {
+            it('... should contain one ScrollToTop component (stubbed)', () => {
+                getAndExpectDebugElementByDirective(compDe, ScrollToTopStubComponent, 1, 1);
+            });
+
             it('... should contain one outer div', () => {
                 getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
             });


### PR DESCRIPTION
This PR introduces a button that scrolls to the top of the page. Will be automatically displayed on all edition pages since these are expected to have the most extended content.