### PR TITLE
feat(edition): add option to place folio items next to systems

### DIFF
--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.spec.ts
@@ -48,6 +48,7 @@ describe('FolioService (DONE)', () => {
     let expectedConvolutes: FolioConvolute[];
     let expectedFolioSettings: FolioSettings;
     let expectedFolioSvgData: FolioSvgData;
+    let expectedDefaultFolio: Folio;
     let expectedReversedFolio: Folio;
 
     let expectedUpperLeftCorner: FolioCalculationPoint;
@@ -81,6 +82,7 @@ describe('FolioService (DONE)', () => {
 
         // Test data
         expectedConvolutes = JSON.parse(JSON.stringify(mockEditionData.mockFolioConvoluteData.convolutes));
+        expectedDefaultFolio = expectedConvolutes[0].folios[0];
         expectedReversedFolio = JSON.parse(JSON.stringify(mockEditionData.mockReversedFolio));
         expectedFolioSettings = {
             factor: 1.5,
@@ -109,11 +111,7 @@ describe('FolioService (DONE)', () => {
         expectedLowerRightCorner = new FolioCalculationPoint(30, 40);
 
         expectedFolioSvgData = new FolioSvgData(
-            new FolioCalculation(
-                expectedFolioSettings,
-                expectedConvolutes[0].folios[0],
-                expectedContentSegmentOffsetCorrection
-            )
+            new FolioCalculation(expectedFolioSettings, expectedDefaultFolio, expectedContentSegmentOffsetCorrection)
         );
 
         // Spies on service functions
@@ -257,7 +255,7 @@ describe('FolioService (DONE)', () => {
         it('... should return an instance of FolioSvgData object', () => {
             // Create mock FolioSettings and Folio objects
             const folioSettings: FolioSettings = expectedFolioSettings;
-            const folio: Folio = expectedConvolutes[0].folios[0];
+            const folio: Folio = expectedDefaultFolio;
 
             // Call the method with the mock objects
             const result = folioService.getFolioSvgData(folioSettings, folio);
@@ -269,8 +267,7 @@ describe('FolioService (DONE)', () => {
         it('... should create a new FolioCalculation object with the correct parameters', () => {
             // Create mock FolioSettings and Folio objects
             const folioSettings: FolioSettings = expectedFolioSettings;
-            const folio: Folio = expectedConvolutes[0].folios[0];
-
+            const folio: Folio = expectedDefaultFolio;
             const result = folioService.getFolioSvgData(folioSettings, folio);
 
             expectToEqual(result, expectedFolioSvgData);
@@ -279,7 +276,7 @@ describe('FolioService (DONE)', () => {
         it('... should create a new FolioCalculation object when contentSegmentOffsetCorrection is undefined', () => {
             // Create mock FolioSettings and Folio objects
             const folioSettings: FolioSettings = expectedFolioSettings;
-            const folio: Folio = expectedConvolutes[0].folios[0];
+            const folio: Folio = expectedDefaultFolio;
 
             const expectedFolioSvgDataWithoutOffset = new FolioSvgData(new FolioCalculation(folioSettings, folio, 0));
 

--- a/src/app/views/edition-view/models/folio-calculation.model.ts
+++ b/src/app/views/edition-view/models/folio-calculation.model.ts
@@ -277,8 +277,20 @@ export class FolioCalculationContentSegmentVertices {
         const systemIndex = isStart ? section.startSystem - 1 : section.endSystem - 1;
         const systemLines = this.systems.SYSTEMS_LINES.SYSTEMS_ARRAYS[systemIndex];
 
+        let offset = 0;
+        switch (section.relativeToSystem) {
+            case 'below':
+                offset = 20;
+                break;
+            case 'above':
+                offset = -20;
+                break;
+            default:
+                offset = 0;
+        }
+
         const yValue = isStart ? systemLines.at(0).START_POINT.y : systemLines.at(-1).END_POINT.y;
-        const correction = this.segmentOffsetCorrection * (isStart ? -1 : 1);
+        const correction = this.segmentOffsetCorrection * (isStart ? -1 : 1) + offset;
 
         return round(yValue + correction, 2);
     }

--- a/src/app/views/edition-view/models/folio.model.ts
+++ b/src/app/views/edition-view/models/folio.model.ts
@@ -165,4 +165,9 @@ export class FolioSection {
      * The folio section's optional position (number).
      */
     position?: number;
+
+    /**
+     * The folio section's optional position relative to the system (string).
+     */
+    relativeToSystem?: string;
 }

--- a/src/testing/mock-data/mockEditionData.ts
+++ b/src/testing/mock-data/mockEditionData.ts
@@ -134,6 +134,36 @@ export const mockEditionData = {
                                     },
                                 ],
                             },
+                            {
+                                complexId: 'op12',
+                                sheetId: 'M_212_Sk3',
+                                sigle: 'M 212 Sk3',
+                                sigleAddendum: 'T. 3',
+                                sectionPartition: 1,
+                                sections: [
+                                    {
+                                        position: 1,
+                                        startSystem: 5,
+                                        endSystem: 7,
+                                        relativeToSystem: 'above',
+                                    },
+                                ],
+                            },
+                            {
+                                complexId: 'op12',
+                                sheetId: 'M_212_Sk2',
+                                sigle: 'M 212 Sk2',
+                                sigleAddendum: 'T. 2',
+                                sectionPartition: 1,
+                                sections: [
+                                    {
+                                        position: 1,
+                                        startSystem: 5,
+                                        endSystem: 7,
+                                        relativeToSystem: 'below',
+                                    },
+                                ],
+                            },
                         ],
                     },
                 ],


### PR DESCRIPTION
This PR adds an option to place folio items next to a system (above or below), to indicate non-system items.