### PR TITLE
ci(gh-actions): switch back to latest node v22

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -32,7 +32,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                node-version: [18.19, 20.13, 22.5.1]
+                node-version: [18.19, 20.13, 22.x]
 
         outputs:
             sha: ${{ steps.get-sha.outputs.SHA }}


### PR DESCRIPTION
This PR switches the node version used in the gh actions back to latest v22. Thus reverts the temporary fix in #1660.