### PR TITLE
fix(edition): remove landscape image from jumbotron

### DIFF
--- a/src/app/views/edition-view/edition-jumbotron/edition-jumbotron.component.html
+++ b/src/app/views/edition-view/edition-jumbotron/edition-jumbotron.component.html
@@ -1,5 +1,3 @@
-<div
-    class="p-5 bg-image text-white text-center awg-jumbotron-image shadow border rounded-3"
-    style="background-image: url('https://mdbcdn.b-cdn.net/img/new/slides/041.webp')">
+<div class="p-3 pt-4 text-center shadow border rounded-3 awg-jumbotron">
     <h1 id="{{ jumbotronId }}" class="mb-4">{{ jumbotronTitle }}</h1>
 </div>

--- a/src/app/views/edition-view/edition-jumbotron/edition-jumbotron.component.spec.ts
+++ b/src/app/views/edition-view/edition-jumbotron/edition-jumbotron.component.spec.ts
@@ -39,8 +39,8 @@ describe('EditionJumbotronComponent', () => {
         });
 
         describe('VIEW', () => {
-            it('... should have one div.awg-jumbotron-image', () => {
-                getAndExpectDebugElementByCss(compDe, 'div.awg-jumbotron-image', 1, 1);
+            it('... should have one div.awg-jumbotron', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.awg-jumbotron', 1, 1);
             });
         });
     });
@@ -65,13 +65,13 @@ describe('EditionJumbotronComponent', () => {
 
         describe('VIEW', () => {
             it('... should have an h1 in jumbotron', () => {
-                const jumbotronDes = getAndExpectDebugElementByCss(compDe, 'div.awg-jumbotron-image', 1, 1);
+                const jumbotronDes = getAndExpectDebugElementByCss(compDe, 'div.awg-jumbotron', 1, 1);
 
                 getAndExpectDebugElementByCss(jumbotronDes[0], 'h1', 1, 1);
             });
 
             it('... should pass down `jumbotronId` and `jumbotronTitle`to jumbotron h1', () => {
-                const headingDes = getAndExpectDebugElementByCss(compDe, 'div.awg-jumbotron-image > h1', 1, 1);
+                const headingDes = getAndExpectDebugElementByCss(compDe, 'div.awg-jumbotron > h1', 1, 1);
                 const headingEl = headingDes[0].nativeElement;
 
                 expectToBe(headingEl.id, expectedId);


### PR DESCRIPTION
This PR removes the off-topic landscape image from the awg jumbotron.