### PR TITLE
fix(edition): improve handling of errors and loading state

### DIFF
--- a/src/app/shared/error-alert/error-alert.component.html
+++ b/src/app/shared/error-alert/error-alert.component.html
@@ -1,0 +1,5 @@
+<div class="awg-error-message">
+    <div class="col-12 text-center">
+        <div class="alert alert-danger">{{ errorObject | json }}</div>
+    </div>
+</div>

--- a/src/app/shared/error-alert/error-alert.component.spec.ts
+++ b/src/app/shared/error-alert/error-alert.component.spec.ts
@@ -1,0 +1,77 @@
+import { JsonPipe } from '@angular/common';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { expectToBe, expectToContain, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+
+import { ErrorAlertComponent } from './error-alert.component';
+
+describe('ErrorAlertComponent', () => {
+    let component: ErrorAlertComponent;
+    let fixture: ComponentFixture<ErrorAlertComponent>;
+    let compDe: DebugElement;
+
+    let expectedErrorObject: any;
+
+    const jsonPipe = new JsonPipe();
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [ErrorAlertComponent],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ErrorAlertComponent);
+        component = fixture.componentInstance;
+        compDe = fixture.debugElement;
+
+        // Test data
+        expectedErrorObject = { status: 404, statusText: 'got Error' };
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    describe('BEFORE initial data binding', () => {
+        it('... should not have `errorObject`', () => {
+            expect(component.errorObject).toBeUndefined();
+        });
+
+        describe('VIEW', () => {
+            it('... should have an outer div.awg-error-message', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.awg-error-message', 1, 1);
+            });
+
+            it('... should have a centered danger alert in div.awg-error-message', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div.awg-error-message ', 1, 1);
+
+                getAndExpectDebugElementByCss(divDes[0], 'div.text-center > div.alert-danger', 1, 1);
+            });
+
+            it('... should not display an error message in div.alert yet', () => {
+                const alertDes = getAndExpectDebugElementByCss(compDe, 'div.alert-danger', 1, 1);
+                const alertEl = alertDes[0].nativeElement;
+
+                expectToBe(alertEl.textContent, '');
+            });
+        });
+    });
+
+    describe('AFTER initial data binding', () => {
+        beforeEach(() => {
+            component.errorObject = expectedErrorObject;
+
+            // Trigger initial data binding
+            fixture.detectChanges();
+        });
+
+        describe('VIEW', () => {
+            it('... should display an error message in div.alert', () => {
+                const alertDes = getAndExpectDebugElementByCss(compDe, 'div.alert-danger', 1, 1);
+                const alertEl = alertDes[0].nativeElement;
+
+                expectToContain(alertEl.textContent, jsonPipe.transform(expectedErrorObject));
+            });
+        });
+    });
+});

