### PR TITLE
ci(gh-actions): pin fixed node version temporarily

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -32,7 +32,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                node-version: [18.19, 20.13, 22.x]
+                node-version: [18.19, 20.13, 22.5.1]
 
         outputs:
             sha: ${{ steps.get-sha.outputs.SHA }}


### PR DESCRIPTION
A regression in Node 22.5.0 prevents `yarn install` from running and in turns prevents CI from completing successfully. This regression was fixed in 22.5.1. So this commit ensures that CI is using the correct version by naming it explicitly.