--- a/src/app/shared/error-alert/error-alert.component.ts
+++ b/src/app/shared/error-alert/error-alert.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * The ErrorAlertComponent.
+ *
+ * It contains an error alert message that is
+ * provided via the {@link SharedModule}.
+ */
+@Component({
+    selector: 'awg-error-alert',
+    templateUrl: './error-alert.component.html',
+    styleUrl: './error-alert.component.scss',
+})
+export class ErrorAlertComponent {
+    /**
+     * Input variable: errorObject.
+     *
+     * It keeps the error object for the component.
+     */
+    @Input()
+    errorObject: any;
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -15,6 +15,7 @@ import { CompileHtmlModule } from './compile-html';
 //
 // Shared components
 import { AddressComponent } from './address/address.component';
+import { ErrorAlertComponent } from './error-alert/error-alert.component';
 import { HeadingComponent } from './heading/heading.component';
 import { JsonViewerComponent } from './json-viewer/json-viewer.component';
 import { LicenseComponent } from './license/license.component';
@@ -56,6 +57,7 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
     ],
     declarations: [
         AddressComponent,
+        ErrorAlertComponent,
         HeadingComponent,
         JsonViewerComponent,
         LicenseComponent,
@@ -84,6 +86,7 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
         SharedNgbootstrapModule,
 
         AddressComponent,
+        ErrorAlertComponent,
         HeadingComponent,
         JsonViewerComponent,
         LicenseComponent,

--- a/src/app/views/data-view/data-outlets/resource-detail/resource-detail.component.html
+++ b/src/app/views/data-view/data-outlets/resource-detail/resource-detail.component.html
@@ -8,7 +8,7 @@
 } @else {
     <!-- error message -->
     @if (errorMessage) {
-        <div class="errorMessage">
+        <div class="awg-error-message">
             <p>Die Anfrage "{{ errorMessage?.route }}" ist fehlgeschlagen.</p>
             <p>Fehlermeldung: "{{ errorMessage?.statusText || errorMessage }}".</p>
             <p>Möglicherweise gab es ein Problem mit der Internetverbindung oder dem verwendeten Suchbegriff.</p>

--- a/src/app/views/data-view/data-outlets/search-panel/search-panel.component.html
+++ b/src/app/views/data-view/data-outlets/search-panel/search-panel.component.html
@@ -34,7 +34,7 @@
     </div>
 } @else {
     @if (errorMessage) {
-        <div class="errorMessage">
+        <div class="awg-error-message">
             <p>Die Anfrage "{{ errorMessage?.route }}" ist fehlgeschlagen.</p>
             <p>Fehlermeldung: "{{ errorMessage?.statusText || errorMessage }}".</p>
             <p>Möglicherweise gab es ein Problem mit der Internetverbindung oder der Suchanfrage.</p>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.html
@@ -99,11 +99,7 @@
     } @else {
         <!-- error message -->
         @if (errorObject) {
-            <div class="errorMessage">
-                <div class="col-12 text-center">
-                    <div class="alert alert-danger">{{ errorObject | json }}</div>
-                </div>
-            </div>
+            <awg-error-alert [errorObject]="errorObject"></awg-error-alert>
         } @else {
             <!-- loading spinner -->
             <awg-twelve-tone-spinner></awg-twelve-tone-spinner>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.html
@@ -97,23 +97,16 @@
             }
         </div>
     } @else {
+        <!-- error message -->
         @if (errorObject) {
             <div class="errorMessage">
                 <div class="col-12 text-center">
                     <div class="alert alert-danger">{{ errorObject | json }}</div>
                 </div>
             </div>
+        } @else {
+            <!-- loading spinner -->
+            <awg-twelve-tone-spinner></awg-twelve-tone-spinner>
         }
     }
-
-    <!-- error message -->
-    <ng-template #error>
-        @if (errorObject) {
-            <div class="errorMessage">
-                <div class="col-12 text-center">
-                    <div class="alert alert-danger">{{ errorObject | json }}</div>
-                </div>
-            </div>
-        }
-    </ng-template>
 </div>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
@@ -36,6 +36,12 @@ import { EditionComplexesService, EditionDataService, EditionService } from '@aw
 import { EditionGraphComponent } from './edition-graph.component';
 
 // Mock components
+@Component({ selector: 'awg-error-alert', template: '' })
+class ErrorAlertStubComponent {
+    @Input()
+    errorObject: any;
+}
+
 @Component({ selector: 'awg-graph-visualizer', template: '' })
 class GraphVisualizerStubComponent {
     @Input()
@@ -101,6 +107,7 @@ describe('EditionGraphComponent (DONE)', () => {
             imports: [FontAwesomeTestingModule],
             declarations: [
                 EditionGraphComponent,
+                ErrorAlertStubComponent,
                 GraphVisualizerStubComponent,
                 ModalStubComponent,
                 CompileHtmlComponent,
@@ -210,7 +217,7 @@ describe('EditionGraphComponent (DONE)', () => {
         });
 
         describe('VIEW', () => {
-            it('... should have a `div`', () => {
+            it('... should contain a `div`', () => {
                 getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
             });
 
@@ -220,12 +227,20 @@ describe('EditionGraphComponent (DONE)', () => {
                 getAndExpectDebugElementByDirective(divDes[0], ModalStubComponent, 1, 1);
             });
 
-            it('... should not have a nested div.awg-graph-view', () => {
+            it('... should contain no div.awg-graph-view yet', () => {
                 getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view', 0, 0);
             });
 
-            it('... should not have a nested div.errorMessage', () => {
-                getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+            it('... should not contain an error alert component (stubbed)', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+
+                getAndExpectDebugElementByDirective(divDes[0], ErrorAlertStubComponent, 0, 0);
+            });
+
+            it('... should not contain a loading spinner component (stubbed)', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+
+                getAndExpectDebugElementByDirective(divDes[0], TwelveToneSpinnerStubComponent, 0, 0);
             });
         });
     });
@@ -245,7 +260,7 @@ describe('EditionGraphComponent (DONE)', () => {
         });
 
         describe('VIEW', () => {
-            it('... should have one div.awg-graph-view', () => {
+            it('... should contain one div.awg-graph-view', () => {
                 getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view', 1, 1);
             });
 
@@ -570,18 +585,20 @@ describe('EditionGraphComponent (DONE)', () => {
                     detectChangesOnPush(fixture);
                 }));
 
-                it('... should not have graph view, but one div.errorMessage with centered danger alert', waitForAsync(() => {
+                it('... should not contain graph view, but one ErrorAlertComponent (stubbed)', waitForAsync(() => {
                     getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view', 0, 0);
-                    const errorDes = getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 1, 1);
 
-                    getAndExpectDebugElementByCss(errorDes[0], 'div.text-center > div.alert-danger', 1, 1);
+                    const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+                    getAndExpectDebugElementByDirective(divDes[0], ErrorAlertStubComponent, 1, 1);
                 }));
 
-                it('... should display errorMessage', waitForAsync(() => {
-                    const alertDes = getAndExpectDebugElementByCss(compDe, 'div.alert-danger', 1, 1);
-                    const alertEl = alertDes[0].nativeElement;
+                it('... should pass down error object to ErrorAlertComponent', waitForAsync(() => {
+                    const errorAlertDes = getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 1, 1);
+                    const errorAlertCmp = errorAlertDes[0].injector.get(
+                        ErrorAlertStubComponent
+                    ) as ErrorAlertStubComponent;
 
-                    expectToContain(alertEl.textContent, jsonPipe.transform(expectedError));
+                    expectToEqual(errorAlertCmp.errorObject, expectedError);
                 }));
             });
 
@@ -593,7 +610,7 @@ describe('EditionGraphComponent (DONE)', () => {
                         detectChangesOnPush(fixture);
 
                         getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view', 0, 0);
-                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 0, 0);
                         getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
                     });
 
@@ -603,7 +620,7 @@ describe('EditionGraphComponent (DONE)', () => {
                         detectChangesOnPush(fixture);
 
                         getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view', 0, 0);
-                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 0, 0);
                         getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
                     });
 
@@ -613,7 +630,7 @@ describe('EditionGraphComponent (DONE)', () => {
                         detectChangesOnPush(fixture);
 
                         getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view', 0, 0);
-                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 0, 0);
                         getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
                     });
                 });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
@@ -2,7 +2,14 @@ import { DOCUMENT, JsonPipe } from '@angular/common';
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { EmptyError, lastValueFrom, Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
+import {
+    EMPTY,
+    EmptyError,
+    lastValueFrom,
+    Observable,
+    of as observableOf,
+    throwError as observableThrowError,
+} from 'rxjs';
 import Spy = jasmine.Spy;
 
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
@@ -46,6 +53,9 @@ class ModalStubComponent {
     }
 }
 
+@Component({ selector: 'awg-twelve-tone-spinner', template: '' })
+class TwelveToneSpinnerStubComponent {}
+
 describe('EditionGraphComponent (DONE)', () => {
     let component: EditionGraphComponent;
     let fixture: ComponentFixture<EditionGraphComponent>;
@@ -63,14 +73,18 @@ describe('EditionGraphComponent (DONE)', () => {
     let editionDataServiceGetEditionGraphDataSpy: Spy;
     let editionServiceGetSelectedEditionComplexSpy: Spy;
 
-    const jsonPipe = new JsonPipe();
-
     let expectedEditionComplex: EditionComplex;
     let expectedEditionGraphDataEmpty: GraphList;
     let expectedEditionGraphDataOp25: GraphList;
     const expectedEditionRouteConstants: typeof EDITION_ROUTE_CONSTANTS = EDITION_ROUTE_CONSTANTS;
 
     let expectedIsFullscreen: boolean;
+
+    const jsonPipe = new JsonPipe();
+
+    beforeAll(() => {
+        EditionComplexesService.initializeEditionComplexesList();
+    });
 
     beforeEach(waitForAsync(() => {
         // Mocked editionDataService
@@ -90,6 +104,7 @@ describe('EditionGraphComponent (DONE)', () => {
                 GraphVisualizerStubComponent,
                 ModalStubComponent,
                 CompileHtmlComponent,
+                TwelveToneSpinnerStubComponent,
             ],
             providers: [
                 { provide: EditionDataService, useValue: mockEditionDataService },
@@ -234,7 +249,7 @@ describe('EditionGraphComponent (DONE)', () => {
                 getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view', 1, 1);
             });
 
-            it('... should not contain a div.awg-graph-view if graph data is not provided', waitForAsync(() => {
+            it('... should not contain a div in div.awg-graph-view if graph data is not provided', waitForAsync(() => {
                 const noGraphData = new GraphList();
                 noGraphData.graph = undefined;
 
@@ -246,7 +261,7 @@ describe('EditionGraphComponent (DONE)', () => {
                 getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view > div', 0, 0);
             }));
 
-            it('... should contain a div.awg-graph-view if graph data is provided', () => {
+            it('... should contain a div in div.awg-graph-view if graph data is provided', () => {
                 getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view > div', 1, 1);
             });
 
@@ -568,6 +583,40 @@ describe('EditionGraphComponent (DONE)', () => {
 
                     expectToContain(alertEl.textContent, jsonPipe.transform(expectedError));
                 }));
+            });
+
+            describe('on loading', () => {
+                describe('... should contain only TwelveToneSpinnerComponent (stubbed) if ... ', () => {
+                    it('... editionGraphData$ is EMPTY', () => {
+                        // Mock empty observable
+                        component.editionGraphData$ = EMPTY;
+                        detectChangesOnPush(fixture);
+
+                        getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view', 0, 0);
+                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
+                    });
+
+                    it('... editionGraphData$ is undefined', () => {
+                        // Mock undefined response
+                        component.editionGraphData$ = observableOf(undefined);
+                        detectChangesOnPush(fixture);
+
+                        getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view', 0, 0);
+                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
+                    });
+
+                    it('... editionGraphData$ is null', () => {
+                        // Mock null response
+                        component.editionGraphData$ = observableOf(null);
+                        detectChangesOnPush(fixture);
+
+                        getAndExpectDebugElementByCss(compDe, 'div.awg-graph-view', 0, 0);
+                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
+                    });
+                });
             });
         });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.html
@@ -37,11 +37,12 @@
         @if (errorObject) {
             <div class="errorMessage">
                 <div class="col-12 text-center">
-                    <div class="alert alert-danger">
-                        {{ errorObject }}
-                    </div>
+                    <div class="alert alert-danger">{{ errorObject | json }}</div>
                 </div>
             </div>
+        } @else {
+            <!-- loading spinner -->
+            <awg-twelve-tone-spinner></awg-twelve-tone-spinner>
         }
     }
 </div>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.html
@@ -35,11 +35,7 @@
     } @else {
         <!-- error message -->
         @if (errorObject) {
-            <div class="errorMessage">
-                <div class="col-12 text-center">
-                    <div class="alert alert-danger">{{ errorObject | json }}</div>
-                </div>
-            </div>
+            <awg-error-alert [errorObject]="errorObject"></awg-error-alert>
         } @else {
             <!-- loading spinner -->
             <awg-twelve-tone-spinner></awg-twelve-tone-spinner>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { DOCUMENT, JsonPipe } from '@angular/common';
-import { Component, DebugElement } from '@angular/core';
+import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
 import { Router, RouterModule } from '@angular/router';
 
@@ -22,7 +22,6 @@ import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
     expectToBe,
-    expectToContain,
     expectToEqual,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
@@ -38,6 +37,12 @@ import { EditionComplexesService, EditionDataService, EditionService } from '@aw
 import { EditionIntroComponent } from './edition-intro.component';
 
 // Mock components
+@Component({ selector: 'awg-error-alert', template: '' })
+class ErrorAlertStubComponent {
+    @Input()
+    errorObject: any;
+}
+
 @Component({ selector: 'awg-modal', template: '' })
 class ModalStubComponent {
     open(modalContentSnippetKey: string): void {}
@@ -107,6 +112,7 @@ describe('IntroComponent (DONE)', () => {
             declarations: [
                 CompileHtmlComponent,
                 EditionIntroComponent,
+                ErrorAlertStubComponent,
                 ModalStubComponent,
                 RouterLinkStubDirective,
                 TwelveToneSpinnerStubComponent,
@@ -182,18 +188,28 @@ describe('IntroComponent (DONE)', () => {
         });
 
         describe('VIEW', () => {
+            it('... should contain a `div`', () => {
+                getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+            });
+
             it('... should contain one modal component (stubbed)', () => {
                 getAndExpectDebugElementByDirective(compDe, ModalStubComponent, 1, 1);
             });
 
             it('... should contain no div.awg-intro-view yet', () => {
-                // Div debug element
                 getAndExpectDebugElementByCss(compDe, 'div.awg-intro-view', 0, 0);
             });
 
-            it('... should contain no div.errorMessage yet', () => {
-                // Div debug element
-                getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+            it('... should not contain an error alert component (stubbed)', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+
+                getAndExpectDebugElementByDirective(divDes[0], ErrorAlertStubComponent, 0, 0);
+            });
+
+            it('... should not contain a loading spinner component (stubbed)', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+
+                getAndExpectDebugElementByDirective(divDes[0], TwelveToneSpinnerStubComponent, 0, 0);
             });
         });
     });
@@ -353,18 +369,20 @@ describe('IntroComponent (DONE)', () => {
                     detectChangesOnPush(fixture);
                 }));
 
-                it('... should not have intro view, but one div.errorMessage with centered danger alert', waitForAsync(() => {
+                it('... should not contain intro view, but one ErrorAlertComponent (stubbed)', waitForAsync(() => {
                     getAndExpectDebugElementByCss(compDe, 'div.awg-intro-view', 0, 0);
-                    const errorDes = getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 1, 1);
 
-                    getAndExpectDebugElementByCss(errorDes[0], 'div.text-center > div.alert-danger', 1, 1);
+                    const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+                    getAndExpectDebugElementByDirective(divDes[0], ErrorAlertStubComponent, 1, 1);
                 }));
 
-                it('... should display errorMessage', waitForAsync(() => {
-                    const alertDes = getAndExpectDebugElementByCss(compDe, 'div.alert-danger', 1, 1);
-                    const alertEl = alertDes[0].nativeElement;
+                it('... should pass down error object to ErrorAlertComponent', waitForAsync(() => {
+                    const errorAlertDes = getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 1, 1);
+                    const errorAlertCmp = errorAlertDes[0].injector.get(
+                        ErrorAlertStubComponent
+                    ) as ErrorAlertStubComponent;
 
-                    expectToContain(alertEl.textContent, jsonPipe.transform(expectedError));
+                    expectToEqual(errorAlertCmp.errorObject, expectedError);
                 }));
             });
 
@@ -376,7 +394,7 @@ describe('IntroComponent (DONE)', () => {
                         detectChangesOnPush(fixture);
 
                         getAndExpectDebugElementByCss(compDe, 'div.awg-intro-view', 0, 0);
-                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 0, 0);
                         getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
                     });
 
@@ -386,7 +404,7 @@ describe('IntroComponent (DONE)', () => {
                         detectChangesOnPush(fixture);
 
                         getAndExpectDebugElementByCss(compDe, 'div.awg-intro-view', 0, 0);
-                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 0, 0);
                         getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
                     });
 
@@ -396,7 +414,7 @@ describe('IntroComponent (DONE)', () => {
                         detectChangesOnPush(fixture);
 
                         getAndExpectDebugElementByCss(compDe, 'div.awg-intro-view', 0, 0);
-                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 0, 0);
                         getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
                     });
                 });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/edition-report.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/edition-report.component.html
@@ -90,11 +90,7 @@
     } @else {
         <!-- error message -->
         @if (errorObject) {
-            <div class="errorMessage">
-                <div class="col-12 text-center">
-                    <div class="alert alert-danger">{{ errorObject | json }}</div>
-                </div>
-            </div>
+            <awg-error-alert [errorObject]="errorObject"></awg-error-alert>
         } @else {
             <!-- loading spinner -->
             <awg-twelve-tone-spinner></awg-twelve-tone-spinner>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/edition-report.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/edition-report.component.html
@@ -3,6 +3,7 @@
     <!-- modal -->
     <awg-modal #modal></awg-modal>
 
+    <!-- report -->
     @if (editionReportData$ | async; as editionReportData) {
         <div ngbAccordion>
             <!-- source list -->
@@ -86,5 +87,17 @@
                 </div>
             </div>
         </div>
+    } @else {
+        <!-- error message -->
+        @if (errorObject) {
+            <div class="errorMessage">
+                <div class="col-12 text-center">
+                    <div class="alert alert-danger">{{ errorObject | json }}</div>
+                </div>
+            </div>
+        } @else {
+            <!-- loading spinner -->
+            <awg-twelve-tone-spinner></awg-twelve-tone-spinner>
+        }
     }
 </div>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/edition-report.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/edition-report.component.spec.ts
@@ -21,7 +21,6 @@ import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
     expectToBe,
-    expectToContain,
     expectToEqual,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
@@ -44,6 +43,12 @@ import { EditionComplexesService, EditionDataService, EditionService } from '@aw
 import { EditionReportComponent } from './edition-report.component';
 
 // Mock components
+@Component({ selector: 'awg-error-alert', template: '' })
+class ErrorAlertStubComponent {
+    @Input()
+    errorObject: any;
+}
+
 @Component({ selector: 'awg-modal', template: '' })
 class ModalStubComponent {
     open(_modalContentSnippetKey: string): void {}
@@ -171,6 +176,7 @@ describe('EditionReportComponent', () => {
             declarations: [
                 CompileHtmlComponent,
                 EditionReportComponent,
+                ErrorAlertStubComponent,
                 ModalStubComponent,
                 SourceListStubComponent,
                 SourceDescriptionStubComponent,
@@ -257,6 +263,16 @@ describe('EditionReportComponent', () => {
         });
 
         describe('VIEW', () => {
+            it('... should contain a `div`', () => {
+                getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+            });
+
+            it('... should contain one modal component (stubbed)', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+
+                getAndExpectDebugElementByDirective(divDes[0], ModalStubComponent, 1, 1);
+            });
+
             it('... should contain no div.accordion yet', () => {
                 // Div.accordion debug element
                 getAndExpectDebugElementByCss(compDe, 'div.accordion', 0, 0);
@@ -276,6 +292,18 @@ describe('EditionReportComponent', () => {
 
             it('... should not contain textcritics list component (stubbed) yet', () => {
                 getAndExpectDebugElementByDirective(compDe, TextcriticsListStubComponent, 0, 0);
+            });
+
+            it('... should not contain an error alert component (stubbed)', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+
+                getAndExpectDebugElementByDirective(divDes[0], ErrorAlertStubComponent, 0, 0);
+            });
+
+            it('... should not contain a loading spinner component (stubbed)', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+
+                getAndExpectDebugElementByDirective(divDes[0], TwelveToneSpinnerStubComponent, 0, 0);
             });
         });
     });
@@ -309,7 +337,6 @@ describe('EditionReportComponent', () => {
 
         describe('VIEW', () => {
             it('... should contain one div.accordion', () => {
-                // NgbAccordion debug element
                 getAndExpectDebugElementByCss(compDe, 'div.accordion', 1, 1);
             });
 
@@ -381,18 +408,20 @@ describe('EditionReportComponent', () => {
                     detectChangesOnPush(fixture);
                 }));
 
-                it('... should not have report view, but one div.errorMessage with centered danger alert', waitForAsync(() => {
-                    getAndExpectDebugElementByCss(compDe, 'div.awg-report-view', 0, 0);
-                    const errorDes = getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 1, 1);
+                it('... should not contain report view, but one ErrorAlertComponent (stubbed)', waitForAsync(() => {
+                    getAndExpectDebugElementByCss(compDe, 'div.accordion', 0, 0);
 
-                    getAndExpectDebugElementByCss(errorDes[0], 'div.text-center > div.alert-danger', 1, 1);
+                    const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+                    getAndExpectDebugElementByDirective(divDes[0], ErrorAlertStubComponent, 1, 1);
                 }));
 
-                it('... should display errorMessage', waitForAsync(() => {
-                    const alertDes = getAndExpectDebugElementByCss(compDe, 'div.alert-danger', 1, 1);
-                    const alertEl = alertDes[0].nativeElement;
+                it('... should pass down error object to ErrorAlertComponent', waitForAsync(() => {
+                    const errorAlertDes = getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 1, 1);
+                    const errorAlertCmp = errorAlertDes[0].injector.get(
+                        ErrorAlertStubComponent
+                    ) as ErrorAlertStubComponent;
 
-                    expectToContain(alertEl.textContent, jsonPipe.transform(expectedError));
+                    expectToEqual(errorAlertCmp.errorObject, expectedError);
                 }));
             });
 
@@ -404,7 +433,7 @@ describe('EditionReportComponent', () => {
                         detectChangesOnPush(fixture);
 
                         getAndExpectDebugElementByCss(compDe, 'div.awg-report-view', 0, 0);
-                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 0, 0);
                         getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
                     });
 
@@ -414,7 +443,7 @@ describe('EditionReportComponent', () => {
                         detectChangesOnPush(fixture);
 
                         getAndExpectDebugElementByCss(compDe, 'div.awg-report-view', 0, 0);
-                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 0, 0);
                         getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
                     });
 
@@ -424,7 +453,7 @@ describe('EditionReportComponent', () => {
                         detectChangesOnPush(fixture);
 
                         getAndExpectDebugElementByCss(compDe, 'div.awg-report-view', 0, 0);
-                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 0, 0);
                         getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
                     });
                 });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.html
@@ -9,11 +9,7 @@
     } @else {
         <!-- error message -->
         @if (errorObject) {
-            <div class="errorMessage">
-                <div class="col-12 text-center">
-                    <div class="alert alert-danger">{{ errorObject | json }}</div>
-                </div>
-            </div>
+            <awg-error-alert [errorObject]="errorObject"></awg-error-alert>
         } @else {
             <div class="awg-sheets-view">
                 <!-- accolade view -->

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.html
@@ -3,30 +3,44 @@
     <!-- modal -->
     <awg-modal #modal></awg-modal>
 
-    <!-- body with embedded svg's -->
-    <!-- accolade view -->
+    <!-- loading spinner -->
+    @if (isLoading) {
+        <awg-twelve-tone-spinner></awg-twelve-tone-spinner>
+    } @else {
+        <!-- error message -->
+        @if (errorObject) {
+            <div class="errorMessage">
+                <div class="col-12 text-center">
+                    <div class="alert alert-danger">{{ errorObject | json }}</div>
+                </div>
+            </div>
+        } @else {
+            <div class="awg-sheets-view">
+                <!-- accolade view -->
+                <awg-edition-accolade
+                    [svgSheetsData]="svgSheetsData"
+                    [selectedSvgSheet]="selectedSvgSheet"
+                    [selectedTextcritics]="selectedTextcritics"
+                    [selectedTextcriticalCommentBlocks]="selectedTextcriticalCommentBlocks"
+                    [showTkA]="showTkA"
+                    (browseSvgSheetRequest)="onBrowseSvgSheet($event)"
+                    (navigateToReportFragmentRequest)="onReportFragmentNavigate($event)"
+                    (openModalRequest)="modal.open($event)"
+                    (selectLinkBoxRequest)="onLinkBoxSelect($event)"
+                    (selectOverlaysRequest)="onOverlaySelect($event)"
+                    (selectSvgSheetRequest)="onSvgSheetSelect($event)">
+                </awg-edition-accolade>
 
-    <awg-edition-accolade
-        [svgSheetsData]="svgSheetsData"
-        [selectedSvgSheet]="selectedSvgSheet"
-        [selectedTextcritics]="selectedTextcritics"
-        [selectedTextcriticalCommentBlocks]="selectedTextcriticalCommentBlocks"
-        [showTkA]="showTkA"
-        (browseSvgSheetRequest)="onBrowseSvgSheet($event)"
-        (navigateToReportFragmentRequest)="onReportFragmentNavigate($event)"
-        (openModalRequest)="modal.open($event)"
-        (selectLinkBoxRequest)="onLinkBoxSelect($event)"
-        (selectOverlaysRequest)="onOverlaySelect($event)"
-        (selectSvgSheetRequest)="onSvgSheetSelect($event)">
-    </awg-edition-accolade>
-
-    <!-- convolute view -->
-    @if (selectedConvolute && selectedSvgSheet) {
-        <awg-edition-convolute
-            [selectedConvolute]="selectedConvolute"
-            [selectedSvgSheet]="selectedSvgSheet"
-            (openModalRequest)="modal.open($event)"
-            (selectSvgSheetRequest)="onSvgSheetSelect($event)">
-        </awg-edition-convolute>
+                <!-- convolute view -->
+                @if (selectedConvolute && selectedSvgSheet) {
+                    <awg-edition-convolute
+                        [selectedConvolute]="selectedConvolute"
+                        [selectedSvgSheet]="selectedSvgSheet"
+                        (openModalRequest)="modal.open($event)"
+                        (selectSvgSheetRequest)="onSvgSheetSelect($event)">
+                    </awg-edition-convolute>
+                }
+            </div>
+        }
     }
 </div>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.spec.ts
@@ -10,7 +10,6 @@ import Spy = jasmine.Spy;
 import {
     expectSpyCall,
     expectToBe,
-    expectToContain,
     expectToEqual,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
@@ -77,6 +76,12 @@ class EditionConvoluteStubComponent {
     openModalRequest: EventEmitter<string> = new EventEmitter();
     @Output()
     selectSvgSheetRequest: EventEmitter<{ complexId: string; sheetId: string }> = new EventEmitter();
+}
+
+@Component({ selector: 'awg-error-alert', template: '' })
+class ErrorAlertStubComponent {
+    @Input()
+    errorObject: any;
 }
 
 @Component({ selector: 'awg-modal', template: '' })
@@ -175,6 +180,7 @@ describe('EditionSheetsComponent', () => {
                 EditionSheetsComponent,
                 EditionConvoluteStubComponent,
                 EditionAccoladeStubComponent,
+                ErrorAlertStubComponent,
                 ModalStubComponent,
                 TwelveToneSpinnerStubComponent,
             ],
@@ -298,7 +304,7 @@ describe('EditionSheetsComponent', () => {
         });
 
         describe('VIEW', () => {
-            it('... should have a `div`', () => {
+            it('... should contain a `div`', () => {
                 getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
             });
 
@@ -308,21 +314,23 @@ describe('EditionSheetsComponent', () => {
                 getAndExpectDebugElementByDirective(divDes[0], ModalStubComponent, 1, 1);
             });
 
-            it('... should not have a nested div.errorMessage', () => {
-                getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+            it('... should not contain an error alert component (stubbed)', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+
+                getAndExpectDebugElementByDirective(divDes[0], ErrorAlertStubComponent, 0, 0);
             });
 
-            it('... should not have a loading spinner (stubbed)', () => {
+            it('... should not contain a loading spinner component (stubbed)', () => {
                 const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
 
                 getAndExpectDebugElementByDirective(divDes[0], TwelveToneSpinnerStubComponent, 0, 0);
             });
 
-            it('... should not have an AccoladeComponent (stubbed)', () => {
+            it('... should not contain an AccoladeComponent (stubbed)', () => {
                 getAndExpectDebugElementByDirective(compDe, EditionAccoladeStubComponent, 0, 0);
             });
 
-            it('... should not have a ConvoluteComponent (stubbed)', () => {
+            it('... should not contain a ConvoluteComponent (stubbed)', () => {
                 getAndExpectDebugElementByDirective(compDe, EditionConvoluteStubComponent, 0, 0);
             });
         });
@@ -351,7 +359,7 @@ describe('EditionSheetsComponent', () => {
         });
 
         describe('VIEW', () => {
-            it('... should have one div.awg-sheets-view', () => {
+            it('... should contain one div.awg-sheets-view', () => {
                 getAndExpectDebugElementByCss(compDe, 'div.awg-sheets-view', 1, 1);
             });
 
@@ -376,18 +384,20 @@ describe('EditionSheetsComponent', () => {
                     detectChangesOnPush(fixture);
                 }));
 
-                it('... should not have sheets view, but one div.errorMessage with centered danger alert', waitForAsync(() => {
+                it('... should not contain sheets view, but one ErrorAlertComponent (stubbed)', waitForAsync(() => {
                     getAndExpectDebugElementByCss(compDe, 'div.awg-sheets-view', 0, 0);
-                    const errorDes = getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 1, 1);
 
-                    getAndExpectDebugElementByCss(errorDes[0], 'div.text-center > div.alert-danger', 1, 1);
+                    const divDes = getAndExpectDebugElementByCss(compDe, 'div', 1, 1);
+                    getAndExpectDebugElementByDirective(divDes[0], ErrorAlertStubComponent, 1, 1);
                 }));
 
-                it('... should display errorMessage', waitForAsync(() => {
-                    const alertDes = getAndExpectDebugElementByCss(compDe, 'div.alert-danger', 1, 1);
-                    const alertEl = alertDes[0].nativeElement;
+                it('... should pass down error object to ErrorAlertComponent', waitForAsync(() => {
+                    const errorAlertDes = getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 1, 1);
+                    const errorAlertCmp = errorAlertDes[0].injector.get(
+                        ErrorAlertStubComponent
+                    ) as ErrorAlertStubComponent;
 
-                    expectToContain(alertEl.textContent, jsonPipe.transform(expectedError));
+                    expectToEqual(errorAlertCmp.errorObject, expectedError);
                 }));
             });
 
@@ -398,7 +408,8 @@ describe('EditionSheetsComponent', () => {
                         detectChangesOnPush(fixture);
 
                         getAndExpectDebugElementByCss(compDe, 'div.awg-sheets-view', 0, 0);
-                        getAndExpectDebugElementByCss(compDe, 'div.errorMessage', 0, 0);
+                        getAndExpectDebugElementByDirective(compDe, ErrorAlertStubComponent, 0, 0);
+
                         getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
                     });
                 });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.ts
@@ -408,11 +408,8 @@ export class EditionSheetsComponent implements OnInit, OnDestroy {
 
             // Reset selectedSvgSheet if no sheetId is provided
             if (sheetIdFromQueryParams === '') {
-                this.selectedSvgSheet = null;
+                this.selectedSvgSheet = undefined;
             }
-
-            // Stop loading spinner
-            this.isLoading = false;
 
             // Navigate once more to the selected sheet
             this.onSvgSheetSelect({


### PR DESCRIPTION
This PR adds a loading spinner to all parts of the edition views and introduces a shared ErrorAlertComponent to handle errors.