### PR TITLE
fix(assets): fix files for m38

### DIFF
--- a/src/assets/data/edition/series/2/section/2a/m38/textcritics.json
+++ b/src/assets/data/edition/series/2/section/2a/m38/textcritics.json
@@ -238,7 +238,7 @@
                         },
                         {
                             "svgGroupId": "g1426",
-                            "measure": "{11A} bis<br />{12A}",
+                            "measure": "{11A}<br />bis {12A}",
                             "system": "1–2",
                             "position": "1/8<br/>2/8",
                             "comment": "Noten gestrichen."

--- a/src/assets/img/edition/series/2/section/2a/m38/M38_Sk2-1von1-final.svg
+++ b/src/assets/img/edition/series/2/section/2a/m38/M38_Sk2-1von1-final.svg
@@ -1,571 +1,226 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xml:space="preserve"
-   id="svg44789"
-   width="1135.802"
-   height="370.335"
-   x="0"
-   y="0"
-   version="1.1"
-   viewBox="0 0 1135.802 370.335"
-   sodipodi:docname="M38_Sk2-1von1-final.svg"
-   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
-   id="namedview1"
-   pagecolor="#ffffff"
-   bordercolor="#000000"
-   borderopacity="0.25"
-   inkscape:showpageshadow="2"
-   inkscape:pageopacity="0.0"
-   inkscape:pagecheckerboard="0"
-   inkscape:deskcolor="#d1d1d1"
-   inkscape:zoom="2.8526099"
-   inkscape:cx="623.98999"
-   inkscape:cy="221.5515"
-   inkscape:window-width="1920"
-   inkscape:window-height="992"
-   inkscape:window-x="-8"
-   inkscape:window-y="-8"
-   inkscape:window-maximized="1"
-   inkscape:current-layer="svg44789" />&#10;  <defs
-   id="defs44793">&#10;    <path
-   id="rect45099"
-   d="M693.814 141.868h20.469v59.994h-20.469z" />&#10;  &#10;    &#10;    &#10;  &#10;      &#10;      &#10;      &#10;      &#10;      &#10;      &#10;    &#10;    &#10;    &#10;  &#10;      &#10;      &#10;      &#10;      &#10;      &#10;      &#10;    </defs>&#10;  <font
-   id="font44536"
-   horiz-adv-x="1000"
-   horiz-origin-x="0"
-   horiz-origin-y="0"
-   vert-adv-y="1024"
-   vert-origin-x="512"
-   vert-origin-y="768">&#10;    <font-face
-   id="font-face44522"
-   font-family="'Maestro'"
-   underline-position="-78"
-   underline-thickness="9"
-   units-per-em="1000">&#10;      <font-face-src>&#10;        <font-face-name
-   name="Maestro" />&#10;      </font-face-src>&#10;    </font-face>&#10;    <glyph
-   id="glyph44526"
-   d="M466-252c-19-3-38-5-59-6s-42 0-62 2c-20 1-38 4-55 7q-25.5 4.5-42 12c-51 25-93 51-124 79-32 27-57 56-74 86Q24.5-27 14 21C7 52 2 84 0 116c-3 35 1 69 10 104s21 68 37 100q22.5 46.5 54 87c20 27 40 50 61 70 24 23 49 45 76 68 26 22 55 45 86 68-1 9-1 16-2 23s-3 14-4 21-3 14-4 23c-2 9-3 19-4 32 0 5-1 15-2 30-1 14-2 31-2 52-1 20 0 43 1 69s5 53 10 81c3 17 11 38 22 64 11 25 24 50 39 74s30 45 47 62 32 26 47 26c7 0 15-4 24-13s17-21 26-36q12-22.5 24-51c8-19 15-39 21-59s11-40 15-59q4.5-28.5 6-51c1-35-1-65-4-91-3-27-8-50-15-71s-14-41-23-58c-9-18-19-36-29-54-11-18-21-34-32-47-11-14-23-28-34-42-12-15-24-27-37-36-13-10-26-21-39-32 6-34 11-65 16-92 2-12 4-24 6-35s4-22 5-31c1-10 3-18 4-24 1-7 2-11 2-12 16 2 33 2 50 1 17-2 33-5 49-8 15-3 29-8 42-13 12-5 22-10 29-15 36-27 62-57 77-91 15-35 23-70 26-106 2-28 0-56-7-84q-10.5-43.5-33-81c-16-26-36-50-61-71s-55-39-89-53c4-27 8-53 11-76 3-20 6-39 9-58s5-33 6-40c6-40 8-73 7-98q-1.5-39-15-63c-7-13-16-26-25-39-10-13-22-24-35-34s-29-18-46-25c-18-7-38-11-61-12-17-1-38 0-62 5-24 4-47 12-69 23s-41 25-57 44q-24 28.5-27 69c-1 16 0 32 3 49 3 16 9 31 18 44 8 13 19 23 33 32 13 9 30 14 50 15 12 1 24-1 37-5 12-5 23-11 34-19s19-18 26-30q10.5-18 12-39c2-25-6-48-23-71s-47-41-88-52c7-9 19-18 38-26 19-9 42-13 70-13 29 0 58 9 85 26s47 39 62 65c9 17 14 40 14 68 0 27-2 55-5 83-1 5-3 16-6 35q-4.5 27-9 57-4.5 34.5-12 78m21 1267c-26 0-49-12-68-36q-30-37.5-48-93c-13-37-21-78-25-123q-6-67.5 3-129c22 17 45 37 69 61q36 34.5 66 75 28.5 40.5 48 81 18 40.5 15 78c-1 8-2 17-4 27s-5 19-10 28-11 16-18 22-17 9-28 9m-2-1226c29 10 51 23 67 39s28 33 36 52c7 19 12 37 13 56s1 35 0 50c-1 12-4 27-8 45-5 18-13 35-25 52q-18 25.5-51 42c-22 11-51 15-88 13m-26-2c-27-1-50-7-67-16-18-10-32-22-42-35-11-14-18-29-21-44-4-15-6-29-5-41s3-24 8-37 11-24 19-35c7-11 16-21 25-30s18-16 27-21l-3-3-4-4c-1-1-2-3-3-4q-31.5 15-54 36c-16 13-26 23-31 29-7 10-14 19-19 27s-10 17-13 26-6 18-8 29c-3 11-4 23-5 38q-1.5 21 3 45c3 15 9 31 17 47 7 16 17 32 30 47 12 15 26 29 43 42 9 7 17 12 24 16s13 8 19 11 12 5 19 7c6 1 13 3 20 5l-30 181c-8-5-21-14-39-28s-38-31-59-50-42-40-63-62c-21-23-39-44-52-65-24-38-43-73-56-105S65 75 68 38q4.5-63 39-117c23-37 52-67 88-92q54-37.5 123-51c46-10 94-9 143 3-11 66-20 125-29 177-4 22-8 44-11 65q-4.5 31.5-9 57c-3 17-6 30-7 41-1 10-2 15-2 15"
-   horiz-adv-x="709"
-   unicode="&amp;" />&#10;    <glyph
-   id="glyph44528"
-   d="M31 20q0 21 15 36c10 9 22 14 37 14s27-5 37-14q15-15 15-36t-15-36c-10-10-22-15-37-15s-27 5-37 15Q31-1 31 20"
-   horiz-adv-x="155"
-   unicode="." />&#10;    <glyph
-   id="glyph44530"
-   d="M15 287c0-25 6-50 18-77s25-50 40-71c17-23 35-48 54-74 19-27 39-56 58-89 8-14 16-29 23-46s14-34 20-51 11-34 15-49c3-15 6-28 7-38 3-21 6-41 8-61 1-21 2-41 1-60-1-61-12-118-31-170l-12 2c9 23 16 51 21 82 4 31 6 61 6 89 0 24-2 50-6 79s-10 55-19 80c-15 45-34 80-55 106s-40 44-55 54Q91.5 3.5 75 11q-16.5 6-30 9c-11 3-21 4-30 5H1v262z"
-   horiz-adv-x="330"
-   unicode="j" />&#10;    <glyph
-   id="glyph44532"
-   d="M319 251V107H1v144z"
-   horiz-adv-x="319"
-   unicode="∑" />&#10;    <glyph
-   id="glyph44534"
-   d="M8-1c7 18 17 35 31 50 13 15 29 29 47 41 18 11 37 20 58 27q31.5 9 63 9c21 0 40-3 56-10s29-17 38-28c9-12 15-26 18-41 2-16 0-33-7-51s-17-35-31-50c-14-16-30-30-48-41-18-12-37-21-58-27-21-7-42-10-63-10s-40 4-55 11c-16 7-29 16-38 28Q4-75 1-51C-1-36 1-19 8-1"
-   horiz-adv-x="319"
-   unicode="œ" />&#10;  </font>&#10;  <font
-   id="font44572"
-   horiz-adv-x="2048"
-   horiz-origin-x="0"
-   horiz-origin-y="0"
-   vert-adv-y="1024"
-   vert-origin-x="512"
-   vert-origin-y="768">&#10;    <font-face
-   id="font-face44538"
-   font-family="'Times New Roman'"
-   underline-position="-223"
-   underline-thickness="100"
-   units-per-em="2048">&#10;      <font-face-src>&#10;        <font-face-name
-   name="Times New Roman" />&#10;      </font-face-src>&#10;    </font-face>&#10;    <glyph
-   id="glyph44542"
-   horiz-adv-x="512" />&#10;    <glyph
-   id="glyph44544"
-   d="M535 141v499H37v82h498v497h80V722h500v-82H615V141z"
-   horiz-adv-x="1155"
-   unicode="+" />&#10;    <glyph
-   id="glyph44546"
-   d="M74 670c0 155 23 288 70 400q70.5 166.5 186 249c60 43 122 65 186 65 104 0 197-53 280-159 103-131 155-309 155-534 0-157-23-291-68-401S780 100 710 51Q603.5-24 506-24c-129 0-237 76-323 229C110 334 74 489 74 670m196-25c0-187 23-339 69-457 38-99 95-149 170-149 36 0 73 16 112 49 39 32 68 86 88 162 31 115 46 276 46 485q0 232.5-48 387c-24 77-55 131-93 163q-40.5 33-99 33c-45 0-86-20-121-61-48-55-81-142-98-261s-26-236-26-351"
-   horiz-adv-x="1024"
-   unicode="0" />&#10;    <glyph
-   id="glyph44548"
-   d="m240 1223 330 161h33V239c0-76 3-123 10-142 6-19 19-33 39-43s61-16 122-17V0H264v37c64 1 105 7 124 17q28.5 13.5 39 39c7 16 11 65 11 146v732c0 99-3 162-10 190-5 21-13 37-25 47q-19.5 15-45 15c-25 0-59-10-103-31z"
-   horiz-adv-x="1024"
-   unicode="1" />&#10;    <glyph
-   id="glyph44550"
-   d="M939 261 844 0H44v37c235 215 401 390 497 526s144 260 144 373c0 86-26 157-79 212s-116 83-189 83c-67 0-126-19-179-58s-93-97-118-172H83c17 123 60 218 129 284q103.5 99 258 99c110 0 202-35 276-106 73-71 110-154 110-250 0-69-16-137-48-206-49-108-129-222-240-343-166-181-270-291-311-328h354c72 0 123 3 152 8q43.5 7.5 78 33c23 16 44 39 61 69z"
-   horiz-adv-x="1024"
-   unicode="2" />&#10;    <glyph
-   id="glyph44552"
-   d="M104 1098c39 91 88 162 147 212 59 49 132 74 220 74 109 0 192-35 250-106 44-53 66-109 66-169q0-148.5-186-306c83-33 146-79 189-140s64-132 64-214c0-117-37-219-112-305Q596.5-24 319-24c-91 0-153 11-186 34S83 57 83 83q0 28.5 24 51c15 15 34 22 56 22 17 0 34-3 51-8 11-3 37-15 77-36s68-34 83-38c25-7 51-11 79-11 68 0 127 26 178 79 50 53 75 115 75 187 0 53-12 104-35 154-17 37-36 66-57 85-29 27-68 51-118 73-50 21-101 32-153 32h-32v30q79.5 10.5 159 57c53 31 91 69 115 113s36 92 36 145c0 69-21 124-64 167-43 42-97 63-161 63-103 0-190-55-259-166z"
-   horiz-adv-x="1024"
-   unicode="3" />&#10;    <glyph
-   id="glyph44554"
-   d="M953 500V358H771V0H606v358H32v128l629 898h110V500m-165 0v673L130 500z"
-   horiz-adv-x="1024"
-   unicode="4" />&#10;    <glyph
-   id="glyph44556"
-   d="m889 1356-78-170H403l-89-182c177-26 317-92 420-197 89-91 133-197 133-320 0-71-14-137-43-198s-66-112-110-155-93-77-147-103C490-6 412-24 331-24q-121.5 0-177 42c-37 27-56 58-56 91 0 19 8 35 23 50 15 14 35 21 58 21 17 0 33-3 46-8s35-19 66-41c50-35 101-52 152-52 78 0 147 30 206 89s88 130 88 215c0 82-26 159-79 230S533 738 440 777c-73 30-172 47-297 52l260 527z"
-   horiz-adv-x="1024"
-   unicode="5" />&#10;    <glyph
-   id="glyph44558"
-   d="M918 1384v-37c-88-9-160-26-215-52-56-27-111-67-165-121q-82.5-81-135-180-54-100.5-90-237c96 66 192 99 289 99 93 0 173-37 241-112q102-112.5 102-288c0-113-34-217-103-310C759 33 650-24 514-24c-93 0-171 31-236 92C151 187 88 342 88 532c0 121 24 237 73 346s118 206 209 291c90 85 176 142 259 171s160 44 231 44M296 684c-12-90-18-163-18-218 0-64 12-133 36-208 23-75 58-135 105-179 34-31 75-47 124-47 58 0 110 27 156 82 45 55 68 133 68 234 0 114-23 213-68 296S589 769 506 769c-25 0-52-5-81-16q-43.5-16.5-129-69"
-   horiz-adv-x="1024"
-   unicode="6" />&#10;    <glyph
-   id="glyph44560"
-   d="M206 1356h727v-38L481-28H369l405 1221H401c-75 0-129-9-161-27-56-31-101-78-135-142l-29 11z"
-   horiz-adv-x="1024"
-   unicode="7" />&#10;    <glyph
-   id="glyph44562"
-   d="M393 683c-107 88-176 159-207 212s-47 109-47 166q0 132 102 228c68 63 158 95 271 95 109 0 197-30 264-89s100-127 100-203c0-51-18-102-54-155q-54-79.5-225-186c117-91 195-162 233-214 51-68 76-140 76-215 0-95-36-177-109-244C724 10 629-24 511-24 382-24 282 16 210 97c-57 65-86 135-86 212 0 60 20 120 61 179 40 59 109 124 208 195m157 107c80 72 131 129 152 171 21 41 32 88 32 141 0 70-20 125-59 165-39 39-93 59-161 59s-123-20-166-59-64-85-64-138c0-35 9-69 27-104q25.5-52.5 75-99m54-281c-55-47-96-97-123-152s-40-115-40-179c0-86 24-155 71-206 47-52 106-78 179-78 72 0 130 20 173 61s65 90 65 148c0 48-13 91-38 129-47 71-143 163-287 277"
-   horiz-adv-x="1024"
-   unicode="8" />&#10;    <glyph
-   id="glyph44564"
-   d="M108-28V9c87 1 167 22 242 61s147 107 217 204c69 97 118 204 145 321-105-67-199-101-284-101-95 0-177 37-245 111-68 73-102 171-102 293 0 119 34 224 102 317 82 113 189 169 321 169 111 0 207-46 286-138 97-114 146-255 146-422 0-151-37-291-111-421-74-131-177-239-309-325C409 7 292-28 165-28m563 697c12 87 18 156 18 208q0 97.5-33 210c-22 75-53 132-93 172q-61.5 60-138 60c-59 0-111-27-156-80s-67-133-67-238c0-141 30-251 89-330 43-57 97-86 160-86 31 0 67 7 109 22s79 35 111 62"
-   horiz-adv-x="1024"
-   unicode="9" />&#10;    <glyph
-   id="glyph44566"
-   d="M838 0 314 1141V235q0-124.5 27-156 37.5-42 117-42h48V0H34v37h48c57 0 98 17 122 52 15 21 22 70 22 146v886c0 60-7 103-20 130-9 19-26 36-51 49s-66 19-121 19v37h384L910 295l484 1061h384v-37h-47c-58 0-99-17-123-52-15-21-22-70-22-146V235c0-83 9-135 28-156q37.5-42 117-42h47V0h-576v37h48c58 0 99 17 122 52 15 21 22 70 22 146v906L871 0z"
-   horiz-adv-x="1821"
-   unicode="M" />&#10;    <glyph
-   id="glyph44568"
-   d="M939 1387V918h-37c-12 90-33 162-64 215s-76 96-133 127-117 47-178 47c-69 0-127-21-172-63-45-43-68-91-68-145 0-41 14-79 43-113 41-50 140-117 295-200 127-68 213-120 260-156 46-37 82-80 107-129s37-101 37-155c0-103-40-191-119-265C830 6 727-31 602-31q-58.5 0-111 9c-21 3-63 16-128 37S256 46 239 46q-25.5 0-39-15c-10-10-17-31-22-62h-37v465h37c17-97 41-170 70-218 29-49 74-89 135-121q90-48 198-48 124.5 0 198 66 72 66 72 156c0 33-9 67-27 101-19 34-47 66-86 95-26 20-97 63-213 128S327 709 278 748s-87 81-112 128-38 98-38 154c0 97 37 181 112 252q112.5 105 285 105c72 0 148-18 229-53 37-17 64-25 79-25 17 0 32 5 43 16 11 10 19 31 26 62z"
-   horiz-adv-x="1139"
-   unicode="S" />&#10;    <glyph
-   id="glyph44570"
-   d="M335 1422V511l233 212c49 45 78 74 86 86 5 8 8 16 8 24 0 13-5 25-16 35-11 9-30 15-55 16v32h398v-32c-55-1-100-10-136-25-37-15-77-43-120-82L498 560l235-297q97.5-123 132-156c32-31 60-52 84-61 17-7 46-10 87-10V0H591v36c25 1 43 5 52 12s13 16 13 29c0 15-13 40-40 74L335 510V206c0-59 4-98 13-117 8-19 20-32 35-40s49-12 100-13V0H17v36c47 0 82 6 105 17 14 7 25 19 32 34q15 33 15 114v834c0 106-2 171-7 195-5 23-12 40-23 49s-25 13-42 13c-14 0-35-6-63-17l-17 35 272 112z"
-   horiz-adv-x="1024"
-   unicode="k" />&#10;  </font>&#10;  <font
-   id="font44586"
-   horiz-adv-x="2048"
-   horiz-origin-x="0"
-   horiz-origin-y="0"
-   vert-adv-y="1024"
-   vert-origin-x="512"
-   vert-origin-y="768">&#10;    <font-face
-   id="font-face44574"
-   font-family="'Times New Roman'"
-   font-style="italic"
-   underline-position="-223"
-   underline-thickness="100"
-   units-per-em="2048">&#10;      <font-face-src>&#10;        <font-face-name
-   name="Times New Roman Kursiv" />&#10;      </font-face-src>&#10;    </font-face>&#10;    <glyph
-   id="glyph44578"
-   d="M708 1384c85 0 157-36 216-107 58-71 87-184 87-338 0-132-22-267-65-404q-64.5-205.5-183-357C700 99 635 41 566 6c-40-20-86-30-139-30-87 0-159 36-217 107-59 71-88 184-88 339 0 153 29 306 88 460 69 180 156 317 263 410 70 61 148 92 235 92m1-52q-58.5 0-117-45c-40-31-81-94-123-190-43-96-83-220-122-371-50-198-75-367-75-506 0-69 15-121 45-155 30-35 66-52 109-52 41 0 75 13 104 40 77 72 142 195 197 369 89 285 133 516 133 694 0 74-15 129-45 164s-65 52-106 52"
-   horiz-adv-x="1024"
-   unicode="0" />&#10;    <glyph
-   id="glyph44580"
-   d="M855 1384 533 263c-19-66-28-114-28-143 0-25 9-43 26-56s56-22 119-27L640 0H125l14 37c55 1 91 6 108 13q42 18 63 48c22 31 44 86 67 165l232 805c14 49 22 77 23 84q3 19.5 3 39c0 23-6 42-19 55s-30 20-52 20q-25.5 0-81-12l-13 36 337 94z"
-   horiz-adv-x="1024"
-   unicode="1" />&#10;    <glyph
-   id="glyph44582"
-   d="M691 759q96-103.5 141-195c29-61 44-121 44-182 0-109-41-203-124-284S567-24 446-24C337-24 249 9 181 75 112 141 78 218 78 306q0 112.5 84 222 82.5 109.5 315 210-88.5 109.5-120 180c-21 47-32 94-32 141 0 89 33 165 100 229 66 64 149 96 250 96 96 0 174-28 235-83s91-120 91-194c0-73-24-140-73-200S800 798 691 759m-39 42c72 25 128 65 168 121 39 56 59 120 59 193 0 68-19 122-57 161-39 39-89 58-151 58-59 0-107-19-144-56s-55-86-55-145c0-45 10-86 29-124 28-56 78-125 151-208M514 697c-99-41-174-101-225-179-51-79-77-163-77-253 0-73 23-131 68-175 45-45 104-67 177-67 76 0 140 27 192 80s78 117 78 191q0 84-45 177c-31 61-87 137-168 226"
-   horiz-adv-x="1024"
-   unicode="8" />&#10;    <glyph
-   id="glyph44584"
-   d="M59-24V8c69 15 128 36 179 64q135 73.5 243 183c71 73 135 157 191 253-41-20-72-33-95-39s-48-9-76-9c-101 0-178 34-231 103s-80 149-80 240c0 159 52 296 156 410q154.5 171 330 171c106 0 187-40 244-119 57-80 85-173 85-280 0-135-31-269-94-401S763 338 656 243 436 77 318 31C248 4 162-15 59-24m663 615c94 191 141 361 141 511 0 73-18 129-53 169-36 40-78 60-125 60-79 0-150-55-215-165s-98-241-98-392c0-80 19-140 56-181s83-62 139-62c25 0 49 4 70 12 21 7 50 23 85 48"
-   horiz-adv-x="1024"
-   unicode="9" />&#10;  </font>&#10;  <path
-   id="line44608"
-   d="M864.387 177.165v19.76"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <path
-   id="line44610"
-   d="M929.254 177.165v19.76"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <path
-   id="line44612"
-   d="M170.44 177.165h793.896"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <path
-   id="line44614"
-   d="M170.44 182.105h793.896"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <path
-   id="line44616"
-   d="M170.44 187.045h793.896"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <path
-   id="line44618"
-   d="M170.44 191.985h793.896"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <path
-   id="line44620"
-   d="M170.44 196.925h793.896"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <g
-   id="g5"
-   class="supplied staffN">&#10;    <g
-   id="text44622"
-   aria-label="18"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"
-   transform="translate(22.677)">&#10;      <path
-   id="path951"
-   d="m92.683 191.985 1.213-5.788q-.784.617-2.206.988l.178-.857q.705-.283 1.39-.737.69-.455 1.035-.795.21-.21.398-.507h.549l-1.605 7.696z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path953"
-   d="M98.481 187.77q-.428-.234-.643-.6-.214-.372-.214-.795 0-.695.502-1.286.669-.8 1.814-.8 1.009 0 1.59.544.58.538.58 1.322 0 .56-.314 1.01t-.983.716q.46.287.659.611.256.424.256.988 0 1.03-.732 1.836-.727.805-1.94.805-.967 0-1.579-.596-.611-.596-.611-1.49 0-.842.434-1.443.434-.607 1.181-.821m.073-1.353q0 .491.314.794.32.298.873.298.649 0 1.051-.392.408-.397.408-.972 0-.486-.319-.79-.314-.308-.868-.308-.418 0-.768.193-.35.194-.523.528-.168.33-.168.649m-.737 3.696q0 .319.152.612.157.293.47.465.314.173.717.173.768 0 1.244-.722.376-.565.376-1.218 0-.533-.35-.873-.345-.34-.91-.34-.71 0-1.207.528-.492.528-.492 1.375"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;    </g>&#10;  </g>&#10;  <g
-   id="text44672"
-   aria-label="j"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path964"
-   d="M822.072 156.674h-.277v5.177h.277s.968.04 1.837.632c.593.395 1.581 1.403 2.174 3.162.336.968.494 2.193.494 3.142 0 1.106-.178 2.47-.534 3.379l.237.039c.396-1.047.593-2.174.613-3.36.02-.77-.06-1.58-.178-2.39-.099-.81-.632-2.55-1.284-3.636-.77-1.284-1.561-2.312-2.213-3.22-.573-.811-1.146-1.957-1.146-2.925"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44674"
-   d="M821.483 173.871v-16.466"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <g
-   id="text44676"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path968"
-   d="M815.265 174.714c-.533 1.403.395 2.569 2.055 2.588s3.419-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44678"
-   d="M838.952 166.46v-13.173"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <path
-   id="line44680"
-   d="M831.34 172.225h9.057"
-   style="fill:none;stroke:#000;stroke-width:.81733102" />&#10;  <path
-   id="line44682"
-   d="M831.34 167.285h9.057"
-   style="fill:none;stroke:#000;stroke-width:.81733102" />&#10;  <g
-   id="text44684"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path974"
-   d="M832.734 167.305c-.534 1.402.395 2.568 2.055 2.588s3.418-1.106 3.952-2.53c.513-1.402-.396-2.548-2.075-2.568-1.66-.02-3.419 1.107-3.932 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44688"
-   d="M871.3 172.225h9.056"
-   style="fill:none;stroke:#000;stroke-width:.81733102" />&#10;  <g
-   id="text44690"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path978"
-   d="M872.693 169.774c-.533 1.403.395 2.569 2.055 2.588s3.419-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44692"
-   d="M878.911 168.931V153.7"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <path
-   id="line44694"
-   d="M882.62 172.225h9.058"
-   style="fill:none;stroke:#000;stroke-width:.81733102" />&#10;  <g
-   id="text44696"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path983"
-   d="M884.014 172.245c-.533 1.402.396 2.568 2.055 2.588s3.419-1.106 3.952-2.53c.514-1.402-.395-2.548-2.074-2.568-1.66-.02-3.419 1.107-3.933 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44698"
-   d="M890.232 171.4v-15.23"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <path
-   id="path44700"
-   d="m878.62 152.465 11.903 2.47v2.47l-11.903-2.47z"
-   style="fill:#000;fill-rule:nonzero;stroke:none;stroke-width:1.33333004" />&#10;  <g
-   id="text44702"
-   aria-label="."
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path987"
-   d="M902.817 179.65c0 .554.454 1.009 1.027 1.009s1.028-.455 1.028-1.008-.455-.988-1.028-.988-1.027.435-1.027.988"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44704"
-   d="M900.347 181.28v-13.173"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <g
-   id="text44706"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path991"
-   d="M894.13 182.125c-.534 1.402.394 2.568 2.054 2.588s3.419-1.106 3.952-2.53c.514-1.402-.395-2.548-2.075-2.568-1.66-.02-3.418 1.107-3.932 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text44708"
-   aria-label="j"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path994"
-   d="M922.311 156.674h-.276v5.177h.276s.969.04 1.838.632c.593.395 1.58 1.403 2.174 3.162.335.968.494 2.193.494 3.142 0 1.106-.178 2.47-.534 3.379l.237.039c.395-1.047.593-2.174.613-3.36.02-.77-.06-1.58-.178-2.39-.099-.81-.632-2.55-1.285-3.636-.77-1.284-1.56-2.312-2.213-3.22-.573-.811-1.146-1.957-1.146-2.925"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44710"
-   d="M921.723 173.871v-16.466"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <g
-   id="text44712"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path998"
-   d="M915.505 174.714c-.534 1.403.395 2.569 2.055 2.588s3.419-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44714"
-   d="M878.911 198.571v-16.466"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <g
-   id="text44716"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1002"
-   d="M872.693 199.414c-.533 1.403.395 2.569 2.055 2.588s3.419-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44718"
-   d="M912.196 201.04v-21.406"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <g
-   id="text44720"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1006"
-   d="M905.978 196.944c-.533 1.403.396 2.57 2.055 2.589s3.419-1.107 3.952-2.53c.514-1.402-.395-2.548-2.074-2.568-1.66-.02-3.419 1.106-3.933 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44722"
-   d="M904.586 201.865h9.056"
-   style="fill:none;stroke:#000;stroke-width:.81733102" />&#10;  <g
-   id="text44724"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1010"
-   d="M905.978 201.884c-.533 1.403.396 2.57 2.055 2.589s3.419-1.107 3.952-2.53c.514-1.402-.395-2.548-2.074-2.568-1.66-.02-3.419 1.106-3.933 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text44738"
-   aria-label="j"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1013"
-   d="M961.67 151.734h-.277v5.177h.277s.968.04 1.838.632c.592.395 1.58 1.403 2.173 3.162.336.968.494 2.193.494 3.142 0 1.106-.178 2.47-.533 3.379l.237.039c.395-1.047.593-2.174.612-3.36.02-.77-.059-1.58-.178-2.39-.098-.81-.632-2.55-1.284-3.636-.77-1.284-1.561-2.312-2.213-3.22-.573-.811-1.146-1.957-1.146-2.925"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44740"
-   d="M961.083 168.931v-16.466"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <g
-   id="text44742"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1017"
-   d="M954.865 169.774c-.534 1.403.395 2.569 2.055 2.588s3.418-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text44744"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1020"
-   d="M965.631 169.774c-.533 1.403.395 2.569 2.055 2.588s3.419-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44746"
-   d="M971.849 168.931V153.7"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <g
-   id="text44748"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1024"
-   d="M973.388 174.714c-.534 1.403.395 2.569 2.055 2.588s3.418-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line44750"
-   d="M979.606 173.871V156.17"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;  <path
-   id="path44752"
-   d="m971.586 152.465 8.312 2.47v2.47l-8.312-2.47z"
-   style="fill:#000;fill-rule:nonzero;stroke:none;stroke-width:1.66701996" />&#10;  <path
-   id="path44764"
-   d="M984.26 158.433v19.76"
-   style="fill:none;stroke:#000;stroke-width:.719998" />&#10;  <g
-   id="g4"
-   class="supplied measureN"
-   transform="translate(37.677)">&#10;    <g
-   id="text44686"
-   aria-label="9"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333">&#10;      <path
-   id="path1028"
-   d="m771.565 115.221.889-.089q.089.643.366.915t.658.272q.544 0 1.01-.47.684-.69 1.008-1.982-.475.356-.846.507-.366.152-.753.152-.7 0-1.255-.47-.732-.612-.732-1.757 0-1.297.847-2.222.727-.795 1.783-.795.951 0 1.579.706.627.7.627 1.987 0 1.25-.418 2.467-.497 1.433-1.344 2.112-.69.555-1.553.555-.794 0-1.301-.492-.502-.496-.565-1.396m1.26-3.032q0 .721.382 1.15.386.429.914.429.393 0 .78-.267.386-.266.663-.794.278-.534.278-1.093 0-.44-.183-.816t-.502-.564q-.314-.194-.638-.194-.314 0-.617.167-.303.168-.565.492-.256.324-.387.748-.125.418-.125.742"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;    </g>&#10;    <g
-   id="text44726"
-   aria-label="10"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333">&#10;      <path
-   id="path1031"
-   d="m828.997 116.978 1.213-5.788q-.785.617-2.207.988l.178-.857q.706-.282 1.39-.737.691-.455 1.036-.795.21-.209.397-.507h.55l-1.606 7.696z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1033"
-   d="M833.138 114.463q0-.972.287-1.976.293-1.004.648-1.605t.738-.941.747-.497q.371-.162.821-.162.878 0 1.464.654.59.653.59 1.887 0 1.27-.407 2.515-.481 1.474-1.339 2.211-.658.56-1.5.56-.863 0-1.459-.675-.59-.68-.59-1.97m.914.24q0 .706.236 1.104.319.549.946.549.549 0 .999-.497.648-.7.972-2.05.33-1.353.33-2.21 0-.827-.32-1.193-.313-.366-.83-.366-.377 0-.707.194-.324.193-.622.664-.423.664-.737 1.986-.267 1.13-.267 1.82"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;    </g>&#10;    <g
-   id="text44766"
-   aria-label="11"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333">&#10;      <path
-   id="path1036"
-   d="m894.863 117.094 1.213-5.788q-.784.617-2.206.988l.178-.857q.705-.282 1.39-.737.69-.455 1.036-.795.209-.21.397-.507h.549l-1.605 7.696z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1038"
-   d="m900.029 117.094 1.213-5.788q-.785.617-2.207.988l.178-.857q.706-.282 1.39-.737.691-.455 1.036-.795.21-.21.397-.507h.55l-1.606 7.696z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;    </g>&#10;  </g>&#10;  &#10;  &#10;  <g
-   id="g3"
-   class="supplied foliation">&#10;    <g
-   id="text297"
-   aria-label="A: Bl. 2r"
-   style="font-size:10.66670036px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;letter-spacing:0;word-spacing:0;opacity:.604762">&#10;      <path
-   id="path1067"
-   d="M118.943 115.406h-3.026l-.917 1.688h-1.614l4.318-7.636h1.744l1.24 7.636h-1.49zm-.193-1.27-.442-3.074-1.844 3.073z"
-   style="font-style:italic;font-variant:normal;font-weight:700;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1069"
-   d="M123.12 111.562h1.474l-.302 1.448h-1.474zm-.854 4.089h1.48l-.303 1.443h-1.479z"
-   style="font-style:italic;font-variant:normal;font-weight:700;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1071"
-   d="m128.198 117.094 1.6-7.636h2.364q.646 0 .958.052.51.089.86.313.354.219.547.604.192.38.192.844 0 .63-.349 1.11-.343.478-1.057.728.62.203.927.615.307.406.307.953 0 .63-.364 1.208-.36.579-.959.896-.593.313-1.328.313zm1.938-4.375h1.547q1.11 0 1.594-.354.49-.355.49-1.032 0-.323-.152-.557-.151-.234-.406-.339-.25-.109-.948-.109h-1.625zm-.734 3.51h1.74q.692 0 .931-.047.485-.083.787-.281.302-.203.474-.531t.172-.688q0-.536-.339-.812-.333-.282-1.276-.282h-1.937z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1073"
-   d="m135.141 117.094 1.594-7.636h.943l-1.594 7.636z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1075"
-   d="m137.85 117.094.223-1.068h1.068l-.229 1.068z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1077"
-   d="M143.777 117.094q.145-.683.4-1.14.261-.464.688-.876.427-.417 1.646-1.39.74-.59 1.01-.87.391-.407.568-.797.12-.266.12-.578 0-.526-.375-.891-.37-.37-.912-.37-.536 0-.937.375-.401.37-.573 1.193l-.922-.135q.136-1.016.787-1.6.656-.588 1.63-.588.65 0 1.177.27.531.272.797.761.265.49.265 1.01 0 .761-.541 1.464-.334.438-1.959 1.724-.698.552-1.041.906-.339.355-.51.667h3.416l-.182.865z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1079"
-   d="m149.32 112.827.75-3.595h.543l-.153.734q.278-.416.542-.616.267-.2.545-.2.183 0 .45.132l-.25.57q-.16-.116-.35-.116-.32 0-.66.359-.338.359-.53 1.29l-.305 1.442z"
-   style="font-size:64.99999762%;baseline-shift:super" />&#10;    </g>&#10;  </g>&#10;  <g
-   id="text1141"
-   aria-label="M 38 Sk2 T. 9–11"
-   style="font-style:italic;font-size:10.66670036px;line-height:1.25;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;letter-spacing:0;word-spacing:0">&#10;    <path
-   id="path1082"
-   d="M113.97 87.239V75.786h3.46l2.078 7.812 2.055-7.812h3.469v11.453h-2.149v-9.016l-2.273 9.016h-2.227l-2.265-9.016v9.016z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;    <path
-   id="path1084"
-   d="m131.22 84.2 2.124-.258q.102.813.547 1.242t1.078.43q.68 0 1.14-.516.47-.515.47-1.39 0-.828-.446-1.313-.445-.484-1.086-.484-.422 0-1.008.164l.243-1.79q.89.024 1.359-.382.469-.414.469-1.094 0-.578-.344-.922-.344-.343-.914-.343-.563 0-.961.39t-.484 1.14l-2.024-.343q.211-1.039.633-1.656.43-.625 1.188-.977.765-.359 1.71-.359 1.618 0 2.594 1.031.805.844.805 1.906 0 1.508-1.649 2.407.985.21 1.57.945.595.734.595 1.773 0 1.508-1.102 2.57-1.102 1.063-2.742 1.063-1.555 0-2.578-.89-1.024-.899-1.188-2.344"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;    <path
-   id="path1086"
-   d="M142.086 81.06q-.851-.36-1.242-.985-.383-.633-.383-1.383 0-1.281.89-2.117.9-.836 2.548-.836 1.633 0 2.531.836.906.836.906 2.117 0 .797-.414 1.422-.414.617-1.164.945.953.383 1.446 1.117.5.735.5 1.696 0 1.586-1.016 2.578-1.008.992-2.688.992-1.562 0-2.601-.82-1.227-.969-1.227-2.656 0-.93.461-1.704.461-.78 1.453-1.203m.453-2.212q0 .657.368 1.024.375.367.992.367.625 0 1-.367.375-.375.375-1.031 0-.618-.375-.985-.367-.375-.977-.375-.633 0-1.008.375t-.375.992m-.203 4.907q0 .906.461 1.414.469.507 1.164.507.68 0 1.125-.484.446-.492.446-1.414 0-.805-.453-1.289-.454-.492-1.149-.492-.805 0-1.203.554-.39.555-.39 1.204"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;    <path
-   id="path1088"
-   d="m153.446 83.512 2.25-.218q.203 1.132.82 1.664.625.531 1.68.531 1.117 0 1.68-.469.57-.476.57-1.11 0-.405-.242-.687-.235-.289-.829-.5-.406-.14-1.851-.5-1.86-.46-2.61-1.132-1.054-.946-1.054-2.305 0-.875.492-1.633.5-.766 1.43-1.164.937-.398 2.257-.398 2.157 0 3.243.945 1.093.945 1.148 2.523l-2.312.102q-.149-.883-.641-1.266-.484-.39-1.461-.39-1.008 0-1.578.414-.367.265-.367.71 0 .407.343.696.438.367 2.125.766 1.688.398 2.493.828.812.422 1.265 1.164.461.734.461 1.82 0 .984-.547 1.844t-1.547 1.281q-1 .414-2.492.414-2.172 0-3.336-1-1.164-1.008-1.39-2.93"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;    <path
-   id="path1090"
-   d="M164.625 87.239V75.786h2.196v6.078l2.57-2.922h2.703l-2.836 3.031 3.04 5.266h-2.368l-2.086-3.727-1.023 1.07v2.657z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;    <path
-   id="path1092"
-   d="M180.555 85.2v2.039h-7.695q.125-1.156.75-2.188.625-1.039 2.469-2.75 1.484-1.382 1.82-1.875.453-.68.453-1.343 0-.735-.398-1.125-.391-.399-1.086-.399-.688 0-1.094.414t-.469 1.375l-2.187-.218q.195-1.813 1.226-2.602t2.578-.789q1.696 0 2.664.914.97.914.97 2.273 0 .774-.282 1.477-.274.695-.875 1.461-.399.508-1.438 1.46-1.039.954-1.32 1.267-.273.312-.445.609z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;    <path
-   id="path1094"
-   d="M189.547 87.239v-9.516h-3.398v-1.937h9.101v1.937h-3.39v9.516z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;    <path
-   id="path1096"
-   d="M194.954 87.239v-2.195h2.195v2.195z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;    <path
-   id="path1098"
-   d="m203.407 84.59 2.125-.234q.078.649.406.961.328.313.867.313.68 0 1.156-.625.477-.625.61-2.594-.828.96-2.07.96-1.352 0-2.337-1.038-.976-1.047-.976-2.719 0-1.742 1.031-2.805 1.04-1.07 2.64-1.07 1.743 0 2.86 1.352 1.117 1.343 1.117 4.43 0 3.14-1.164 4.53t-3.031 1.391q-1.344 0-2.172-.71-.828-.72-1.062-2.141m4.968-4.796q0-1.063-.492-1.649-.484-.586-1.125-.586-.61 0-1.015.485-.399.476-.399 1.57 0 1.11.438 1.633.437.515 1.093.515.633 0 1.063-.5.437-.5.437-1.468"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;    <path
-   id="path1100"
-   d="M211.555 83.91v-1.64h8.899v1.64z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;    <path
-   id="path1102"
-   d="M226.79 87.239h-2.196v-8.273q-1.203 1.125-2.836 1.664v-1.993q.86-.28 1.867-1.062 1.008-.79 1.383-1.836h1.781z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;    <path
-   id="path1104"
-   d="M234.82 87.239h-2.195v-8.273q-1.203 1.125-2.836 1.664v-1.993q.86-.28 1.868-1.062 1.007-.79 1.382-1.836h1.782z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;  </g>&#10;  <g
-   id="g47070"
-   class="supplied clef, supplied key"
-   transform="translate(37.677)">&#10;    <g
-   id="g1339"
-   transform="translate(694.617 -94.41)">&#10;      <g
-   id="text1317"
-   aria-label="b"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004">&#10;        <path
-   id="path1107"
-   d="M66.85 271.537h-.569v12.924c0-.044 2.843-1.99 3.237-2.384.35-.35.874-.721 1.071-1.203.175-.371.306-.852.284-1.312-.022-.874-.721-1.968-1.815-1.946-.918.022-1.377.175-2.208.919v-1.4c.022-2.886 0-5.598 0-5.598m1.771 7.479c.416.459.481 1.159.306 1.815-.153.656-.459 1.071-.853 1.443-.437.415-1.224 1.093-1.224 1.071v-1.88c0-.678-.044-1.618.24-2.165.46-.875 1.247-.612 1.531-.284"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004" />&#10;      </g>&#10;      <g
-   id="g1234"
-   transform="matrix(.75 0 0 .75 49.722 71.408)">&#10;        <g
-   id="text1224"
-   aria-label="&amp;"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004">&#10;          <path
-   id="path1110"
-   d="m12.352 291.983.59 3.717c.153 1.225.197 2.558-.196 3.302-.635 1.137-1.947 1.99-3.215 1.99-1.224 0-2.077-.46-2.361-.853 1.814-.503 2.514-1.618 2.427-2.69-.088-1.246-1.334-2.099-2.384-2.033-1.727.131-2.361 1.64-2.274 3.061.153 2.405 3.17 3.17 4.701 3.083 1.99-.13 3.018-1.224 3.652-2.405.372-.7.438-1.793.175-3.52-.087-.657-.568-3.805-.568-3.805 2.995-1.247 4.351-3.849 4.154-6.32-.11-1.552-.7-3.149-2.252-4.307-.612-.438-2.318-.94-3.717-.766-.022-.284-.722-4.242-.722-4.242.547-.481 1.137-.853 1.662-1.487.503-.612.984-1.159 1.443-1.946.897-1.574 1.618-2.952 1.553-5.991-.044-1.968-1.553-5.904-2.537-5.883-1.268.022-3.105 3.477-3.39 4.942-.458 2.471-.174 4.614-.152 5.073.087 1.094.262 1.4.306 2.165a44 44 0 0 0-3.543 2.974c-1.814 1.727-3.76 4.833-3.542 7.894.197 2.82.918 5.576 5.423 7.719.918.437 3.149.59 4.767.328m.46-27.705c.983-.022 1.267 1.202 1.311 1.88.153 2.165-2.427 4.964-4.33 6.45-.502-3.607.766-8.308 3.018-8.33m-1.27 19.177c3.193-.153 3.674 2.252 3.762 3.323.087 1.29-.022 3.455-2.537 4.308zm-.568.043c-.022 0 1.269 7.763 1.269 7.763-4.33 1.028-8.332-1.968-8.594-5.62-.131-1.618.503-2.93 1.553-4.57 1.18-1.837 3.98-4.089 4.657-4.482l.656 3.957c-.656.154-1.028.285-1.793.853-1.465 1.137-2.121 2.755-2.034 3.958.088 1.29.35 1.771.984 2.624.197.263.963.984 1.86 1.421 0 0 .108-.174.218-.24-.81-.416-1.684-1.64-1.728-2.69-.065-1.05.569-2.886 2.952-2.974"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004" />&#10;        </g>&#10;        <g
-   id="g1232"
-   transform="translate(.133 247.042)">&#10;          <path
-   id="path1228"
-   d="M1.839 53.386H-.758V14.42H1.84"
-   style="fill:none;stroke:#777;stroke-width:.87066698;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />&#10;          <path
-   id="path1230"
-   d="M28.635 14.421h2.597v38.965h-2.597"
-   style="fill:none;stroke:#777;stroke-width:.87066698;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />&#10;        </g>&#10;      </g>&#10;    </g>&#10;  </g>&#10;  <g
-   id="g950"
-   class="tkk"
-   transform="translate(37.677)">&#10;    <g
-   id="text44728"
-   aria-label="j"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;      <path
-   id="path1114"
-   d="M900.953 156.674h-.277v5.177h.277s.968.04 1.837.632c.593.395 1.581 1.403 2.174 3.162.336.968.494 2.193.494 3.142 0 1.106-.178 2.47-.533 3.379l.237.039c.395-1.047.592-2.174.612-3.36.02-.77-.06-1.58-.178-2.39-.098-.81-.632-2.55-1.284-3.636-.77-1.284-1.561-2.312-2.213-3.22-.573-.811-1.146-1.957-1.146-2.925"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;    </g>&#10;    <path
-   id="line44730"
-   d="M900.866 173.871v-16.466"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;    <g
-   id="text44732"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;      <path
-   id="path1118"
-   d="M894.648 174.714c-.534 1.403.395 2.569 2.055 2.588s3.418-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;    </g>&#10;    <g
-   id="text44736"
-   aria-label="œ"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;      <path
-   id="path1121"
-   d="M906.028 174.714c-.534 1.403.395 2.569 2.055 2.588s3.418-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;    </g>&#10;    <g
-   id="text44754"
-   aria-label="œ"
-   style="font-size:14.81999969px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;      <path
-   id="path1124"
-   d="M896.255 174.709c-.4 1.052.296 1.927 1.541 1.941s2.564-.83 2.964-1.897c.386-1.052-.296-1.911-1.556-1.926-1.245-.015-2.564.83-2.949 1.882"
-   style="font-size:14.81999969px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;    </g>&#10;    <g
-   id="text44758"
-   aria-label="œ"
-   style="font-size:14.81999969px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;      <path
-   id="path1127"
-   d="M908.135 174.709c-.4 1.052.296 1.927 1.541 1.941s2.564-.83 2.964-1.897c.386-1.052-.296-1.911-1.556-1.926-1.245-.015-2.564.83-2.949 1.882"
-   style="font-size:14.81999969px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;    </g>&#10;    <path
-   id="line44760"
-   d="M912.558 174.077v-15.66"
-   style="fill:none;stroke:#000;stroke-width:.58266503" />&#10;    <path
-   id="path44762"
-   d="M900.658 162.032h11.863v1.39h-11.863z"
-   style="fill:#777;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33332992" />&#10;    <g
-   id="text939"
-   aria-label="j"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;      <path
-   id="path1131"
-   d="M900.953 156.674h-.277v5.177h.277s.968.04 1.837.632c.593.395 1.581 1.403 2.174 3.162.336.968.494 2.193.494 3.142 0 1.106-.178 2.47-.533 3.379l.237.039c.395-1.047.592-2.174.612-3.36.02-.77-.06-1.58-.178-2.39-.098-.81-.632-2.55-1.284-3.636-.77-1.284-1.561-2.312-2.213-3.22-.573-.811-1.146-1.957-1.146-2.925"
-   style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;    </g>&#10;  </g>&#10;<g
-   id="g1"
-   class="link-box"><path
-     id="rect44630"
-     d="m 320.491,158.433 h 141.613 v 60.309 H 320.491 Z"
-     style="fill:#ffffff;stroke:#777777;stroke-width:0.823998;stroke-opacity:1" /><path
-     id="path1041"
-     d="m 346.733,194.143 v -15.27 h 4.614 l 2.77,10.417 2.74,-10.416 h 4.625 v 15.27 h -2.864 v -12.02 l -3.031,12.02 h -2.969 l -3.02,-12.02 v 12.02 z"
-     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777777;fill-opacity:1;stroke-width:1.33333" /><path
-     id="path1043"
-     d="m 369.731,190.092 2.833,-0.344 q 0.136,1.083 0.73,1.656 0.593,0.573 1.437,0.573 0.906,0 1.52,-0.688 0.626,-0.687 0.626,-1.854 0,-1.104 -0.594,-1.75 -0.594,-0.646 -1.448,-0.645 -0.562,0 -1.344,0.218 l 0.323,-2.385 q 1.188,0.031 1.813,-0.51 0.625,-0.552 0.625,-1.458 0,-0.771 -0.459,-1.23 -0.458,-0.458 -1.218,-0.458 -0.75,0 -1.282,0.521 -0.53,0.52 -0.645,1.52 l -2.698,-0.457 q 0.281,-1.386 0.844,-2.209 0.573,-0.833 1.583,-1.302 1.02,-0.479 2.281,-0.479 2.156,0 3.458,1.375 1.073,1.125 1.073,2.542 0,2.01 -2.198,3.208 1.313,0.28 2.094,1.26 0.791,0.98 0.791,2.364 0,2.01 -1.468,3.427 -1.469,1.417 -3.656,1.417 -2.073,0 -3.438,-1.188 -1.364,-1.197 -1.583,-3.124"
-     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777777;fill-opacity:1;stroke-width:1.33333" /><path
-     id="path1045"
-     d="m 381.71,181.8 v -2.718 h 10.01 v 2.125 q -1.24,1.219 -2.521,3.5 -1.282,2.28 -1.959,4.853 -0.666,2.563 -0.656,4.583 h -2.823 q 0.073,-3.166 1.302,-6.457 1.24,-3.292 3.302,-5.885 z"
-     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777777;fill-opacity:1;stroke-width:1.33333" /><path
-     id="path1047"
-     d="m 399.364,189.175 3,-0.292 q 0.271,1.51 1.094,2.219 0.833,0.708 2.24,0.708 1.489,0 2.239,-0.625 0.76,-0.635 0.76,-1.479 0,-0.541 -0.323,-0.916 -0.312,-0.386 -1.104,-0.667 -0.542,-0.187 -2.469,-0.667 -2.478,-0.614 -3.478,-1.51 -1.407,-1.26 -1.407,-3.073 0,-1.166 0.657,-2.176 0.666,-1.021 1.906,-1.552 1.25,-0.532 3.01,-0.532 2.875,0 4.323,1.26 1.458,1.261 1.53,3.365 l -3.082,0.135 q -0.198,-1.177 -0.855,-1.687 -0.645,-0.52 -1.947,-0.52 -1.344,0 -2.104,0.551 -0.49,0.354 -0.49,0.948 0,0.542 0.458,0.927 0.584,0.49 2.834,1.02 2.25,0.532 3.322,1.105 1.083,0.562 1.688,1.552 0.614,0.979 0.614,2.427 0,1.312 -0.729,2.458 -0.73,1.146 -2.062,1.708 -1.334,0.552 -3.323,0.552 -2.896,0 -4.448,-1.333 -1.552,-1.344 -1.854,-3.906"
-     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777777;fill-opacity:1;stroke-width:1.33333" /><path
-     id="path1049"
-     d="m 414.27,194.143 v -15.27 h 2.926 v 8.104 l 3.427,-3.895 h 3.604 l -3.78,4.041 4.05,7.02 h -3.155 l -2.781,-4.968 -1.365,1.427 v 3.541 z"
-     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777777;fill-opacity:1;stroke-width:1.33333" /><path
-     d="m 432.48115,194.20811 h -2.92708 v -11.03123 q -1.60417,1.5 -3.78125,2.21875 v -2.65625 q 1.14584,-0.375 2.48958,-1.41666 1.34375,-1.05208 1.84375,-2.44791 h 2.375 z"
-     id="text1"
-     style="font-weight:bold;font-size:21.3333px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';fill:#777777;stroke-width:0.88063;stroke-opacity:0.866667"
-     aria-label="1" /></g><g
-   id="g2"
-   class="link-box"><path
-     id="rect44646"
-     d="m 531.47,157.405 h 190.601 v 60.926 h -190.6 z"
-     style="fill:#ffffff;stroke:#777777;stroke-width:0.823998;stroke-opacity:1" /><path
-     id="path1054"
-     d="m 584.52,194.143 v -15.27 h 4.614 l 2.77,10.417 2.74,-10.416 h 4.624 v 15.27 h -2.864 v -12.02 l -3.031,12.02 h -2.969 l -3.02,-12.02 v 12.02 z"
-     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777777;fill-opacity:1;stroke-width:1.33333" /><path
-     id="path1056"
-     d="m 607.518,190.092 2.833,-0.344 q 0.135,1.083 0.729,1.656 0.594,0.573 1.437,0.573 0.906,0 1.521,-0.688 0.625,-0.687 0.625,-1.854 0,-1.104 -0.594,-1.75 -0.593,-0.645 -1.448,-0.645 -0.562,0 -1.343,0.218 l 0.323,-2.385 q 1.187,0.031 1.812,-0.51 0.625,-0.552 0.625,-1.458 0,-0.771 -0.458,-1.23 -0.459,-0.458 -1.219,-0.458 -0.75,0 -1.281,0.521 -0.531,0.52 -0.646,1.52 l -2.698,-0.457 q 0.282,-1.386 0.844,-2.209 0.573,-0.833 1.583,-1.302 1.021,-0.479 2.281,-0.479 2.156,0 3.458,1.375 1.073,1.125 1.073,2.542 0,2.01 -2.198,3.208 1.313,0.28 2.094,1.26 0.792,0.98 0.792,2.364 0,2.01 -1.469,3.427 -1.469,1.417 -3.656,1.417 -2.073,0 -3.437,-1.188 -1.365,-1.197 -1.583,-3.124"
-     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777777;fill-opacity:1;stroke-width:1.33333" /><path
-     id="path1058"
-     d="m 619.496,181.8 v -2.718 h 10.01 v 2.125 q -1.24,1.219 -2.521,3.5 -1.281,2.281 -1.958,4.853 -0.667,2.563 -0.656,4.583 h -2.823 q 0.073,-3.166 1.302,-6.457 1.24,-3.292 3.302,-5.885 z"
-     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777777;fill-opacity:1;stroke-width:1.33333" /><path
-     id="path1060"
-     d="m 637.15,189.175 3,-0.292 q 0.271,1.51 1.094,2.219 0.833,0.708 2.24,0.708 1.49,0 2.239,-0.625 0.76,-0.635 0.76,-1.479 0,-0.541 -0.322,-0.916 -0.313,-0.386 -1.105,-0.667 -0.541,-0.187 -2.468,-0.667 -2.48,-0.614 -3.479,-1.51 -1.406,-1.26 -1.406,-3.073 0,-1.166 0.656,-2.176 0.667,-1.021 1.906,-1.552 1.25,-0.532 3.01,-0.532 2.875,0 4.323,1.26 1.458,1.261 1.531,3.365 l -3.083,0.135 q -0.198,-1.177 -0.854,-1.687 -0.646,-0.52 -1.948,-0.52 -1.344,0 -2.104,0.551 -0.49,0.354 -0.49,0.948 0,0.542 0.459,0.927 0.583,0.49 2.833,1.02 2.25,0.532 3.323,1.105 1.083,0.562 1.687,1.552 0.614,0.979 0.614,2.427 0,1.312 -0.729,2.458 -0.729,1.146 -2.062,1.708 -1.333,0.552 -3.323,0.552 -2.895,0 -4.447,-1.333 -1.552,-1.344 -1.854,-3.906"
-     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777777;fill-opacity:1;stroke-width:1.33333" /><path
-     id="path1062"
-     d="m 652.056,194.143 v -15.27 h 2.927 v 8.104 l 3.427,-3.895 h 3.603 l -3.78,4.041 4.051,7.02 h -3.156 l -2.78,-4.968 -1.365,1.427 v 3.541 z"
-     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777777;fill-opacity:1;stroke-width:1.33333" /><path
-     d="m 673.8724,191.37182 v 2.71874 H 663.612 q 0.16667,-1.54166 1,-2.91666 0.83333,-1.38542 3.29166,-3.66666 1.97916,-1.84375 2.42708,-2.5 0.60416,-0.90625 0.60416,-1.79166 0,-0.97917 -0.53125,-1.5 -0.52083,-0.53125 -1.44791,-0.53125 -0.91666,0 -1.45833,0.55208 -0.54167,0.55209 -0.625,1.83333 l -2.91666,-0.29166 q 0.26041,-2.41666 1.63541,-3.46875 1.375,-1.05208 3.4375,-1.05208 2.26041,0 3.55207,1.21875 1.29167,1.21875 1.29167,3.03125 0,1.03124 -0.375,1.96874 -0.36458,0.92708 -1.16667,1.94792 -0.53124,0.67708 -1.91666,1.94791 -1.38541,1.27083 -1.76041,1.6875 -0.36459,0.41666 -0.59375,0.8125 z"
-     id="text2"
-     style="font-weight:bold;font-size:21.3333px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';fill:#777777;stroke-width:0.88063;stroke-opacity:0.866667"
-     aria-label="2" /></g></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" id="svg44789" width="1135.802" height="370.335" x="0" y="0" version="1.1" viewBox="0 0 1135.802 370.335">
+  <defs id="defs44793">
+    <path id="rect45099" d="M693.814 141.868h20.469v59.994h-20.469z"/>
+  </defs>
+  <font id="font44536" horiz-adv-x="1000" horiz-origin-x="0" horiz-origin-y="0" vert-adv-y="1024" vert-origin-x="512" vert-origin-y="768">
+    <font-face id="font-face44522" font-family="'Maestro'" underline-position="-78" underline-thickness="9" units-per-em="1000">
+      <font-face-src>
+        <font-face-name name="Maestro"/>
+      </font-face-src>
+    </font-face>
+    <glyph id="glyph44526" d="M466-252c-19-3-38-5-59-6s-42 0-62 2c-20 1-38 4-55 7q-25.5 4.5-42 12c-51 25-93 51-124 79-32 27-57 56-74 86Q24.5-27 14 21C7 52 2 84 0 116c-3 35 1 69 10 104s21 68 37 100q22.5 46.5 54 87c20 27 40 50 61 70 24 23 49 45 76 68 26 22 55 45 86 68-1 9-1 16-2 23s-3 14-4 21-3 14-4 23c-2 9-3 19-4 32 0 5-1 15-2 30-1 14-2 31-2 52-1 20 0 43 1 69s5 53 10 81c3 17 11 38 22 64 11 25 24 50 39 74s30 45 47 62 32 26 47 26c7 0 15-4 24-13s17-21 26-36q12-22.5 24-51c8-19 15-39 21-59s11-40 15-59q4.5-28.5 6-51c1-35-1-65-4-91-3-27-8-50-15-71s-14-41-23-58c-9-18-19-36-29-54-11-18-21-34-32-47-11-14-23-28-34-42-12-15-24-27-37-36-13-10-26-21-39-32 6-34 11-65 16-92 2-12 4-24 6-35s4-22 5-31c1-10 3-18 4-24 1-7 2-11 2-12 16 2 33 2 50 1 17-2 33-5 49-8 15-3 29-8 42-13 12-5 22-10 29-15 36-27 62-57 77-91 15-35 23-70 26-106 2-28 0-56-7-84q-10.5-43.5-33-81c-16-26-36-50-61-71s-55-39-89-53c4-27 8-53 11-76 3-20 6-39 9-58s5-33 6-40c6-40 8-73 7-98q-1.5-39-15-63c-7-13-16-26-25-39-10-13-22-24-35-34s-29-18-46-25c-18-7-38-11-61-12-17-1-38 0-62 5-24 4-47 12-69 23s-41 25-57 44q-24 28.5-27 69c-1 16 0 32 3 49 3 16 9 31 18 44 8 13 19 23 33 32 13 9 30 14 50 15 12 1 24-1 37-5 12-5 23-11 34-19s19-18 26-30q10.5-18 12-39c2-25-6-48-23-71s-47-41-88-52c7-9 19-18 38-26 19-9 42-13 70-13 29 0 58 9 85 26s47 39 62 65c9 17 14 40 14 68 0 27-2 55-5 83-1 5-3 16-6 35q-4.5 27-9 57-4.5 34.5-12 78m21 1267c-26 0-49-12-68-36q-30-37.5-48-93c-13-37-21-78-25-123q-6-67.5 3-129c22 17 45 37 69 61q36 34.5 66 75 28.5 40.5 48 81 18 40.5 15 78c-1 8-2 17-4 27s-5 19-10 28-11 16-18 22-17 9-28 9m-2-1226c29 10 51 23 67 39s28 33 36 52c7 19 12 37 13 56s1 35 0 50c-1 12-4 27-8 45-5 18-13 35-25 52q-18 25.5-51 42c-22 11-51 15-88 13m-26-2c-27-1-50-7-67-16-18-10-32-22-42-35-11-14-18-29-21-44-4-15-6-29-5-41s3-24 8-37 11-24 19-35c7-11 16-21 25-30s18-16 27-21l-3-3-4-4c-1-1-2-3-3-4q-31.5 15-54 36c-16 13-26 23-31 29-7 10-14 19-19 27s-10 17-13 26-6 18-8 29c-3 11-4 23-5 38q-1.5 21 3 45c3 15 9 31 17 47 7 16 17 32 30 47 12 15 26 29 43 42 9 7 17 12 24 16s13 8 19 11 12 5 19 7c6 1 13 3 20 5l-30 181c-8-5-21-14-39-28s-38-31-59-50-42-40-63-62c-21-23-39-44-52-65-24-38-43-73-56-105S65 75 68 38q4.5-63 39-117c23-37 52-67 88-92q54-37.5 123-51c46-10 94-9 143 3-11 66-20 125-29 177-4 22-8 44-11 65q-4.5 31.5-9 57c-3 17-6 30-7 41-1 10-2 15-2 15" horiz-adv-x="709" unicode="&amp;"/>
+    <glyph id="glyph44528" d="M31 20q0 21 15 36c10 9 22 14 37 14s27-5 37-14q15-15 15-36t-15-36c-10-10-22-15-37-15s-27 5-37 15Q31-1 31 20" horiz-adv-x="155" unicode="."/>
+    <glyph id="glyph44530" d="M15 287c0-25 6-50 18-77s25-50 40-71c17-23 35-48 54-74 19-27 39-56 58-89 8-14 16-29 23-46s14-34 20-51 11-34 15-49c3-15 6-28 7-38 3-21 6-41 8-61 1-21 2-41 1-60-1-61-12-118-31-170l-12 2c9 23 16 51 21 82 4 31 6 61 6 89 0 24-2 50-6 79s-10 55-19 80c-15 45-34 80-55 106s-40 44-55 54Q91.5 3.5 75 11q-16.5 6-30 9c-11 3-21 4-30 5H1v262z" horiz-adv-x="330" unicode="j"/>
+    <glyph id="glyph44532" d="M319 251V107H1v144z" horiz-adv-x="319" unicode="∑"/>
+    <glyph id="glyph44534" d="M8-1c7 18 17 35 31 50 13 15 29 29 47 41 18 11 37 20 58 27q31.5 9 63 9c21 0 40-3 56-10s29-17 38-28c9-12 15-26 18-41 2-16 0-33-7-51s-17-35-31-50c-14-16-30-30-48-41-18-12-37-21-58-27-21-7-42-10-63-10s-40 4-55 11c-16 7-29 16-38 28Q4-75 1-51C-1-36 1-19 8-1" horiz-adv-x="319" unicode="œ"/>
+  </font>
+  <font id="font44572" horiz-adv-x="2048" horiz-origin-x="0" horiz-origin-y="0" vert-adv-y="1024" vert-origin-x="512" vert-origin-y="768">
+    <font-face id="font-face44538" font-family="'Times New Roman'" underline-position="-223" underline-thickness="100" units-per-em="2048">
+      <font-face-src>
+        <font-face-name name="Times New Roman"/>
+      </font-face-src>
+    </font-face>
+    <glyph id="glyph44542" horiz-adv-x="512"/>
+    <glyph id="glyph44544" d="M535 141v499H37v82h498v497h80V722h500v-82H615V141z" horiz-adv-x="1155" unicode="+"/>
+    <glyph id="glyph44546" d="M74 670c0 155 23 288 70 400q70.5 166.5 186 249c60 43 122 65 186 65 104 0 197-53 280-159 103-131 155-309 155-534 0-157-23-291-68-401S780 100 710 51Q603.5-24 506-24c-129 0-237 76-323 229C110 334 74 489 74 670m196-25c0-187 23-339 69-457 38-99 95-149 170-149 36 0 73 16 112 49 39 32 68 86 88 162 31 115 46 276 46 485q0 232.5-48 387c-24 77-55 131-93 163q-40.5 33-99 33c-45 0-86-20-121-61-48-55-81-142-98-261s-26-236-26-351" horiz-adv-x="1024" unicode="0"/>
+    <glyph id="glyph44548" d="m240 1223 330 161h33V239c0-76 3-123 10-142 6-19 19-33 39-43s61-16 122-17V0H264v37c64 1 105 7 124 17q28.5 13.5 39 39c7 16 11 65 11 146v732c0 99-3 162-10 190-5 21-13 37-25 47q-19.5 15-45 15c-25 0-59-10-103-31z" horiz-adv-x="1024" unicode="1"/>
+    <glyph id="glyph44550" d="M939 261 844 0H44v37c235 215 401 390 497 526s144 260 144 373c0 86-26 157-79 212s-116 83-189 83c-67 0-126-19-179-58s-93-97-118-172H83c17 123 60 218 129 284q103.5 99 258 99c110 0 202-35 276-106 73-71 110-154 110-250 0-69-16-137-48-206-49-108-129-222-240-343-166-181-270-291-311-328h354c72 0 123 3 152 8q43.5 7.5 78 33c23 16 44 39 61 69z" horiz-adv-x="1024" unicode="2"/>
+    <glyph id="glyph44552" d="M104 1098c39 91 88 162 147 212 59 49 132 74 220 74 109 0 192-35 250-106 44-53 66-109 66-169q0-148.5-186-306c83-33 146-79 189-140s64-132 64-214c0-117-37-219-112-305Q596.5-24 319-24c-91 0-153 11-186 34S83 57 83 83q0 28.5 24 51c15 15 34 22 56 22 17 0 34-3 51-8 11-3 37-15 77-36s68-34 83-38c25-7 51-11 79-11 68 0 127 26 178 79 50 53 75 115 75 187 0 53-12 104-35 154-17 37-36 66-57 85-29 27-68 51-118 73-50 21-101 32-153 32h-32v30q79.5 10.5 159 57c53 31 91 69 115 113s36 92 36 145c0 69-21 124-64 167-43 42-97 63-161 63-103 0-190-55-259-166z" horiz-adv-x="1024" unicode="3"/>
+    <glyph id="glyph44554" d="M953 500V358H771V0H606v358H32v128l629 898h110V500m-165 0v673L130 500z" horiz-adv-x="1024" unicode="4"/>
+    <glyph id="glyph44556" d="m889 1356-78-170H403l-89-182c177-26 317-92 420-197 89-91 133-197 133-320 0-71-14-137-43-198s-66-112-110-155-93-77-147-103C490-6 412-24 331-24q-121.5 0-177 42c-37 27-56 58-56 91 0 19 8 35 23 50 15 14 35 21 58 21 17 0 33-3 46-8s35-19 66-41c50-35 101-52 152-52 78 0 147 30 206 89s88 130 88 215c0 82-26 159-79 230S533 738 440 777c-73 30-172 47-297 52l260 527z" horiz-adv-x="1024" unicode="5"/>
+    <glyph id="glyph44558" d="M918 1384v-37c-88-9-160-26-215-52-56-27-111-67-165-121q-82.5-81-135-180-54-100.5-90-237c96 66 192 99 289 99 93 0 173-37 241-112q102-112.5 102-288c0-113-34-217-103-310C759 33 650-24 514-24c-93 0-171 31-236 92C151 187 88 342 88 532c0 121 24 237 73 346s118 206 209 291c90 85 176 142 259 171s160 44 231 44M296 684c-12-90-18-163-18-218 0-64 12-133 36-208 23-75 58-135 105-179 34-31 75-47 124-47 58 0 110 27 156 82 45 55 68 133 68 234 0 114-23 213-68 296S589 769 506 769c-25 0-52-5-81-16q-43.5-16.5-129-69" horiz-adv-x="1024" unicode="6"/>
+    <glyph id="glyph44560" d="M206 1356h727v-38L481-28H369l405 1221H401c-75 0-129-9-161-27-56-31-101-78-135-142l-29 11z" horiz-adv-x="1024" unicode="7"/>
+    <glyph id="glyph44562" d="M393 683c-107 88-176 159-207 212s-47 109-47 166q0 132 102 228c68 63 158 95 271 95 109 0 197-30 264-89s100-127 100-203c0-51-18-102-54-155q-54-79.5-225-186c117-91 195-162 233-214 51-68 76-140 76-215 0-95-36-177-109-244C724 10 629-24 511-24 382-24 282 16 210 97c-57 65-86 135-86 212 0 60 20 120 61 179 40 59 109 124 208 195m157 107c80 72 131 129 152 171 21 41 32 88 32 141 0 70-20 125-59 165-39 39-93 59-161 59s-123-20-166-59-64-85-64-138c0-35 9-69 27-104q25.5-52.5 75-99m54-281c-55-47-96-97-123-152s-40-115-40-179c0-86 24-155 71-206 47-52 106-78 179-78 72 0 130 20 173 61s65 90 65 148c0 48-13 91-38 129-47 71-143 163-287 277" horiz-adv-x="1024" unicode="8"/>
+    <glyph id="glyph44564" d="M108-28V9c87 1 167 22 242 61s147 107 217 204c69 97 118 204 145 321-105-67-199-101-284-101-95 0-177 37-245 111-68 73-102 171-102 293 0 119 34 224 102 317 82 113 189 169 321 169 111 0 207-46 286-138 97-114 146-255 146-422 0-151-37-291-111-421-74-131-177-239-309-325C409 7 292-28 165-28m563 697c12 87 18 156 18 208q0 97.5-33 210c-22 75-53 132-93 172q-61.5 60-138 60c-59 0-111-27-156-80s-67-133-67-238c0-141 30-251 89-330 43-57 97-86 160-86 31 0 67 7 109 22s79 35 111 62" horiz-adv-x="1024" unicode="9"/>
+    <glyph id="glyph44566" d="M838 0 314 1141V235q0-124.5 27-156 37.5-42 117-42h48V0H34v37h48c57 0 98 17 122 52 15 21 22 70 22 146v886c0 60-7 103-20 130-9 19-26 36-51 49s-66 19-121 19v37h384L910 295l484 1061h384v-37h-47c-58 0-99-17-123-52-15-21-22-70-22-146V235c0-83 9-135 28-156q37.5-42 117-42h47V0h-576v37h48c58 0 99 17 122 52 15 21 22 70 22 146v906L871 0z" horiz-adv-x="1821" unicode="M"/>
+    <glyph id="glyph44568" d="M939 1387V918h-37c-12 90-33 162-64 215s-76 96-133 127-117 47-178 47c-69 0-127-21-172-63-45-43-68-91-68-145 0-41 14-79 43-113 41-50 140-117 295-200 127-68 213-120 260-156 46-37 82-80 107-129s37-101 37-155c0-103-40-191-119-265C830 6 727-31 602-31q-58.5 0-111 9c-21 3-63 16-128 37S256 46 239 46q-25.5 0-39-15c-10-10-17-31-22-62h-37v465h37c17-97 41-170 70-218 29-49 74-89 135-121q90-48 198-48 124.5 0 198 66 72 66 72 156c0 33-9 67-27 101-19 34-47 66-86 95-26 20-97 63-213 128S327 709 278 748s-87 81-112 128-38 98-38 154c0 97 37 181 112 252q112.5 105 285 105c72 0 148-18 229-53 37-17 64-25 79-25 17 0 32 5 43 16 11 10 19 31 26 62z" horiz-adv-x="1139" unicode="S"/>
+    <glyph id="glyph44570" d="M335 1422V511l233 212c49 45 78 74 86 86 5 8 8 16 8 24 0 13-5 25-16 35-11 9-30 15-55 16v32h398v-32c-55-1-100-10-136-25-37-15-77-43-120-82L498 560l235-297q97.5-123 132-156c32-31 60-52 84-61 17-7 46-10 87-10V0H591v36c25 1 43 5 52 12s13 16 13 29c0 15-13 40-40 74L335 510V206c0-59 4-98 13-117 8-19 20-32 35-40s49-12 100-13V0H17v36c47 0 82 6 105 17 14 7 25 19 32 34q15 33 15 114v834c0 106-2 171-7 195-5 23-12 40-23 49s-25 13-42 13c-14 0-35-6-63-17l-17 35 272 112z" horiz-adv-x="1024" unicode="k"/>
+  </font>
+  <font id="font44586" horiz-adv-x="2048" horiz-origin-x="0" horiz-origin-y="0" vert-adv-y="1024" vert-origin-x="512" vert-origin-y="768">
+    <font-face id="font-face44574" font-family="'Times New Roman'" font-style="italic" underline-position="-223" underline-thickness="100" units-per-em="2048">
+      <font-face-src>
+        <font-face-name name="Times New Roman Kursiv"/>
+      </font-face-src>
+    </font-face>
+    <glyph id="glyph44578" d="M708 1384c85 0 157-36 216-107 58-71 87-184 87-338 0-132-22-267-65-404q-64.5-205.5-183-357C700 99 635 41 566 6c-40-20-86-30-139-30-87 0-159 36-217 107-59 71-88 184-88 339 0 153 29 306 88 460 69 180 156 317 263 410 70 61 148 92 235 92m1-52q-58.5 0-117-45c-40-31-81-94-123-190-43-96-83-220-122-371-50-198-75-367-75-506 0-69 15-121 45-155 30-35 66-52 109-52 41 0 75 13 104 40 77 72 142 195 197 369 89 285 133 516 133 694 0 74-15 129-45 164s-65 52-106 52" horiz-adv-x="1024" unicode="0"/>
+    <glyph id="glyph44580" d="M855 1384 533 263c-19-66-28-114-28-143 0-25 9-43 26-56s56-22 119-27L640 0H125l14 37c55 1 91 6 108 13q42 18 63 48c22 31 44 86 67 165l232 805c14 49 22 77 23 84q3 19.5 3 39c0 23-6 42-19 55s-30 20-52 20q-25.5 0-81-12l-13 36 337 94z" horiz-adv-x="1024" unicode="1"/>
+    <glyph id="glyph44582" d="M691 759q96-103.5 141-195c29-61 44-121 44-182 0-109-41-203-124-284S567-24 446-24C337-24 249 9 181 75 112 141 78 218 78 306q0 112.5 84 222 82.5 109.5 315 210-88.5 109.5-120 180c-21 47-32 94-32 141 0 89 33 165 100 229 66 64 149 96 250 96 96 0 174-28 235-83s91-120 91-194c0-73-24-140-73-200S800 798 691 759m-39 42c72 25 128 65 168 121 39 56 59 120 59 193 0 68-19 122-57 161-39 39-89 58-151 58-59 0-107-19-144-56s-55-86-55-145c0-45 10-86 29-124 28-56 78-125 151-208M514 697c-99-41-174-101-225-179-51-79-77-163-77-253 0-73 23-131 68-175 45-45 104-67 177-67 76 0 140 27 192 80s78 117 78 191q0 84-45 177c-31 61-87 137-168 226" horiz-adv-x="1024" unicode="8"/>
+    <glyph id="glyph44584" d="M59-24V8c69 15 128 36 179 64q135 73.5 243 183c71 73 135 157 191 253-41-20-72-33-95-39s-48-9-76-9c-101 0-178 34-231 103s-80 149-80 240c0 159 52 296 156 410q154.5 171 330 171c106 0 187-40 244-119 57-80 85-173 85-280 0-135-31-269-94-401S763 338 656 243 436 77 318 31C248 4 162-15 59-24m663 615c94 191 141 361 141 511 0 73-18 129-53 169-36 40-78 60-125 60-79 0-150-55-215-165s-98-241-98-392c0-80 19-140 56-181s83-62 139-62c25 0 49 4 70 12 21 7 50 23 85 48" horiz-adv-x="1024" unicode="9"/>
+  </font>
+  <path id="line44608" d="M864.387 177.165v19.76" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <path id="line44610" d="M929.254 177.165v19.76" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <path id="line44612" d="M170.44 177.165h793.896" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <path id="line44614" d="M170.44 182.105h793.896" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <path id="line44616" d="M170.44 187.045h793.896" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <path id="line44618" d="M170.44 191.985h793.896" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <path id="line44620" d="M170.44 196.925h793.896" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <g id="g5" class="supplied staffN">
+    <g id="text44622" aria-label="18" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" transform="translate(22.677)">
+      <path id="path951" d="m92.683 191.985 1.213-5.788q-.784.617-2.206.988l.178-.857q.705-.283 1.39-.737.69-.455 1.035-.795.21-.21.398-.507h.549l-1.605 7.696z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path953" d="M98.481 187.77q-.428-.234-.643-.6-.214-.372-.214-.795 0-.695.502-1.286.669-.8 1.814-.8 1.009 0 1.59.544.58.538.58 1.322 0 .56-.314 1.01t-.983.716q.46.287.659.611.256.424.256.988 0 1.03-.732 1.836-.727.805-1.94.805-.967 0-1.579-.596-.611-.596-.611-1.49 0-.842.434-1.443.434-.607 1.181-.821m.073-1.353q0 .491.314.794.32.298.873.298.649 0 1.051-.392.408-.397.408-.972 0-.486-.319-.79-.314-.308-.868-.308-.418 0-.768.193-.35.194-.523.528-.168.33-.168.649m-.737 3.696q0 .319.152.612.157.293.47.465.314.173.717.173.768 0 1.244-.722.376-.565.376-1.218 0-.533-.35-.873-.345-.34-.91-.34-.71 0-1.207.528-.492.528-.492 1.375" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    </g>
+  </g>
+  <g id="text44672" aria-label="j" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path964" d="M822.072 156.674h-.277v5.177h.277s.968.04 1.837.632c.593.395 1.581 1.403 2.174 3.162.336.968.494 2.193.494 3.142 0 1.106-.178 2.47-.534 3.379l.237.039c.396-1.047.593-2.174.613-3.36.02-.77-.06-1.58-.178-2.39-.099-.81-.632-2.55-1.284-3.636-.77-1.284-1.561-2.312-2.213-3.22-.573-.811-1.146-1.957-1.146-2.925" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44674" d="M821.483 173.871v-16.466" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <g id="text44676" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path968" d="M815.265 174.714c-.533 1.403.395 2.569 2.055 2.588s3.419-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44678" d="M838.952 166.46v-13.173" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <path id="line44680" d="M831.34 172.225h9.057" style="fill:none;stroke:#000;stroke-width:.81733102"/>
+  <path id="line44682" d="M831.34 167.285h9.057" style="fill:none;stroke:#000;stroke-width:.81733102"/>
+  <g id="text44684" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path974" d="M832.734 167.305c-.534 1.402.395 2.568 2.055 2.588s3.418-1.106 3.952-2.53c.513-1.402-.396-2.548-2.075-2.568-1.66-.02-3.419 1.107-3.932 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44688" d="M871.3 172.225h9.056" style="fill:none;stroke:#000;stroke-width:.81733102"/>
+  <g id="text44690" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path978" d="M872.693 169.774c-.533 1.403.395 2.569 2.055 2.588s3.419-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44692" d="M878.911 168.931V153.7" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <path id="line44694" d="M882.62 172.225h9.058" style="fill:none;stroke:#000;stroke-width:.81733102"/>
+  <g id="text44696" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path983" d="M884.014 172.245c-.533 1.402.396 2.568 2.055 2.588s3.419-1.106 3.952-2.53c.514-1.402-.395-2.548-2.074-2.568-1.66-.02-3.419 1.107-3.933 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44698" d="M890.232 171.4v-15.23" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <path id="path44700" d="m878.62 152.465 11.903 2.47v2.47l-11.903-2.47z" style="fill:#000;fill-rule:nonzero;stroke:none;stroke-width:1.33333004"/>
+  <g id="text44702" aria-label="." style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path987" d="M902.817 179.65c0 .554.454 1.009 1.027 1.009s1.028-.455 1.028-1.008-.455-.988-1.028-.988-1.027.435-1.027.988" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44704" d="M900.347 181.28v-13.173" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <g id="text44706" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path991" d="M894.13 182.125c-.534 1.402.394 2.568 2.054 2.588s3.419-1.106 3.952-2.53c.514-1.402-.395-2.548-2.075-2.568-1.66-.02-3.418 1.107-3.932 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text44708" aria-label="j" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path994" d="M922.311 156.674h-.276v5.177h.276s.969.04 1.838.632c.593.395 1.58 1.403 2.174 3.162.335.968.494 2.193.494 3.142 0 1.106-.178 2.47-.534 3.379l.237.039c.395-1.047.593-2.174.613-3.36.02-.77-.06-1.58-.178-2.39-.099-.81-.632-2.55-1.285-3.636-.77-1.284-1.56-2.312-2.213-3.22-.573-.811-1.146-1.957-1.146-2.925" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44710" d="M921.723 173.871v-16.466" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <g id="text44712" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path998" d="M915.505 174.714c-.534 1.403.395 2.569 2.055 2.588s3.419-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44714" d="M878.911 198.571v-16.466" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <g id="text44716" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1002" d="M872.693 199.414c-.533 1.403.395 2.569 2.055 2.588s3.419-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44718" d="M912.196 201.04v-21.406" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <g id="text44720" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1006" d="M905.978 196.944c-.533 1.403.396 2.57 2.055 2.589s3.419-1.107 3.952-2.53c.514-1.402-.395-2.548-2.074-2.568-1.66-.02-3.419 1.106-3.933 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44722" d="M904.586 201.865h9.056" style="fill:none;stroke:#000;stroke-width:.81733102"/>
+  <g id="text44724" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1010" d="M905.978 201.884c-.533 1.403.396 2.57 2.055 2.589s3.419-1.107 3.952-2.53c.514-1.402-.395-2.548-2.074-2.568-1.66-.02-3.419 1.106-3.933 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text44738" aria-label="j" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1013" d="M961.67 151.734h-.277v5.177h.277s.968.04 1.838.632c.592.395 1.58 1.403 2.173 3.162.336.968.494 2.193.494 3.142 0 1.106-.178 2.47-.533 3.379l.237.039c.395-1.047.593-2.174.612-3.36.02-.77-.059-1.58-.178-2.39-.098-.81-.632-2.55-1.284-3.636-.77-1.284-1.561-2.312-2.213-3.22-.573-.811-1.146-1.957-1.146-2.925" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44740" d="M961.083 168.931v-16.466" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <g id="text44742" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1017" d="M954.865 169.774c-.534 1.403.395 2.569 2.055 2.588s3.418-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text44744" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1020" d="M965.631 169.774c-.533 1.403.395 2.569 2.055 2.588s3.419-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44746" d="M971.849 168.931V153.7" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <g id="text44748" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1024" d="M973.388 174.714c-.534 1.403.395 2.569 2.055 2.588s3.418-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line44750" d="M979.606 173.871V156.17" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+  <path id="path44752" d="m971.586 152.465 8.312 2.47v2.47l-8.312-2.47z" style="fill:#000;fill-rule:nonzero;stroke:none;stroke-width:1.66701996"/>
+  <path id="path44764" d="M984.26 158.433v19.76" style="fill:none;stroke:#000;stroke-width:.719998"/>
+  <g id="g4" class="supplied measureN" transform="translate(37.677)">
+    <g id="text44686" aria-label="9" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333">
+      <path id="path1028" d="m771.565 115.221.889-.089q.089.643.366.915t.658.272q.544 0 1.01-.47.684-.69 1.008-1.982-.475.356-.846.507-.366.152-.753.152-.7 0-1.255-.47-.732-.612-.732-1.757 0-1.297.847-2.222.727-.795 1.783-.795.951 0 1.579.706.627.7.627 1.987 0 1.25-.418 2.467-.497 1.433-1.344 2.112-.69.555-1.553.555-.794 0-1.301-.492-.502-.496-.565-1.396m1.26-3.032q0 .721.382 1.15.386.429.914.429.393 0 .78-.267.386-.266.663-.794.278-.534.278-1.093 0-.44-.183-.816t-.502-.564q-.314-.194-.638-.194-.314 0-.617.167-.303.168-.565.492-.256.324-.387.748-.125.418-.125.742" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    </g>
+    <g id="text44726" aria-label="10" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333">
+      <path id="path1031" d="m828.997 116.978 1.213-5.788q-.785.617-2.207.988l.178-.857q.706-.282 1.39-.737.691-.455 1.036-.795.21-.209.397-.507h.55l-1.606 7.696z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1033" d="M833.138 114.463q0-.972.287-1.976.293-1.004.648-1.605t.738-.941.747-.497q.371-.162.821-.162.878 0 1.464.654.59.653.59 1.887 0 1.27-.407 2.515-.481 1.474-1.339 2.211-.658.56-1.5.56-.863 0-1.459-.675-.59-.68-.59-1.97m.914.24q0 .706.236 1.104.319.549.946.549.549 0 .999-.497.648-.7.972-2.05.33-1.353.33-2.21 0-.827-.32-1.193-.313-.366-.83-.366-.377 0-.707.194-.324.193-.622.664-.423.664-.737 1.986-.267 1.13-.267 1.82" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    </g>
+    <g id="text44766" aria-label="11" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333">
+      <path id="path1036" d="m894.863 117.094 1.213-5.788q-.784.617-2.206.988l.178-.857q.705-.282 1.39-.737.69-.455 1.036-.795.209-.21.397-.507h.549l-1.605 7.696z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1038" d="m900.029 117.094 1.213-5.788q-.785.617-2.207.988l.178-.857q.706-.282 1.39-.737.691-.455 1.036-.795.21-.21.397-.507h.55l-1.606 7.696z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    </g>
+  </g>
+  <g id="g3" class="supplied foliation">
+    <g id="text297" aria-label="A: Bl. 2r" style="font-size:10.66670036px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;letter-spacing:0;word-spacing:0;opacity:.604762">
+      <path id="path1067" d="M118.943 115.406h-3.026l-.917 1.688h-1.614l4.318-7.636h1.744l1.24 7.636h-1.49zm-.193-1.27-.442-3.074-1.844 3.073z" style="font-style:italic;font-variant:normal;font-weight:700;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1069" d="M123.12 111.562h1.474l-.302 1.448h-1.474zm-.854 4.089h1.48l-.303 1.443h-1.479z" style="font-style:italic;font-variant:normal;font-weight:700;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1071" d="m128.198 117.094 1.6-7.636h2.364q.646 0 .958.052.51.089.86.313.354.219.547.604.192.38.192.844 0 .63-.349 1.11-.343.478-1.057.728.62.203.927.615.307.406.307.953 0 .63-.364 1.208-.36.579-.959.896-.593.313-1.328.313zm1.938-4.375h1.547q1.11 0 1.594-.354.49-.355.49-1.032 0-.323-.152-.557-.151-.234-.406-.339-.25-.109-.948-.109h-1.625zm-.734 3.51h1.74q.692 0 .931-.047.485-.083.787-.281.302-.203.474-.531t.172-.688q0-.536-.339-.812-.333-.282-1.276-.282h-1.937z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1073" d="m135.141 117.094 1.594-7.636h.943l-1.594 7.636z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1075" d="m137.85 117.094.223-1.068h1.068l-.229 1.068z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1077" d="M143.777 117.094q.145-.683.4-1.14.261-.464.688-.876.427-.417 1.646-1.39.74-.59 1.01-.87.391-.407.568-.797.12-.266.12-.578 0-.526-.375-.891-.37-.37-.912-.37-.536 0-.937.375-.401.37-.573 1.193l-.922-.135q.136-1.016.787-1.6.656-.588 1.63-.588.65 0 1.177.27.531.272.797.761.265.49.265 1.01 0 .761-.541 1.464-.334.438-1.959 1.724-.698.552-1.041.906-.339.355-.51.667h3.416l-.182.865z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1079" d="m149.32 112.827.75-3.595h.543l-.153.734q.278-.416.542-.616.267-.2.545-.2.183 0 .45.132l-.25.57q-.16-.116-.35-.116-.32 0-.66.359-.338.359-.53 1.29l-.305 1.442z" style="font-size:64.99999762%;baseline-shift:super"/>
+    </g>
+  </g>
+  <g id="text1141" aria-label="M 38 Sk2 T. 9–11" style="font-style:italic;font-size:10.66670036px;line-height:1.25;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;letter-spacing:0;word-spacing:0">
+    <path id="path1082" d="M113.97 87.239V75.786h3.46l2.078 7.812 2.055-7.812h3.469v11.453h-2.149v-9.016l-2.273 9.016h-2.227l-2.265-9.016v9.016z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+    <path id="path1084" d="m131.22 84.2 2.124-.258q.102.813.547 1.242t1.078.43q.68 0 1.14-.516.47-.515.47-1.39 0-.828-.446-1.313-.445-.484-1.086-.484-.422 0-1.008.164l.243-1.79q.89.024 1.359-.382.469-.414.469-1.094 0-.578-.344-.922-.344-.343-.914-.343-.563 0-.961.39t-.484 1.14l-2.024-.343q.211-1.039.633-1.656.43-.625 1.188-.977.765-.359 1.71-.359 1.618 0 2.594 1.031.805.844.805 1.906 0 1.508-1.649 2.407.985.21 1.57.945.595.734.595 1.773 0 1.508-1.102 2.57-1.102 1.063-2.742 1.063-1.555 0-2.578-.89-1.024-.899-1.188-2.344" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+    <path id="path1086" d="M142.086 81.06q-.851-.36-1.242-.985-.383-.633-.383-1.383 0-1.281.89-2.117.9-.836 2.548-.836 1.633 0 2.531.836.906.836.906 2.117 0 .797-.414 1.422-.414.617-1.164.945.953.383 1.446 1.117.5.735.5 1.696 0 1.586-1.016 2.578-1.008.992-2.688.992-1.562 0-2.601-.82-1.227-.969-1.227-2.656 0-.93.461-1.704.461-.78 1.453-1.203m.453-2.212q0 .657.368 1.024.375.367.992.367.625 0 1-.367.375-.375.375-1.031 0-.618-.375-.985-.367-.375-.977-.375-.633 0-1.008.375t-.375.992m-.203 4.907q0 .906.461 1.414.469.507 1.164.507.68 0 1.125-.484.446-.492.446-1.414 0-.805-.453-1.289-.454-.492-1.149-.492-.805 0-1.203.554-.39.555-.39 1.204" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+    <path id="path1088" d="m153.446 83.512 2.25-.218q.203 1.132.82 1.664.625.531 1.68.531 1.117 0 1.68-.469.57-.476.57-1.11 0-.405-.242-.687-.235-.289-.829-.5-.406-.14-1.851-.5-1.86-.46-2.61-1.132-1.054-.946-1.054-2.305 0-.875.492-1.633.5-.766 1.43-1.164.937-.398 2.257-.398 2.157 0 3.243.945 1.093.945 1.148 2.523l-2.312.102q-.149-.883-.641-1.266-.484-.39-1.461-.39-1.008 0-1.578.414-.367.265-.367.71 0 .407.343.696.438.367 2.125.766 1.688.398 2.493.828.812.422 1.265 1.164.461.734.461 1.82 0 .984-.547 1.844t-1.547 1.281q-1 .414-2.492.414-2.172 0-3.336-1-1.164-1.008-1.39-2.93" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+    <path id="path1090" d="M164.625 87.239V75.786h2.196v6.078l2.57-2.922h2.703l-2.836 3.031 3.04 5.266h-2.368l-2.086-3.727-1.023 1.07v2.657z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+    <path id="path1092" d="M180.555 85.2v2.039h-7.695q.125-1.156.75-2.188.625-1.039 2.469-2.75 1.484-1.382 1.82-1.875.453-.68.453-1.343 0-.735-.398-1.125-.391-.399-1.086-.399-.688 0-1.094.414t-.469 1.375l-2.187-.218q.195-1.813 1.226-2.602t2.578-.789q1.696 0 2.664.914.97.914.97 2.273 0 .774-.282 1.477-.274.695-.875 1.461-.399.508-1.438 1.46-1.039.954-1.32 1.267-.273.312-.445.609z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+    <path id="path1094" d="M189.547 87.239v-9.516h-3.398v-1.937h9.101v1.937h-3.39v9.516z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+    <path id="path1096" d="M194.954 87.239v-2.195h2.195v2.195z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+    <path id="path1098" d="m203.407 84.59 2.125-.234q.078.649.406.961.328.313.867.313.68 0 1.156-.625.477-.625.61-2.594-.828.96-2.07.96-1.352 0-2.337-1.038-.976-1.047-.976-2.719 0-1.742 1.031-2.805 1.04-1.07 2.64-1.07 1.743 0 2.86 1.352 1.117 1.343 1.117 4.43 0 3.14-1.164 4.53t-3.031 1.391q-1.344 0-2.172-.71-.828-.72-1.062-2.141m4.968-4.796q0-1.063-.492-1.649-.484-.586-1.125-.586-.61 0-1.015.485-.399.476-.399 1.57 0 1.11.438 1.633.437.515 1.093.515.633 0 1.063-.5.437-.5.437-1.468" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+    <path id="path1100" d="M211.555 83.91v-1.64h8.899v1.64z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+    <path id="path1102" d="M226.79 87.239h-2.196v-8.273q-1.203 1.125-2.836 1.664v-1.993q.86-.28 1.867-1.062 1.008-.79 1.383-1.836h1.781z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+    <path id="path1104" d="M234.82 87.239h-2.195v-8.273q-1.203 1.125-2.836 1.664v-1.993q.86-.28 1.868-1.062 1.007-.79 1.382-1.836h1.782z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+  </g>
+  <g id="g47070" class="supplied clef, supplied key" transform="translate(37.677)">
+    <g id="g1339" transform="translate(694.617 -94.41)">
+      <g id="text1317" aria-label="b" style="font-size:21.86660004px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004">
+        <path id="path1107" d="M66.85 271.537h-.569v12.924c0-.044 2.843-1.99 3.237-2.384.35-.35.874-.721 1.071-1.203.175-.371.306-.852.284-1.312-.022-.874-.721-1.968-1.815-1.946-.918.022-1.377.175-2.208.919v-1.4c.022-2.886 0-5.598 0-5.598m1.771 7.479c.416.459.481 1.159.306 1.815-.153.656-.459 1.071-.853 1.443-.437.415-1.224 1.093-1.224 1.071v-1.88c0-.678-.044-1.618.24-2.165.46-.875 1.247-.612 1.531-.284" style="font-size:21.86660004px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004"/>
+      </g>
+      <g id="g1234" transform="matrix(.75 0 0 .75 49.722 71.408)">
+        <g id="text1224" aria-label="&amp;" style="font-size:21.86660004px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004">
+          <path id="path1110" d="m12.352 291.983.59 3.717c.153 1.225.197 2.558-.196 3.302-.635 1.137-1.947 1.99-3.215 1.99-1.224 0-2.077-.46-2.361-.853 1.814-.503 2.514-1.618 2.427-2.69-.088-1.246-1.334-2.099-2.384-2.033-1.727.131-2.361 1.64-2.274 3.061.153 2.405 3.17 3.17 4.701 3.083 1.99-.13 3.018-1.224 3.652-2.405.372-.7.438-1.793.175-3.52-.087-.657-.568-3.805-.568-3.805 2.995-1.247 4.351-3.849 4.154-6.32-.11-1.552-.7-3.149-2.252-4.307-.612-.438-2.318-.94-3.717-.766-.022-.284-.722-4.242-.722-4.242.547-.481 1.137-.853 1.662-1.487.503-.612.984-1.159 1.443-1.946.897-1.574 1.618-2.952 1.553-5.991-.044-1.968-1.553-5.904-2.537-5.883-1.268.022-3.105 3.477-3.39 4.942-.458 2.471-.174 4.614-.152 5.073.087 1.094.262 1.4.306 2.165a44 44 0 0 0-3.543 2.974c-1.814 1.727-3.76 4.833-3.542 7.894.197 2.82.918 5.576 5.423 7.719.918.437 3.149.59 4.767.328m.46-27.705c.983-.022 1.267 1.202 1.311 1.88.153 2.165-2.427 4.964-4.33 6.45-.502-3.607.766-8.308 3.018-8.33m-1.27 19.177c3.193-.153 3.674 2.252 3.762 3.323.087 1.29-.022 3.455-2.537 4.308zm-.568.043c-.022 0 1.269 7.763 1.269 7.763-4.33 1.028-8.332-1.968-8.594-5.62-.131-1.618.503-2.93 1.553-4.57 1.18-1.837 3.98-4.089 4.657-4.482l.656 3.957c-.656.154-1.028.285-1.793.853-1.465 1.137-2.121 2.755-2.034 3.958.088 1.29.35 1.771.984 2.624.197.263.963.984 1.86 1.421 0 0 .108-.174.218-.24-.81-.416-1.684-1.64-1.728-2.69-.065-1.05.569-2.886 2.952-2.974" style="font-size:21.86660004px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004"/>
+        </g>
+        <g id="g1232" transform="translate(.133 247.042)">
+          <path id="path1228" d="M1.839 53.386H-.758V14.42H1.84" style="fill:none;stroke:#777;stroke-width:.87066698;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+          <path id="path1230" d="M28.635 14.421h2.597v38.965h-2.597" style="fill:none;stroke:#777;stroke-width:.87066698;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+        </g>
+      </g>
+    </g>
+  </g>
+  <g id="g950" class="tkk" transform="translate(37.677)">
+    <g id="text44728" aria-label="j" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+      <path id="path1114" d="M900.953 156.674h-.277v5.177h.277s.968.04 1.837.632c.593.395 1.581 1.403 2.174 3.162.336.968.494 2.193.494 3.142 0 1.106-.178 2.47-.533 3.379l.237.039c.395-1.047.592-2.174.612-3.36.02-.77-.06-1.58-.178-2.39-.098-.81-.632-2.55-1.284-3.636-.77-1.284-1.561-2.312-2.213-3.22-.573-.811-1.146-1.957-1.146-2.925" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+    </g>
+    <path id="line44730" d="M900.866 173.871v-16.466" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+    <g id="text44732" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+      <path id="path1118" d="M894.648 174.714c-.534 1.403.395 2.569 2.055 2.588s3.418-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+    </g>
+    <g id="text44736" aria-label="œ" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+      <path id="path1121" d="M906.028 174.714c-.534 1.403.395 2.569 2.055 2.588s3.418-1.106 3.952-2.529c.514-1.403-.395-2.549-2.075-2.569-1.66-.02-3.418 1.107-3.932 2.51" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+    </g>
+    <g id="text44754" aria-label="œ" style="font-size:14.81999969px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+      <path id="path1124" d="M896.255 174.709c-.4 1.052.296 1.927 1.541 1.941s2.564-.83 2.964-1.897c.386-1.052-.296-1.911-1.556-1.926-1.245-.015-2.564.83-2.949 1.882" style="font-size:14.81999969px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+    </g>
+    <g id="text44758" aria-label="œ" style="font-size:14.81999969px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+      <path id="path1127" d="M908.135 174.709c-.4 1.052.296 1.927 1.541 1.941s2.564-.83 2.964-1.897c.386-1.052-.296-1.911-1.556-1.926-1.245-.015-2.564.83-2.949 1.882" style="font-size:14.81999969px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+    </g>
+    <path id="line44760" d="M912.558 174.077v-15.66" style="fill:none;stroke:#000;stroke-width:.58266503"/>
+    <path id="path44762" d="M900.658 162.032h11.863v1.39h-11.863z" style="fill:#777;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33332992"/>
+    <g id="text939" aria-label="j" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+      <path id="path1131" d="M900.953 156.674h-.277v5.177h.277s.968.04 1.837.632c.593.395 1.581 1.403 2.174 3.162.336.968.494 2.193.494 3.142 0 1.106-.178 2.47-.533 3.379l.237.039c.395-1.047.592-2.174.612-3.36.02-.77-.06-1.58-.178-2.39-.098-.81-.632-2.55-1.284-3.636-.77-1.284-1.561-2.312-2.213-3.22-.573-.811-1.146-1.957-1.146-2.925" style="font-size:19.76000023px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+    </g>
+  </g>
+  <g id="g1" class="link-box">
+    <path id="rect44630" d="M320.491 158.433h141.613v60.309H320.491Z" style="fill:#fff;stroke:#777;stroke-width:.823998;stroke-opacity:1"/>
+    <path id="path1041" d="M346.733 194.143v-15.27h4.614l2.77 10.417 2.74-10.416h4.625v15.27h-2.864v-12.02l-3.031 12.02h-2.969l-3.02-12.02v12.02z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    <path id="path1043" d="m369.731 190.092 2.833-.344q.136 1.083.73 1.656.593.573 1.437.573.906 0 1.52-.688.626-.687.626-1.854 0-1.104-.594-1.75t-1.448-.645q-.562 0-1.344.218l.323-2.385q1.188.031 1.813-.51.625-.552.625-1.458 0-.771-.459-1.23-.458-.458-1.218-.458-.75 0-1.282.521-.53.52-.645 1.52l-2.698-.457q.281-1.386.844-2.209.573-.833 1.583-1.302 1.02-.479 2.281-.479 2.156 0 3.458 1.375 1.073 1.125 1.073 2.542 0 2.01-2.198 3.208 1.313.28 2.094 1.26.791.98.791 2.364 0 2.01-1.468 3.427-1.469 1.417-3.656 1.417-2.073 0-3.438-1.188-1.364-1.197-1.583-3.124" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    <path id="path1045" d="M381.71 181.8v-2.718h10.01v2.125q-1.24 1.219-2.521 3.5-1.282 2.28-1.959 4.853-.666 2.563-.656 4.583h-2.823q.073-3.166 1.302-6.457 1.24-3.292 3.302-5.885z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    <path id="path1047" d="m399.364 189.175 3-.292q.271 1.51 1.094 2.219.833.708 2.24.708 1.489 0 2.239-.625.76-.635.76-1.479 0-.541-.323-.916-.312-.386-1.104-.667-.542-.187-2.469-.667-2.478-.614-3.478-1.51-1.407-1.26-1.407-3.073 0-1.166.657-2.176.666-1.021 1.906-1.552 1.25-.532 3.01-.532 2.875 0 4.323 1.26 1.458 1.261 1.53 3.365l-3.082.135q-.198-1.177-.855-1.687-.645-.52-1.947-.52-1.344 0-2.104.551-.49.354-.49.948 0 .542.458.927.584.49 2.834 1.02 2.25.532 3.322 1.105 1.083.562 1.688 1.552.614.979.614 2.427 0 1.312-.729 2.458-.73 1.146-2.062 1.708-1.334.552-3.323.552-2.896 0-4.448-1.333-1.552-1.344-1.854-3.906" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    <path id="path1049" d="M414.27 194.143v-15.27h2.926v8.104l3.427-3.895h3.604l-3.78 4.041 4.05 7.02h-3.155l-2.781-4.968-1.365 1.427v3.541z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    <path id="text1" d="M432.481 194.208h-2.927v-11.031q-1.604 1.5-3.781 2.219v-2.657q1.146-.375 2.49-1.416 1.343-1.052 1.843-2.448h2.375z" aria-label="1" style="font-weight:700;font-size:21.3333px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;fill:#777;stroke-width:.88063;stroke-opacity:.866667"/>
+  </g>
+  <g id="g2" class="link-box">
+    <path id="rect44646" d="M531.47 157.405h190.601v60.926h-190.6z" style="fill:#fff;stroke:#777;stroke-width:.823998;stroke-opacity:1"/>
+    <path id="path1054" d="M584.52 194.143v-15.27h4.614l2.77 10.417 2.74-10.416h4.624v15.27h-2.864v-12.02l-3.031 12.02h-2.969l-3.02-12.02v12.02z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    <path id="path1056" d="m607.518 190.092 2.833-.344q.135 1.083.729 1.656t1.437.573q.906 0 1.521-.688.625-.687.625-1.854 0-1.104-.594-1.75-.593-.645-1.448-.645-.562 0-1.343.218l.323-2.385q1.187.031 1.812-.51.625-.552.625-1.458 0-.771-.458-1.23-.459-.458-1.219-.458-.75 0-1.281.521-.531.52-.646 1.52l-2.698-.457q.282-1.386.844-2.209.573-.833 1.583-1.302 1.021-.479 2.281-.479 2.156 0 3.458 1.375 1.073 1.125 1.073 2.542 0 2.01-2.198 3.208 1.313.28 2.094 1.26.792.98.792 2.364 0 2.01-1.469 3.427t-3.656 1.417q-2.073 0-3.437-1.188-1.365-1.197-1.583-3.124" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    <path id="path1058" d="M619.496 181.8v-2.718h10.01v2.125q-1.24 1.219-2.521 3.5t-1.958 4.853q-.667 2.563-.656 4.583h-2.823q.073-3.166 1.302-6.457 1.24-3.292 3.302-5.885z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    <path id="path1060" d="m637.15 189.175 3-.292q.271 1.51 1.094 2.219.833.708 2.24.708 1.49 0 2.239-.625.76-.635.76-1.479 0-.541-.322-.916-.313-.386-1.105-.667-.541-.187-2.468-.667-2.48-.614-3.479-1.51-1.406-1.26-1.406-3.073 0-1.166.656-2.176.667-1.021 1.906-1.552 1.25-.532 3.01-.532 2.875 0 4.323 1.26 1.458 1.261 1.531 3.365l-3.083.135q-.198-1.177-.854-1.687-.646-.52-1.948-.52-1.344 0-2.104.551-.49.354-.49.948 0 .542.459.927.583.49 2.833 1.02 2.25.532 3.323 1.105 1.083.562 1.687 1.552.614.979.614 2.427 0 1.312-.729 2.458t-2.062 1.708q-1.333.552-3.323.552-2.895 0-4.447-1.333-1.552-1.344-1.854-3.906" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    <path id="path1062" d="M652.056 194.143v-15.27h2.927v8.104l3.427-3.895h3.603l-3.78 4.041 4.051 7.02h-3.156l-2.78-4.968-1.365 1.427v3.541z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    <path id="text2" d="M673.872 191.372v2.719h-10.26q.167-1.542 1-2.917.833-1.386 3.292-3.667 1.979-1.844 2.427-2.5.604-.906.604-1.791 0-.98-.531-1.5-.521-.532-1.448-.532-.917 0-1.459.552-.541.552-.625 1.834l-2.916-.292q.26-2.417 1.635-3.469t3.438-1.052q2.26 0 3.552 1.219 1.291 1.219 1.291 3.031 0 1.031-.375 1.969-.364.927-1.166 1.948-.532.677-1.917 1.948t-1.76 1.687q-.365.417-.594.813z" aria-label="2" style="font-weight:700;font-size:21.3333px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;fill:#777;stroke-width:.88063;stroke-opacity:.866667"/>
+  </g>
+</svg>

--- a/src/assets/img/edition/series/2/section/2a/m38/M38_Sk3-2von5-final.svg
+++ b/src/assets/img/edition/series/2/section/2a/m38/M38_Sk3-2von5-final.svg
@@ -1,635 +1,269 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xml:space="preserve"
-   id="svg61035"
-   width="1116.961"
-   height="451.57"
-   x="0"
-   y="0"
-   version="1.1"
-   viewBox="0 0 1116.961 451.57"
-   sodipodi:docname="M38_Sk3-2von5-final.svg"
-   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"><defs
-   id="defs1">&#10;    &#10;    &#10;    &#10;    &#10;    &#10;    &#10;    &#10;    &#10;    &#10;    &#10;    &#10;  </defs><sodipodi:namedview
-   id="namedview1"
-   pagecolor="#ffffff"
-   bordercolor="#000000"
-   borderopacity="0.25"
-   inkscape:showpageshadow="2"
-   inkscape:pageopacity="0.0"
-   inkscape:pagecheckerboard="0"
-   inkscape:deskcolor="#d1d1d1"
-   inkscape:zoom="2.9007278"
-   inkscape:cx="168.57838"
-   inkscape:cy="2.4131875"
-   inkscape:window-width="1920"
-   inkscape:window-height="992"
-   inkscape:window-x="-8"
-   inkscape:window-y="-8"
-   inkscape:window-maximized="1"
-   inkscape:current-layer="svg61035" />&#10;  <font
-   id="font60842"
-   horiz-adv-x="1000"
-   horiz-origin-x="0"
-   horiz-origin-y="0"
-   vert-adv-y="1024"
-   vert-origin-x="512"
-   vert-origin-y="768">&#10;    <font-face
-   id="font-face60826"
-   font-family="'Maestro'"
-   underline-position="-78"
-   underline-thickness="9"
-   units-per-em="1000">&#10;      <font-face-src>&#10;        <font-face-name
-   name="Maestro" />&#10;      </font-face-src>&#10;    </font-face>&#10;    <glyph
-   id="glyph60830"
-   d="M72 62V-87l98 32V94M43 156v163h29V166l98 32v146h29V207l39 13V116l-39-13V-45l39 12v-103l-39-13v-163h-29v154l-98-32v-148H43v138L0-214v104l43 14V53L0 39v103z"
-   horiz-adv-x="236"
-   unicode="#" />&#10;    <glyph
-   id="glyph60832"
-   d="M466-252c-19-3-38-5-59-6s-42 0-62 2c-20 1-38 4-55 7q-25.5 4.5-42 12c-51 25-93 51-124 79-32 27-57 56-74 86Q24.5-27 14 21C7 52 2 84 0 116c-3 35 1 69 10 104s21 68 37 100q22.5 46.5 54 87c20 27 40 50 61 70 24 23 49 45 76 68 26 22 55 45 86 68-1 9-1 16-2 23s-3 14-4 21-3 14-4 23c-2 9-3 19-4 32 0 5-1 15-2 30-1 14-2 31-2 52-1 20 0 43 1 69s5 53 10 81c3 17 11 38 22 64 11 25 24 50 39 74s30 45 47 62 32 26 47 26c7 0 15-4 24-13s17-21 26-36q12-22.5 24-51c8-19 15-39 21-59s11-40 15-59q4.5-28.5 6-51c1-35-1-65-4-91-3-27-8-50-15-71s-14-41-23-58c-9-18-19-36-29-54-11-18-21-34-32-47-11-14-23-28-34-42-12-15-24-27-37-36-13-10-26-21-39-32 6-34 11-65 16-92 2-12 4-24 6-35s4-22 5-31c1-10 3-18 4-24 1-7 2-11 2-12 16 2 33 2 50 1 17-2 33-5 49-8 15-3 29-8 42-13 12-5 22-10 29-15 36-27 62-57 77-91 15-35 23-70 26-106 2-28 0-56-7-84q-10.5-43.5-33-81c-16-26-36-50-61-71s-55-39-89-53c4-27 8-53 11-76 3-20 6-39 9-58s5-33 6-40c6-40 8-73 7-98q-1.5-39-15-63c-7-13-16-26-25-39-10-13-22-24-35-34s-29-18-46-25c-18-7-38-11-61-12-17-1-38 0-62 5-24 4-47 12-69 23s-41 25-57 44q-24 28.5-27 69c-1 16 0 32 3 49 3 16 9 31 18 44 8 13 19 23 33 32 13 9 30 14 50 15 12 1 24-1 37-5 12-5 23-11 34-19s19-18 26-30q10.5-18 12-39c2-25-6-48-23-71s-47-41-88-52c7-9 19-18 38-26 19-9 42-13 70-13 29 0 58 9 85 26s47 39 62 65c9 17 14 40 14 68 0 27-2 55-5 83-1 5-3 16-6 35q-4.5 27-9 57-4.5 34.5-12 78m21 1267c-26 0-49-12-68-36q-30-37.5-48-93c-13-37-21-78-25-123q-6-67.5 3-129c22 17 45 37 69 61q36 34.5 66 75 28.5 40.5 48 81 18 40.5 15 78c-1 8-2 17-4 27s-5 19-10 28-11 16-18 22-17 9-28 9m-2-1226c29 10 51 23 67 39s28 33 36 52c7 19 12 37 13 56s1 35 0 50c-1 12-4 27-8 45-5 18-13 35-25 52q-18 25.5-51 42c-22 11-51 15-88 13m-26-2c-27-1-50-7-67-16-18-10-32-22-42-35-11-14-18-29-21-44-4-15-6-29-5-41s3-24 8-37 11-24 19-35c7-11 16-21 25-30s18-16 27-21l-3-3-4-4c-1-1-2-3-3-4q-31.5 15-54 36c-16 13-26 23-31 29-7 10-14 19-19 27s-10 17-13 26-6 18-8 29c-3 11-4 23-5 38q-1.5 21 3 45c3 15 9 31 17 47 7 16 17 32 30 47 12 15 26 29 43 42 9 7 17 12 24 16s13 8 19 11 12 5 19 7c6 1 13 3 20 5l-30 181c-8-5-21-14-39-28s-38-31-59-50-42-40-63-62c-21-23-39-44-52-65-24-38-43-73-56-105S65 75 68 38q4.5-63 39-117c23-37 52-67 88-92q54-37.5 123-51c46-10 94-9 143 3-11 66-20 125-29 177-4 22-8 44-11 65q-4.5 31.5-9 57c-3 17-6 30-7 41-1 10-2 15-2 15"
-   horiz-adv-x="709"
-   unicode="&amp;" />&#10;    <glyph
-   id="glyph60834"
-   d="M502-262c-6-11-12-22-17-31l-18-27c-6-9-12-17-19-25-7-9-14-18-23-28q-13.5-15-24-27l-23-23c-8-7-16-14-25-21s-18-15-29-23c-13-10-26-19-37-26-12-7-24-14-35-20-12-6-24-11-37-16s-27-11-42-17-32-11-50-16c-19-5-36-10-53-13-19-4-39-8-58-11l-7 15c31 11 63 23 94 37 26 12 54 27 83 44s54 36 75 58c54 57 95 121 123 190S421-95 420-7q0 30-6 69c-5 26-12 51-23 74s-27 43-46 60c-20 17-46 25-77 25-18 0-37-4-57-11-21-7-39-17-56-29-17-13-30-27-41-44s-15-36-13-55c1-3 3-3 7-2 3 1 9 2 16 4s15 4 26 6c10 2 22 3 36 2 15-1 27-5 38-13 11-9 19-19 26-32s11-26 13-41 1-30-2-44c-5-22-15-39-29-52-15-13-35-20-60-20-16 0-31 3-46 9-15 5-29 13-40 24-11 10-20 23-27 38S48-7 48 12c-1 29 3 54 10 76s15 41 26 57c10 16 21 29 33 40 11 10 22 18 32 24 25 15 50 26 75 32q37.5 7.5 72 9c25 0 51-4 77-12q37.5-13.5 72-36c23-16 43-35 61-56 18-22 32-46 41-73 11-30 17-62 18-95 0-34-4-71-13-110q-4.5-19.5-9-36c-3-11-7-21-11-31s-8-20-13-30-11-21-17-33m101 385q-1.5 22.5 15 39 16.5 15 39 15c15 1 29-4 40-14s16-23 16-38q1.5-22.5-15-39c-11-11-24-17-39-17q-22.5-1.5-39 15c-11 11-17 24-17 39m0-252c0 15 5 28 16 38s24 15 39 16c15 0 29-5 40-14 11-10 16-23 16-38q1.5-22.5-15-39c-11-11-24-17-39-17q-22.5-1.5-39 15t-18 39"
-   horiz-adv-x="723"
-   unicode="?" />&#10;    <glyph
-   id="glyph60836"
-   d="M26 354V113c9 9 18 16 26 21s16 10 23 13 15 5 24 6c8 1 17 2 28 2 13 0 24-3 34-8s19-12 26-21 13-18 17-29 6-21 6-31c1-11 0-21-3-31-3-11-6-20-10-29-5-11-12-21-22-30s-19-17-27-25c-3-3-8-7-17-14s-18-14-29-22-23-16-35-24c-12-9-23-16-33-23q-15-10.5-24-18c-7-5-10-8-10-8v591h26m81-342c-3 4-8 7-13 10-6 3-12 4-19 4s-13-2-20-6q-10.5-6-18-21c-7-13-10-28-10-47-1-19-1-37-1-52v-86s2 2 6 5q6 4.5 15 12c5 5 11 10 18 16 6 6 12 11 17 16 9 9 17 18 24 28s12 23 15 38q6 22.5 3 45c-2 15-8 27-17 38"
-   horiz-adv-x="210"
-   unicode="b" />&#10;    <glyph
-   id="glyph60838"
-   d="M8-1c7 18 17 35 31 50 13 15 29 29 47 41 18 11 37 20 58 27q31.5 9 63 9c21 0 40-3 56-10s29-17 38-28c9-12 15-26 18-41 2-16 0-33-7-51s-17-35-31-50c-14-16-30-30-48-41-18-12-37-21-58-27-21-7-42-10-63-10s-40 4-55 11c-16 7-29 16-38 28Q4-75 1-51C-1-36 1-19 8-1"
-   horiz-adv-x="319"
-   unicode="œ" />&#10;    <glyph
-   id="glyph60840"
-   d="M320 89c4-7 7-15 8-24s1-18 0-27-3-18-5-26-4-14-6-19c-9-25-23-48-42-67s-36-33-51-40c-33-17-72-23-117-19-7 1-14 2-23 3s-18 4-27 7-18 8-26 13c-9 5-15 12-20 20-5 9-8 18-9 27S1-46 2-37c1 8 2 16 4 23Q9-3.5 12 4c9 25 23 46 40 63s34 30 49 39q22.5 13.5 57 21 33 7.5 75 3c5-1 12-1 20-2s16-3 25-6q12-4.5 24-12 10.5-7.5 18-21m-23-17c-5 8-12 13-19 16-8 3-16 4-25 3s-19-3-28-6-18-7-26-11c-11-5-21-11-30-16s-19-11-29-16c-19-11-39-23-59-36-7-5-15-10-22-16-8-6-15-13-20-20s-9-15-10-23c-2-9-1-17 4-25s11-13 19-16 17-3 26-2 18 3 27 6 18 7 26 11c11 5 22 11 32 16 9 5 19 11 29 16s20 11 29 16 18 12 29 19c7 5 14 10 22 16 7 6 14 13 19 20s9 15 11 24c1 8 0 16-5 24"
-   horiz-adv-x="328"
-   unicode="˙" />&#10;  </font>&#10;  <font
-   id="font60876"
-   horiz-adv-x="2048"
-   horiz-origin-x="0"
-   horiz-origin-y="0"
-   vert-adv-y="1024"
-   vert-origin-x="512"
-   vert-origin-y="768">&#10;    <font-face
-   id="font-face60844"
-   font-family="'Times New Roman'"
-   underline-position="-223"
-   underline-thickness="100"
-   units-per-em="2048">&#10;      <font-face-src>&#10;        <font-face-name
-   name="Times New Roman" />&#10;      </font-face-src>&#10;    </font-face>&#10;    <glyph
-   id="glyph60848"
-   horiz-adv-x="512" />&#10;    <glyph
-   id="glyph60850"
-   d="M494 1044c-3 46-12 92-28 137-23 65-34 110-34 135 0 35 8 61 25 79q24 27 60 27 31.5 0 54-27c15-18 23-44 23-77 0-30-9-72-26-125-18-54-29-104-33-149 37 23 70 52 99 85 45 53 79 85 101 98s44 19 67 19c22 0 41-7 56-22s22-33 22-54q0-37.5-33-66c-22-19-77-39-165-58-51-11-94-24-128-39 35-18 77-32 127-41 81-15 134-33 159-55s37-46 37-72c0-20-7-37-22-52s-33-22-53-22q-30 0-66 21c-25 14-58 45-99 94-27 33-61 63-102 92 1-38 9-79 23-124 24-79 36-132 36-161 0-27-8-49-24-67-16-19-33-28-51-28-25 0-47 10-67 29-14 14-21 36-21 67 0 32 8 71 23 116s25 76 29 93 8 42 11 75c-39-26-74-55-103-87-49-55-85-89-110-104-17-11-35-16-54-16-23 0-42 8-58 23q-24 22.5-24 51c0 17 7 34 21 53 13 18 34 33 61 45 18 8 59 19 123 32 41 9 82 21 121 38q-54 27-129 42c-82 17-133 33-152 47-30 22-45 49-45 80 0 18 8 35 23 50s32 22 52 22c22 0 45-7 70-21s55-42 92-84c37-43 74-76 112-99"
-   horiz-adv-x="1024"
-   unicode="*" />&#10;    <glyph
-   id="glyph60852"
-   d="M256 194c31 0 58-11 79-32 21-22 32-48 32-79s-11-57-32-78c-22-22-48-33-79-33q-46.5 0-78 33-33 31.5-33 78c0 31 11 58 33 79 21 21 47 32 78 32"
-   horiz-adv-x="512"
-   unicode="." />&#10;    <glyph
-   id="glyph60854"
-   d="M74 670c0 155 23 288 70 400q70.5 166.5 186 249c60 43 122 65 186 65 104 0 197-53 280-159 103-131 155-309 155-534 0-157-23-291-68-401S780 100 710 51Q603.5-24 506-24c-129 0-237 76-323 229C110 334 74 489 74 670m196-25c0-187 23-339 69-457 38-99 95-149 170-149 36 0 73 16 112 49 39 32 68 86 88 162 31 115 46 276 46 485q0 232.5-48 387c-24 77-55 131-93 163q-40.5 33-99 33c-45 0-86-20-121-61-48-55-81-142-98-261s-26-236-26-351"
-   horiz-adv-x="1024"
-   unicode="0" />&#10;    <glyph
-   id="glyph60856"
-   d="m240 1223 330 161h33V239c0-76 3-123 10-142 6-19 19-33 39-43s61-16 122-17V0H264v37c64 1 105 7 124 17q28.5 13.5 39 39c7 16 11 65 11 146v732c0 99-3 162-10 190-5 21-13 37-25 47q-19.5 15-45 15c-25 0-59-10-103-31z"
-   horiz-adv-x="1024"
-   unicode="1" />&#10;    <glyph
-   id="glyph60858"
-   d="M939 261 844 0H44v37c235 215 401 390 497 526s144 260 144 373c0 86-26 157-79 212s-116 83-189 83c-67 0-126-19-179-58s-93-97-118-172H83c17 123 60 218 129 284q103.5 99 258 99c110 0 202-35 276-106 73-71 110-154 110-250 0-69-16-137-48-206-49-108-129-222-240-343-166-181-270-291-311-328h354c72 0 123 3 152 8q43.5 7.5 78 33c23 16 44 39 61 69z"
-   horiz-adv-x="1024"
-   unicode="2" />&#10;    <glyph
-   id="glyph60860"
-   d="M953 500V358H771V0H606v358H32v128l629 898h110V500m-165 0v673L130 500z"
-   horiz-adv-x="1024"
-   unicode="4" />&#10;    <glyph
-   id="glyph60862"
-   d="m889 1356-78-170H403l-89-182c177-26 317-92 420-197 89-91 133-197 133-320 0-71-14-137-43-198s-66-112-110-155-93-77-147-103C490-6 412-24 331-24q-121.5 0-177 42c-37 27-56 58-56 91 0 19 8 35 23 50 15 14 35 21 58 21 17 0 33-3 46-8s35-19 66-41c50-35 101-52 152-52 78 0 147 30 206 89s88 130 88 215c0 82-26 159-79 230S533 738 440 777c-73 30-172 47-297 52l260 527z"
-   horiz-adv-x="1024"
-   unicode="5" />&#10;    <glyph
-   id="glyph60864"
-   d="M206 1356h727v-38L481-28H369l405 1221H401c-75 0-129-9-161-27-56-31-101-78-135-142l-29 11z"
-   horiz-adv-x="1024"
-   unicode="7" />&#10;    <glyph
-   id="glyph60866"
-   d="M838 0 314 1141V235q0-124.5 27-156 37.5-42 117-42h48V0H34v37h48c57 0 98 17 122 52 15 21 22 70 22 146v886c0 60-7 103-20 130-9 19-26 36-51 49s-66 19-121 19v37h384L910 295l484 1061h384v-37h-47c-58 0-99-17-123-52-15-21-22-70-22-146V235c0-83 9-135 28-156q37.5-42 117-42h47V0h-576v37h48c58 0 99 17 122 52 15 21 22 70 22 146v906L871 0z"
-   horiz-adv-x="1821"
-   unicode="M" />&#10;    <glyph
-   id="glyph60868"
-   d="M939 1387V918h-37c-12 90-33 162-64 215s-76 96-133 127-117 47-178 47c-69 0-127-21-172-63-45-43-68-91-68-145 0-41 14-79 43-113 41-50 140-117 295-200 127-68 213-120 260-156 46-37 82-80 107-129s37-101 37-155c0-103-40-191-119-265C830 6 727-31 602-31q-58.5 0-111 9c-21 3-63 16-128 37S256 46 239 46q-25.5 0-39-15c-10-10-17-31-22-62h-37v465h37c17-97 41-170 70-218 29-49 74-89 135-121q90-48 198-48 124.5 0 198 66 72 66 72 156c0 33-9 67-27 101-19 34-47 66-86 95-26 20-97 63-213 128S327 709 278 748s-87 81-112 128-38 98-38 154c0 97 37 181 112 252q112.5 105 285 105c72 0 148-18 229-53 37-17 64-25 79-25 17 0 32 5 43 16 11 10 19 31 26 62z"
-   horiz-adv-x="1139"
-   unicode="S" />&#10;    <glyph
-   id="glyph60870"
-   d="m1185 1356 15-318h-38q-10.5 84-30 120c-21 39-48 67-82 86-35 18-80 27-136 27H723V235q0-124.5 27-156 37.5-42 117-42h47V0H339v37h48c57 0 98 17 122 52 15 21 22 70 22 146v1036H368c-63 0-108-5-135-14-35-13-64-37-89-73s-39-85-44-146H62l16 318z"
-   horiz-adv-x="1251"
-   unicode="T" />&#10;    <glyph
-   id="glyph60872"
-   d="M335 1422V511l233 212c49 45 78 74 86 86 5 8 8 16 8 24 0 13-5 25-16 35-11 9-30 15-55 16v32h398v-32c-55-1-100-10-136-25-37-15-77-43-120-82L498 560l235-297q97.5-123 132-156c32-31 60-52 84-61 17-7 46-10 87-10V0H591v36c25 1 43 5 52 12s13 16 13 29c0 15-13 40-40 74L335 510V206c0-59 4-98 13-117 8-19 20-32 35-40s49-12 100-13V0H17v36c47 0 82 6 105 17 14 7 25 19 32 34q15 33 15 114v834c0 106-2 171-7 195-5 23-12 40-23 49s-25 13-42 13c-14 0-35-6-63-17l-17 35 272 112z"
-   horiz-adv-x="1024"
-   unicode="k" />&#10;    <glyph
-   id="glyph60874"
-   d="M1041 453H-18v73h1059z"
-   horiz-adv-x="1024"
-   unicode="–" />&#10;  </font>&#10;  <font
-   id="font60890"
-   horiz-adv-x="2048"
-   horiz-origin-x="0"
-   horiz-origin-y="0"
-   vert-adv-y="1024"
-   vert-origin-x="512"
-   vert-origin-y="768">&#10;    <font-face
-   id="font-face60878"
-   font-family="'Times New Roman'"
-   font-style="italic"
-   underline-position="-223"
-   underline-thickness="100"
-   units-per-em="2048">&#10;      <font-face-src>&#10;        <font-face-name
-   name="Times New Roman Kursiv" />&#10;      </font-face-src>&#10;    </font-face>&#10;    <glyph
-   id="glyph60882"
-   d="M855 1384 533 263c-19-66-28-114-28-143 0-25 9-43 26-56s56-22 119-27L640 0H125l14 37c55 1 91 6 108 13q42 18 63 48c22 31 44 86 67 165l232 805c14 49 22 77 23 84q3 19.5 3 39c0 23-6 42-19 55s-30 20-52 20q-25.5 0-81-12l-13 36 337 94z"
-   horiz-adv-x="1024"
-   unicode="1" />&#10;    <glyph
-   id="glyph60884"
-   d="M313 741v29c161 25 282 73 361 144 57 51 86 111 86 181 0 53-17 96-50 131-33 34-74 51-121 51-75 0-141-46-199-139l-37 11c35 77 79 136 134 176 54 39 113 59 178 59 79 0 142-23 191-70s73-107 73-179c0-61-23-120-68-177-46-57-125-107-236-152 69-29 122-70 157-123 35-54 53-119 53-194 0-83-24-167-72-250-48-84-114-149-197-194Q440-24 302-24c-84 0-148 15-191 44-29 20-43 43-43 70 0 23 9 43 26 60s37 25 62 25c17 0 35-3 52-8 11-3 37-17 79-40 41-23 74-39 97-46q34.5-12 72-12c60 0 110 35 149 105 39 69 58 143 58 222q0 96-39 171c-27 50-68 91-125 122s-119 48-186 52"
-   horiz-adv-x="1024"
-   unicode="3" />&#10;    <glyph
-   id="glyph60886"
-   d="M997 1356 738 464h162l-36-124H700L595-24H448l106 364H64l42 140 815 876m-146-258L192 464h401z"
-   horiz-adv-x="1024"
-   unicode="4" />&#10;    <glyph
-   id="glyph60888"
-   d="M528 1356h453l-46-165H528l-75-167c108-17 192-51 252-101 93-78 139-187 139-327 0-93-17-176-51-251q-52.5-112.5-126-189c-50-51-103-91-160-120Q391.5-24 273-24c-67 0-121 15-160 44-27 20-40 45-40 76 0 24 9 45 26 62s39 25 64 25c35 0 75-18 118-53 27-22 49-37 66-44 14-6 31-9 50-9 75 0 145 38 208 113s95 172 95 292c0 83-17 154-50 213-34 59-77 100-129 124s-121 41-208 50z"
-   horiz-adv-x="1024"
-   unicode="5" />&#10;  </font>&#10;  <path
-   id="line60914"
-   d="M949.154 199.056v87.467"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60916"
-   d="M166.738 199.056H965.78"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60918"
-   d="M166.738 204.523H965.78"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60920"
-   d="M166.738 209.99H965.78"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60922"
-   d="M166.738 215.456H965.78"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60924"
-   d="M166.738 220.923H965.78"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60926"
-   d="M166.738 264.656H965.78"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60928"
-   d="M166.738 270.123H965.78"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60930"
-   d="M166.738 275.59H965.78"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60932"
-   d="M166.738 281.056H965.78"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60934"
-   d="M166.738 286.523H965.78"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <g
-   id="g17"
-   class="supplied staffN"
-   transform="translate(22.677 -.5)">&#10;    <g
-   id="text60936"
-   aria-label="13"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333">&#10;      <path
-   id="path952"
-   d="m92.619 215.955 1.213-5.787q-.784.617-2.206.988l.177-.857q.706-.283 1.391-.738.69-.455 1.035-.794.21-.21.398-.507h.548l-1.605 7.695z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path954"
-   d="m96.587 213.948.92-.115q.105.805.46 1.155.361.345.941.345.701 0 1.208-.502.513-.502.513-1.15 0-.564-.382-.93-.382-.372-1.025-.372-.073 0-.303.021l.162-.79q.136.022.261.022.81 0 1.245-.392.439-.398.439-.973 0-.528-.36-.889-.356-.36-.874-.36-.507 0-.915.37-.403.367-.518 1.041l-.93-.188q.23-.946.883-1.464.654-.518 1.548-.518.941 0 1.521.57.586.57.586 1.402 0 .606-.319 1.06-.314.45-.946.748.45.267.669.644.225.376.225.862 0 1.03-.774 1.788-.769.753-1.84.753-1.04 0-1.684-.58-.638-.586-.71-1.558"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;    </g>&#10;    <g
-   id="text60938"
-   aria-label="14"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333">&#10;      <path
-   id="path957"
-   d="m92.619 281.555 1.213-5.787q-.784.617-2.206.988l.177-.858q.706-.282 1.391-.737.69-.455 1.035-.795.21-.209.398-.507h.548l-1.605 7.696z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path959"
-   d="m99.201 281.555.413-1.955h-3.126l.198-.936 4.293-4.773h.774l-1.02 4.872h1.077l-.172.837h-1.077l-.413 1.955zm.586-2.792.669-3.2-2.855 3.2z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;    </g>&#10;  </g>&#10;  <path
-   id="rect60940"
-   d="M174.482 181.516h651.67v117.99h-651.67Z"
-   style="fill:#fff;stroke:none;stroke-width:1.33333004" />&#10;  <path
-   id="line60944"
-   d="M867.427 193.59h9.338"
-   style="fill:none;stroke:#000;stroke-width:.90399802" />&#10;  <g
-   id="text60946"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path964"
-   d="M868.968 193.612c-.59 1.552.438 2.842 2.274 2.864s3.783-1.224 4.374-2.799c.568-1.552-.438-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text60948"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path967"
-   d="M868.968 207.278c-.59 1.553.438 2.843 2.274 2.865s3.783-1.225 4.374-2.8c.568-1.552-.438-2.82-2.296-2.842-1.837-.022-3.783 1.225-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text60950"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path970"
-   d="M868.968 212.745c-.59 1.552.438 2.843 2.274 2.864 1.837.022 3.783-1.224 4.374-2.799.568-1.552-.438-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text60952"
-   aria-label="#"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path973"
-   d="M865.45 205.2v3.259l-2.144.7V205.9zm-3.718-1.049v2.253l.94-.307v3.259l-.94.306v2.274l.94-.306v3.017h.634v-3.236l2.143-.7v3.368h.634v-3.564l.853-.285v-2.252l-.853.262v-3.236l.853-.284v-2.274l-.853.284v-2.996h-.634v3.193l-2.143.7v-3.346h-.634v3.564z"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line60954"
-   d="M875.137 211.811v-48.559"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60956"
-   d="M881.41 193.59h9.34"
-   style="fill:none;stroke:#000;stroke-width:.90399802" />&#10;  <g
-   id="text60958"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path978"
-   d="M882.952 190.878c-.59 1.553.437 2.843 2.274 2.865s3.783-1.225 4.374-2.8c.568-1.552-.438-2.82-2.296-2.842-1.837-.022-3.783 1.225-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text60960"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path981"
-   d="M882.952 210.012c-.59 1.552.437 2.842 2.274 2.864s3.783-1.224 4.374-2.799c.568-1.552-.438-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text60962"
-   aria-label="b"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path984"
-   d="M877.923 181.388h-.568v12.923c0-.043 2.842-1.99 3.236-2.383.35-.35.874-.722 1.071-1.203.175-.372.306-.853.285-1.312-.022-.874-.722-1.968-1.815-1.946-.919.022-1.378.175-2.209.918v-1.399c.022-2.886 0-5.598 0-5.598m1.771 7.479c.416.459.481 1.158.306 1.814-.153.656-.459 1.072-.852 1.444-.438.415-1.225 1.093-1.225 1.071v-1.88c0-.678-.044-1.619.24-2.165.46-.875 1.247-.612 1.531-.284"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line60964"
-   d="M889.121 209.078V163.79"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60966"
-   d="M894.621 193.59h9.339"
-   style="fill:none;stroke:#000;stroke-width:.90399802" />&#10;  <g
-   id="text60968"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path989"
-   d="M896.163 193.612c-.59 1.552.437 2.842 2.274 2.864s3.783-1.224 4.373-2.799c.569-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.351 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text60970"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path992"
-   d="M896.163 212.745c-.59 1.552.437 2.843 2.274 2.864 1.837.022 3.783-1.224 4.373-2.799.569-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.351 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line60972"
-   d="M902.332 211.811v-47.47"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line60974"
-   d="M907.832 193.59h9.34"
-   style="fill:none;stroke:#000;stroke-width:.90399802" />&#10;  <path
-   id="line60976"
-   d="M907.832 188.123h9.34"
-   style="fill:none;stroke:#000;stroke-width:.90399802" />&#10;  <path
-   id="line60978"
-   d="M907.832 182.656h9.34"
-   style="fill:none;stroke:#000;stroke-width:.90399802" />&#10;  <g
-   id="text60980"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path999"
-   d="M909.373 182.678c-.59 1.553.438 2.843 2.275 2.865s3.782-1.225 4.373-2.8c.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.225-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line60982"
-   d="M907.832 193.59h9.34"
-   style="fill:none;stroke:#000;stroke-width:.90399802" />&#10;  <path
-   id="line60984"
-   d="M907.832 188.123h9.34"
-   style="fill:none;stroke:#000;stroke-width:.90399802" />&#10;  <g
-   id="text60986"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1004"
-   d="M909.373 188.145c-.59 1.552.438 2.843 2.275 2.864 1.836.022 3.782-1.224 4.373-2.798.568-1.553-.437-2.821-2.296-2.843-1.837-.022-3.783 1.224-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text60988"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1007"
-   d="M909.373 196.345c-.59 1.552.438 2.843 2.275 2.864 1.836.022 3.782-1.224 4.373-2.798.568-1.553-.437-2.821-2.296-2.843-1.837-.022-3.783 1.224-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text60990"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1010"
-   d="M909.373 201.812c-.59 1.552.438 2.842 2.275 2.864s3.782-1.224 4.373-2.799c.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line60992"
-   d="M915.542 200.878v-35.99"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <g
-   id="text60994"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1014"
-   d="M922.585 199.078c-.59 1.553.438 2.843 2.275 2.865s3.782-1.225 4.373-2.8c.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.225-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text60996"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1017"
-   d="M922.585 207.278c-.59 1.553.438 2.843 2.275 2.865s3.782-1.225 4.373-2.8c.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.225-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text60998"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1020"
-   d="M922.585 212.745c-.59 1.552.438 2.843 2.275 2.864 1.836.022 3.782-1.224 4.373-2.799.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text61000"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1023"
-   d="M922.585 218.212c-.59 1.552.438 2.842 2.275 2.864s3.782-1.224 4.373-2.799c.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text61002"
-   aria-label="#"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1026"
-   d="M920.066 205.2v3.259l-2.142.7V205.9zm-3.717-1.049v2.253l.94-.307v3.259l-.94.306v2.274l.94-.306v3.017h.635v-3.236l2.142-.7v3.368h.635v-3.564l.852-.285v-2.252l-.852.262v-3.236l.852-.284v-2.274l-.852.284v-2.996h-.635v3.193l-2.142.7v-3.346h-.635v3.564z"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line61004"
-   d="M928.754 217.278v-51.842"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <g
-   id="text61006"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1030"
-   d="M935.796 201.812c-.59 1.552.437 2.842 2.274 2.864s3.783-1.224 4.373-2.799c.569-1.552-.437-2.82-2.296-2.842-1.836-.022-3.782 1.224-4.351 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="text61008"
-   aria-label="œ"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1033"
-   d="M935.796 220.945c-.59 1.552.437 2.843 2.274 2.864 1.837.022 3.783-1.224 4.373-2.799.569-1.552-.437-2.82-2.296-2.842-1.836-.022-3.782 1.224-4.351 2.777"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <path
-   id="line61010"
-   d="M941.965 220.011v-54.025"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="path61012"
-   d="m874.934 161.886 67.354 2.733v2.733l-67.354-2.733z"
-   style="fill:#000;fill-rule:nonzero;stroke:none;stroke-width:1.33333004" />&#10;  <path
-   id="line61014"
-   d="M875.137 296.544v-31.888"
-   style="fill:none;stroke:#000;stroke-width:.64399803" />&#10;  <path
-   id="line61020"
-   d="M867.427 297.456h9.338"
-   style="fill:none;stroke:#000;stroke-width:.90399802" />&#10;  <path
-   id="line61022"
-   d="M867.427 291.99h9.338"
-   style="fill:none;stroke:#000;stroke-width:.90399802" />&#10;  <g
-   id="text61024"
-   aria-label="˙"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;    <path
-   id="path1040"
-   d="M875.79 295.51c-.415-.743-1.443-.853-1.902-.897-1.224-.153-2.23.154-2.886.525-.656.394-1.53 1.137-1.946 2.23-.153.438-.46 1.313-.022 2.056.437.7 1.509.897 2.099.94.984.088 1.88-.065 2.558-.415.678-.328 1.618-1.225 2.034-2.34.153-.415.415-1.487.066-2.099m-.502.372c.415.721-.416 1.443-1.028 1.837a16 16 0 0 1-1.268.765c-.438.24-.831.46-1.334.7-.678.35-1.706.7-2.143-.022-.416-.722.415-1.443 1.05-1.837a17 17 0 0 1 1.29-.787c.437-.24.787-.46 1.29-.7.678-.328 1.705-.678 2.143.044"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;  </g>&#10;  <g
-   id="g18"
-   class="supplied measureN">&#10;    <g
-   id="text61026"
-   aria-label="5"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"
-   transform="translate(36.677 -.5)">&#10;      <path
-   id="path1043"
-   d="m817.33 114.775.962-.094q-.01.204-.01.246 0 .345.172.695.177.35.475.538.304.183.638.183.44 0 .894-.303.455-.303.737-.883.283-.58.283-1.15 0-.644-.382-1.03-.376-.387-.993-.387-.413 0-.784.198-.366.199-.685.596l-.826-.057 1.155-3.921h3.743l-.183.868h-2.912l-.575 1.95q.324-.236.664-.35.345-.12.706-.12.878 0 1.443.58t.565 1.589q0 .883-.387 1.631-.387.742-1.067 1.145-.674.397-1.458.397-.66 0-1.166-.298-.508-.298-.764-.82-.25-.523-.25-1.046 0-.052.004-.157z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;    </g>&#10;  </g>&#10;  <g
-   id="g16"
-   class="link-box">&#10;    <path
-   id="rect60942"
-   d="M174.482 181.516h651.67v117.99h-651.67Z"
-   style="fill:none;stroke:#777;stroke-width:.910664;stroke-opacity:1" />&#10;    <g
-   id="text61028"
-   aria-label="M* 404 Sk1 T. 12–15"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"
-   transform="translate(36.677 -.5)">&#10;      <path
-   id="path1047"
-   d="M353.556 243.779v-15.27h4.614l2.77 10.416 2.74-10.416h4.625v15.27h-2.865v-12.02l-3.03 12.02h-2.97l-3.02-12.02v12.02z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1049"
-   d="m372.388 235.53-1.573-1.22q.75-.843 1.562-1.614.323-.312.406-.395-.26-.042-1.49-.344-.884-.219-1.166-.323l.615-1.833q1.364.552 2.437 1.218-.25-1.697-.25-2.77h1.854q0 .76-.281 2.791.208-.083.896-.406.937-.427 1.729-.729l.552 1.885q-1.156.26-2.677.51l1.25 1.407q.375.427.594.698l-1.594 1.052-1.406-2.323q-.636 1.125-1.458 2.396"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1051"
-   d="M390.688 243.779v-3.073h-6.25v-2.562l6.625-9.697h2.458v9.687h1.896v2.572h-1.896v3.073zm0-5.645v-5.219l-3.51 5.219z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1053"
-   d="M401.77 228.447q2.22 0 3.47 1.583 1.489 1.875 1.489 6.218 0 4.333-1.5 6.229-1.24 1.562-3.458 1.562-2.23 0-3.594-1.708-1.364-1.718-1.364-6.114 0-4.312 1.5-6.208 1.24-1.562 3.458-1.562m0 2.427q-.53 0-.947.343-.417.334-.646 1.209-.302 1.135-.302 3.822t.27 3.698q.272 1 .678 1.333.417.333.948.333t.948-.333q.416-.344.645-1.219.302-1.124.302-3.812t-.27-3.687q-.271-1.01-.688-1.344-.406-.343-.937-.343"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1055"
-   d="M414.436 243.779v-3.073h-6.25v-2.562l6.625-9.697h2.459v9.687h1.895v2.572h-1.895v3.073zm0-5.645v-5.219l-3.51 5.219z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1057"
-   d="m426.352 238.81 3-.291q.27 1.51 1.094 2.219.833.708 2.239.708 1.49 0 2.24-.625.76-.636.76-1.48 0-.54-.323-.916-.313-.385-1.104-.666-.542-.188-2.469-.667-2.479-.615-3.479-1.51-1.406-1.26-1.406-3.073 0-1.167.656-2.177.667-1.02 1.907-1.552 1.25-.531 3.01-.531 2.874 0 4.322 1.26 1.459 1.26 1.531 3.365l-3.083.135q-.198-1.177-.854-1.687-.646-.521-1.948-.521-1.343 0-2.104.552-.49.354-.49.948 0 .541.46.927.582.49 2.832 1.02 2.25.532 3.323 1.104 1.083.563 1.687 1.552.615.98.615 2.427 0 1.313-.73 2.459-.728 1.145-2.062 1.708-1.333.552-3.322.552-2.896 0-4.448-1.333-1.552-1.344-1.854-3.906"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1059"
-   d="M441.257 243.779v-15.27h2.927v8.104l3.427-3.896h3.604l-3.781 4.042 4.052 7.02h-3.156l-2.781-4.968-1.365 1.427v3.54z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1061"
-   d="M460.1 243.779h-2.927v-11.03q-1.604 1.5-3.781 2.218v-2.656q1.146-.375 2.49-1.416 1.343-1.052 1.843-2.448h2.375z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1063"
-   d="M474.484 243.779v-12.687h-4.531v-2.583h12.134v2.583h-4.52v12.687z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1065"
-   d="M481.692 243.779v-2.927h2.927v2.927z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1067"
-   d="M500.388 243.779h-2.927v-11.03q-1.604 1.5-3.78 2.218v-2.656q1.145-.375 2.489-1.416 1.343-1.052 1.843-2.448h2.375z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1069"
-   d="M514.658 241.06v2.719h-10.26q.167-1.542 1-2.917.833-1.385 3.292-3.666 1.979-1.844 2.426-2.5.605-.906.605-1.791 0-.98-.532-1.5-.52-.531-1.447-.531-.917 0-1.459.552-.541.552-.625 1.833l-2.916-.292q.26-2.416 1.635-3.468t3.438-1.052q2.26 0 3.551 1.218 1.292 1.22 1.292 3.031 0 1.032-.375 1.97-.365.926-1.167 1.947-.53.677-1.916 1.948t-1.76 1.687q-.365.417-.594.812z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1071"
-   d="M515.7 239.342v-2.188h11.863v2.188z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1073"
-   d="M536.01 243.779h-2.926v-11.03q-1.604 1.5-3.781 2.218v-2.656q1.145-.375 2.489-1.416 1.344-1.052 1.844-2.448h2.374z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;      <path
-   id="path1075"
-   d="m540.437 239.852 2.917-.302q.125.99.74 1.573.614.573 1.416.573.916 0 1.552-.74.635-.75.635-2.25 0-1.406-.635-2.104-.625-.708-1.636-.708-1.26 0-2.26 1.115l-2.375-.344 1.5-7.947h7.74v2.739h-5.521l-.459 2.594q.98-.49 2-.49 1.948 0 3.302 1.417 1.354 1.416 1.354 3.676 0 1.886-1.093 3.365-1.49 2.02-4.136 2.02-2.114 0-3.447-1.135t-1.594-3.052"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" />&#10;    </g>&#10;  </g>&#10;  <g
-   id="g1"
-   class="supplied foliation">&#10;    <g
-   id="text297"
-   aria-label="A: Bl. 1v"
-   style="font-size:10.66670036px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;letter-spacing:0;word-spacing:0;opacity:.604762">&#10;      <path
-   id="path1078"
-   d="M118.943 114.907h-3.026l-.917 1.688h-1.614l4.318-7.636h1.744l1.24 7.636h-1.49zm-.193-1.27-.442-3.074-1.844 3.073z"
-   style="font-style:italic;font-variant:normal;font-weight:700;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1080"
-   d="M123.12 111.063h1.474l-.302 1.448h-1.474zm-.854 4.089h1.48l-.303 1.443h-1.479z"
-   style="font-style:italic;font-variant:normal;font-weight:700;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1082"
-   d="m128.198 116.595 1.6-7.636h2.364q.646 0 .958.052.51.089.86.313.354.219.547.604.192.38.192.844 0 .63-.349 1.11-.343.478-1.057.728.62.203.927.615.307.406.307.953 0 .63-.364 1.208-.36.578-.959.896-.593.313-1.328.313zm1.938-4.375h1.547q1.11 0 1.594-.355.49-.354.49-1.03 0-.324-.152-.558-.151-.234-.406-.339-.25-.109-.948-.109h-1.625zm-.734 3.51h1.74q.692 0 .931-.047.485-.083.787-.281.302-.203.474-.531t.172-.688q0-.536-.339-.812-.333-.282-1.276-.282h-1.937z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1084"
-   d="m135.141 116.595 1.594-7.636h.943l-1.594 7.636z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1086"
-   d="m137.85 116.595.223-1.068h1.068l-.229 1.068z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1088"
-   d="m145.72 116.595 1.208-5.766q-.782.615-2.198.984l.177-.854q.703-.281 1.385-.734.688-.453 1.031-.792.209-.208.396-.505h.547l-1.599 7.667z"
-   style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal" />&#10;      <path
-   id="path1090"
-   d="m150.227 112.328-.59-3.595h.596l.308 1.98q.051.325.126 1.06.176-.383.45-.877l1.202-2.163h.646l-2.058 3.595z"
-   style="font-size:64.99999762%;baseline-shift:super" />&#10;    </g>&#10;  </g>&#10;  <path
-   id="path1093"
-   d="M 113.97,87.239 V 75.786 h 3.46 l 2.078,7.812 2.055,-7.812 h 3.469 v 11.453 h -2.149 v -9.016 l -2.273,9.016 h -2.227 l -2.265,-9.016 v 9.016 z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0" /><path
-   id="path1095"
-   d="m 131.22,84.2 2.124,-0.258 q 0.102,0.813 0.547,1.242 0.445,0.429 1.078,0.43 0.68,0 1.14,-0.516 0.47,-0.515 0.47,-1.39 0,-0.828 -0.446,-1.313 -0.445,-0.484 -1.086,-0.484 -0.422,0 -1.008,0.164 l 0.243,-1.79 q 0.89,0.024 1.359,-0.382 0.469,-0.414 0.469,-1.094 0,-0.578 -0.344,-0.922 -0.344,-0.343 -0.914,-0.343 -0.563,0 -0.961,0.39 -0.398,0.39 -0.484,1.14 l -2.024,-0.343 q 0.211,-1.039 0.633,-1.656 0.43,-0.625 1.188,-0.977 0.765,-0.359 1.71,-0.359 1.618,0 2.594,1.031 0.805,0.844 0.805,1.906 0,1.508 -1.649,2.407 0.985,0.21 1.57,0.945 0.595,0.734 0.595,1.773 0,1.508 -1.102,2.57 -1.102,1.063 -2.742,1.063 -1.555,0 -2.578,-0.89 -1.024,-0.899 -1.188,-2.344"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0" /><path
-   id="path1097"
-   d="m 142.086,81.06 q -0.851,-0.36 -1.242,-0.985 -0.383,-0.633 -0.383,-1.383 0,-1.281 0.89,-2.117 0.9,-0.836 2.548,-0.836 1.633,0 2.531,0.836 0.906,0.836 0.906,2.117 0,0.797 -0.414,1.422 -0.414,0.617 -1.164,0.945 0.953,0.383 1.446,1.117 0.5,0.735 0.5,1.696 0,1.586 -1.016,2.578 -1.008,0.992 -2.688,0.992 -1.562,0 -2.601,-0.82 -1.227,-0.969 -1.227,-2.656 0,-0.93 0.461,-1.704 0.461,-0.78 1.453,-1.203 m 0.453,-2.212 q 0,0.657 0.368,1.024 0.375,0.367 0.992,0.367 0.625,0 1,-0.367 0.375,-0.375 0.375,-1.031 0,-0.618 -0.375,-0.985 -0.367,-0.375 -0.977,-0.375 -0.633,0 -1.008,0.375 -0.375,0.375 -0.375,0.992 m -0.203,4.907 q 0,0.906 0.461,1.414 0.469,0.507 1.164,0.507 0.68,0 1.125,-0.484 0.446,-0.492 0.446,-1.414 0,-0.805 -0.453,-1.289 -0.454,-0.492 -1.149,-0.492 -0.805,0 -1.203,0.554 -0.39,0.555 -0.39,1.204"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0" /><path
-   id="path1099"
-   d="m 153.446,83.512 2.25,-0.218 q 0.203,1.132 0.82,1.664 0.625,0.531 1.68,0.531 1.117,0 1.68,-0.469 0.57,-0.476 0.57,-1.11 0,-0.405 -0.242,-0.687 -0.235,-0.289 -0.829,-0.5 -0.406,-0.14 -1.851,-0.5 -1.86,-0.46 -2.61,-1.132 -1.054,-0.946 -1.054,-2.305 0,-0.875 0.492,-1.633 0.5,-0.766 1.43,-1.164 0.937,-0.398 2.257,-0.398 2.157,0 3.243,0.945 1.093,0.945 1.148,2.523 l -2.312,0.102 q -0.149,-0.883 -0.641,-1.266 -0.484,-0.39 -1.461,-0.39 -1.008,0 -1.578,0.414 -0.367,0.265 -0.367,0.71 0,0.407 0.343,0.696 0.438,0.367 2.125,0.766 1.688,0.398 2.493,0.828 0.812,0.422 1.265,1.164 0.461,0.734 0.461,1.82 0,0.984 -0.547,1.844 -0.547,0.86 -1.547,1.281 -1,0.414 -2.492,0.414 -2.172,0 -3.336,-1 -1.164,-1.008 -1.39,-2.93"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0" /><path
-   id="path1101"
-   d="M 164.625,87.239 V 75.786 h 2.196 v 6.078 l 2.57,-2.922 h 2.703 l -2.836,3.031 3.04,5.266 h -2.368 l -2.086,-3.727 -1.023,1.07 v 2.657 z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0" /><path
-   id="path1103"
-   d="m 173.063,84.2 2.125,-0.258 q 0.101,0.813 0.547,1.242 0.445,0.43 1.078,0.43 0.68,0 1.14,-0.516 0.47,-0.515 0.47,-1.39 0,-0.828 -0.446,-1.313 -0.445,-0.484 -1.086,-0.484 -0.422,0 -1.008,0.164 l 0.242,-1.79 q 0.891,0.024 1.36,-0.382 0.469,-0.414 0.469,-1.094 0,-0.578 -0.344,-0.922 -0.344,-0.343 -0.914,-0.343 -0.563,0 -0.961,0.39 -0.399,0.39 -0.485,1.14 l -2.023,-0.343 q 0.21,-1.039 0.633,-1.656 0.43,-0.625 1.187,-0.977 0.766,-0.359 1.711,-0.359 1.617,0 2.594,1.031 0.805,0.844 0.805,1.906 0,1.508 -1.649,2.407 0.985,0.21 1.57,0.945 0.594,0.734 0.594,1.773 0,1.508 -1.101,2.57 -1.102,1.063 -2.742,1.063 -1.555,0 -2.579,-0.89 -1.023,-0.899 -1.187,-2.344"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0" /><path
-   id="path1105"
-   d="m 189.547,87.239 v -9.516 h -3.398 v -1.937 h 9.101 v 1.937 h -3.39 v 9.516 z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0" /><path
-   id="path1107"
-   d="m 194.954,87.239 v -2.195 h 2.195 v 2.195 z"
-   style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0" />&#10;  <g
-   id="g67143"
-   class="supplied clef, supplied key"
-   transform="translate(36.677 -.5)">&#10;    <g
-   id="g1339"
-   transform="translate(744.5 -70.408)">&#10;      <g
-   id="text1317"
-   aria-label="b"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#777;stroke-width:1.33333004">&#10;        <path
-   id="path67145"
-   d="M66.85 273.265v5.27q.306-.285.568-.46.263-.174.503-.262.24-.11.503-.153.285-.044.634-.044.416 0 .744.175t.568.46.372.634q.131.35.131.678.022.35-.065.7-.088.327-.219.612-.153.371-.481.656-.328.284-.59.546-.088.088-.372.306-.284.219-.656.481-.35.263-.744.525-.393.284-.721.503-.328.24-.547.394l-.197.175v-12.924h.569zm1.771 5.75q-.11-.13-.306-.218-.175-.087-.394-.087-.218 0-.437.13-.219.132-.394.46-.218.416-.24 1.05v2.995l.131-.109q.131-.087.306-.262.197-.153.394-.35.218-.197.393-.35.307-.284.525-.612t.328-.831q.131-.503.066-.984-.066-.481-.372-.831" />&#10;      </g>&#10;      <g
-   id="g1234"
-   transform="matrix(.75 0 0 .75 49.722 71.408)">&#10;        <g
-   id="text1224"
-   aria-label="&amp;"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#777;stroke-width:1.33333004">&#10;          <path
-   id="path67148"
-   d="M12.352 291.983q-.612.11-1.312.13-.678.023-1.334-.043-.656-.043-1.224-.153-.547-.087-.897-.262-1.684-.81-2.733-1.728-1.028-.896-1.597-1.88-.568-.984-.809-2.012-.218-1.05-.284-2.1-.087-1.136.197-2.273.306-1.137.809-2.165.525-1.05 1.18-1.924.679-.875 1.356-1.531.788-.743 1.64-1.465.875-.744 1.903-1.509-.022-.284-.066-.503-.022-.218-.065-.437-.044-.24-.11-.525-.043-.284-.065-.7 0-.175-.044-.634-.044-.48-.066-1.137 0-.678.044-1.53.044-.853.219-1.772.11-.546.459-1.377.372-.853.853-1.64.503-.787 1.05-1.356.546-.569 1.027-.569.24 0 .525.307.284.284.547.787.284.48.546 1.115.263.612.46 1.268.196.656.306 1.29.13.635.153 1.116.022 1.137-.088 2.011-.11.853-.328 1.553-.218.678-.525 1.268-.284.569-.612 1.159-.35.59-.721 1.05-.35.437-.722.896-.394.481-.831.81-.415.305-.831.677.197 1.115.35 2.012.066.393.131.765.066.372.11.7.043.306.087.525.044.196.044.24.524-.065 1.071 0 .569.044 1.072.153.524.11.918.285.415.174.656.328 1.18.874 1.662 2.011.503 1.115.59 2.296.066.919-.153 1.837-.219.94-.743 1.771-.503.853-1.334 1.553-.81.7-1.924 1.159l.24 1.662q.11.656.197 1.268.087.634.131.874.197 1.312.153 2.143-.044.853-.328 1.378-.24.437-.568.853-.306.415-.744.743-.437.328-1.028.547-.568.219-1.312.262-.568.044-1.355-.109-.787-.131-1.51-.503-.72-.35-1.245-.962t-.59-1.509q-.045-.525.065-1.071.11-.525.371-.962.285-.416.722-.7.46-.284 1.115-.328.394-.022.787.11.416.152.766.415.35.262.568.656.219.393.263.852.065.81-.503 1.553-.569.765-1.924 1.137.218.306.83.569.613.284 1.531.284.962 0 1.837-.569.896-.568 1.378-1.421.306-.569.306-1.487 0-.897-.11-1.815-.043-.153-.13-.765-.088-.59-.198-1.247-.109-.765-.262-1.705m.46-27.705q-.854 0-1.51.809-.634.787-1.05 2.012-.393 1.224-.524 2.69-.131 1.464.066 2.82.721-.547 1.508-1.312.788-.787 1.422-1.662.656-.875 1.05-1.771.415-.897.35-1.706-.023-.262-.088-.59-.066-.328-.219-.612-.153-.285-.394-.481-.24-.197-.612-.197m-.045 26.808q.94-.328 1.465-.853t.766-1.137q.262-.612.284-1.224.044-.612.022-1.094-.044-.393-.197-.984-.131-.59-.525-1.137-.393-.546-1.115-.896-.721-.372-1.924-.306zm-1.793-7.588q-.896.044-1.487.372-.568.306-.918.766-.328.437-.46.94-.109.503-.087.896.022.394.175.81.153.415.394.765.262.371.547.656.306.306.612.459-.044.044-.088.066-.022.043-.065.087t-.066.088q-.678-.328-1.203-.788-.502-.437-.656-.634-.24-.328-.415-.59-.175-.263-.284-.569-.11-.284-.197-.634-.066-.35-.088-.83-.043-.46.066-.963.11-.525.35-1.05.262-.524.656-1.005.415-.503.962-.94.284-.22.503-.35.24-.132.437-.22.197-.109.394-.152.219-.066.46-.131l-.657-3.958q-.262.153-.853.612-.59.46-1.29 1.093-.7.634-1.4 1.378-.677.721-1.114 1.4-.788 1.246-1.225 2.295-.437 1.05-.328 2.274.087 1.378.83 2.559.766 1.203 1.947 2.012 1.18.809 2.69 1.115 1.508.328 3.127-.066-.35-2.165-.635-3.87-.13-.722-.24-1.422t-.219-1.246q-.087-.547-.13-.875z" />&#10;        </g>&#10;        <g
-   id="g1232"
-   transform="translate(.133 247.042)">&#10;          <path
-   id="path1228"
-   d="M1.839 53.386H-.758V14.42H1.84"
-   style="fill:none;stroke:#777;stroke-width:.87066698;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />&#10;          <path
-   id="path1230"
-   d="M28.635 14.421h2.597v38.965h-2.597"
-   style="fill:none;stroke:#777;stroke-width:.87066698;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />&#10;        </g>&#10;      </g>&#10;    </g>&#10;    <g
-   id="g1362-5"
-   transform="translate(601.243 -169.445)">&#10;      <g
-   id="g1313-2"
-   transform="translate(50 5.5)">&#10;        <g
-   id="g1311-1"
-   transform="translate(137.94 -82.406)">&#10;          <g
-   id="g1305-1">&#10;            <g
-   id="text1297-7"
-   aria-label="b"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#777;fill-opacity:.94117599;stroke-width:1.33333004">&#10;              <path
-   id="path67151"
-   d="M24.141 520.403v5.27q.306-.284.569-.46.262-.174.503-.262.24-.11.503-.153.284-.044.634-.044.415 0 .743.175t.569.46.371.634.132.678q.022.35-.066.7-.087.327-.219.612-.153.371-.48.656-.329.284-.591.546-.088.088-.372.306-.284.219-.656.481-.35.263-.743.525-.394.285-.722.503-.328.24-.547.394l-.196.175v-12.923h.568zm1.771 5.75q-.109-.13-.306-.218-.175-.087-.393-.087t-.438.13-.393.46q-.219.416-.24 1.05v2.995l.13-.109q.132-.087.307-.262.196-.153.393-.35.219-.197.394-.35.306-.284.525-.612.218-.328.328-.831.13-.503.065-.984t-.372-.831" />&#10;            </g>&#10;          </g>&#10;          <path
-   id="path1307-7"
-   d="M7.266 536.894H4.67v-28.465h2.597"
-   style="fill:none;stroke:#777;stroke-width:.653;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />&#10;          <path
-   id="path1309-1"
-   d="M27.846 508.43h2.597v28.464h-2.597"
-   style="fill:none;stroke:#777;stroke-width:.653;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />&#10;        </g>&#10;      </g>&#10;      <g
-   id="text74-8-3"
-   aria-label="?"
-   style="font-size:16.39999962px;font-family:Maestro;fill:#777;stroke-width:1.33333004">&#10;        <path
-   id="path67154"
-   d="M204.11 444.331q-.148.279-.295.508-.132.23-.28.443-.147.213-.31.41-.165.213-.378.46-.213.245-.41.442-.18.197-.377.377-.18.18-.394.345-.213.18-.475.377-.328.246-.624.426-.278.18-.574.328-.278.148-.59.263-.312.131-.689.279-.377.147-.836.262-.443.131-.853.213-.476.099-.951.18l-.115-.245q.77-.263 1.542-.607.64-.295 1.344-.722.722-.41 1.247-.951 1.328-1.41 2.017-3.116.689-1.69.656-3.854 0-.492-.115-1.132-.098-.64-.377-1.213-.262-.574-.754-.984-.476-.41-1.247-.41-.443 0-.951.18-.492.18-.902.492-.41.295-.672.722-.263.41-.214.885.017.066.099.05.098-.033.262-.082.18-.05.427-.099.262-.049.606-.033.361.017.624.23.262.197.426.508.164.312.213.69.05.36-.033.704-.13.542-.492.853-.344.328-.967.328-.394 0-.771-.147-.36-.132-.64-.394-.278-.246-.459-.623-.164-.361-.164-.837-.016-.705.148-1.246.18-.541.426-.935.263-.393.541-.64.296-.262.542-.41.606-.377 1.23-.508.623-.147 1.18-.164.624 0 1.247.213.64.197 1.197.59.558.378 1 .92.443.524.673 1.18.279.738.279 1.558.016.836-.197 1.804-.066.328-.148.59-.082.263-.18.509-.099.246-.23.492-.115.246-.262.541m1.656-6.314q-.016-.377.246-.623.263-.263.64-.263.377-.016.64.23.278.246.278.623.017.377-.246.656-.262.263-.64.263-.377.016-.655-.246-.263-.263-.263-.64m0 4.133q0-.377.263-.623.262-.246.64-.263.376 0 .639.23.279.246.279.623.016.377-.246.64-.263.278-.64.278-.377.017-.656-.246-.262-.262-.279-.64" />&#10;      </g>&#10;    </g>&#10;  </g>&#10;  <g
-   id="g955"
-   class="tkk"
-   transform="translate(35.677 -.5)">&#10;    <g
-   id="text61016"
-   aria-label="˙"
-   style="font-size:16.39999962px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004">&#10;      <path
-   id="path1116"
-   d="M830.787 287.329c-.312-.558-1.083-.64-1.427-.672-.918-.115-1.673.114-2.165.393-.492.295-1.148.853-1.46 1.673-.114.328-.344.984-.016 1.542.328.524 1.132.672 1.575.705.738.065 1.41-.05 1.918-.312.509-.246 1.214-.918 1.526-1.755.114-.311.311-1.115.049-1.574m-.377.279c.311.541-.312 1.082-.771 1.377-.345.23-.623.394-.951.574s-.624.345-1 .525c-.51.263-1.28.525-1.608-.016-.312-.541.312-1.083.787-1.378.345-.23.64-.41.968-.59s.59-.345.967-.525c.509-.246 1.28-.508 1.608.033"
-   style="font-size:16.39999962px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004" />&#10;    </g>&#10;    <g
-   id="text61018"
-   aria-label="˙"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">&#10;      <path
-   id="path1119"
-   d="M840.113 285.076c-.415-.744-1.443-.853-1.902-.897-1.224-.153-2.23.153-2.886.525-.656.394-1.531 1.137-1.946 2.23-.154.438-.46 1.312-.022 2.056.437.7 1.508.896 2.099.94.984.088 1.88-.065 2.558-.415.678-.328 1.618-1.225 2.034-2.34.153-.415.415-1.487.065-2.1m-.502.372c.415.721-.416 1.443-1.028 1.836-.46.306-.831.525-1.268.766-.438.24-.831.459-1.334.7-.678.35-1.706.7-2.143-.023-.416-.721.415-1.443 1.05-1.836.459-.306.852-.547 1.29-.788.437-.24.787-.459 1.29-.7.677-.327 1.705-.677 2.143.044"
-   style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004" />&#10;    </g>&#10;    <path
-   id="line61014-9"
-   d="M830.565 286.651V272.53"
-   style="fill:none;stroke:#777;stroke-width:.64251965;stroke-miterlimit:4;stroke-dasharray:1.92755891,1.92755891;stroke-dashoffset:0;stroke-opacity:1" />&#10;  </g>&#10;  <g
-   id="g19"
-   class="supplied clef, supplied key">&#10;    <g
-   id="g6"
-   transform="translate(781.176 -70.907)">&#10;      <g
-   id="g2"
-   aria-label="b"
-   style="font-size:21.8666px;font-family:Maestro;fill:#777;stroke-width:1.33333">&#10;        <path
-   id="path1"
-   d="M66.85 273.265v5.27q.306-.285.568-.46.263-.174.503-.262.24-.11.503-.153.285-.044.634-.044.416 0 .744.175t.568.46.372.634q.131.35.131.678.022.35-.065.7-.088.327-.219.612-.153.371-.481.656-.328.284-.59.546-.088.088-.372.306-.284.219-.656.481-.35.263-.744.525-.393.284-.721.503-.328.24-.547.394l-.197.175v-12.924h.569zm1.771 5.75q-.11-.13-.306-.218-.175-.087-.394-.087-.218 0-.437.13-.219.132-.394.46-.218.416-.24 1.05v2.995l.131-.109q.131-.087.306-.262.197-.153.394-.35.218-.197.393-.35.307-.284.525-.612t.328-.831q.131-.503.066-.984-.066-.481-.372-.831" />&#10;      </g>&#10;      <g
-   id="g5"
-   transform="matrix(.75 0 0 .75 49.722 71.408)">&#10;        <g
-   id="g3"
-   aria-label="&amp;"
-   style="font-size:21.8666px;font-family:Maestro;fill:#777;stroke-width:1.33333">&#10;          <path
-   id="path2"
-   d="M12.352 291.983q-.612.11-1.312.13-.678.023-1.334-.043-.656-.043-1.224-.153-.547-.087-.897-.262-1.684-.81-2.733-1.728-1.028-.896-1.597-1.88-.568-.984-.809-2.012-.218-1.05-.284-2.1-.087-1.136.197-2.273.306-1.137.809-2.165.525-1.05 1.18-1.924.679-.875 1.356-1.531.788-.743 1.64-1.465.875-.744 1.903-1.509-.022-.284-.066-.503-.022-.218-.065-.437-.044-.24-.11-.525-.043-.284-.065-.7 0-.175-.044-.634-.044-.48-.066-1.137 0-.678.044-1.53.044-.853.219-1.772.11-.546.459-1.377.372-.853.853-1.64.503-.787 1.05-1.356.546-.569 1.027-.569.24 0 .525.307.284.284.547.787.284.48.546 1.115.263.612.46 1.268.196.656.306 1.29.13.635.153 1.116.022 1.137-.088 2.011-.11.853-.328 1.553-.218.678-.525 1.268-.284.569-.612 1.159-.35.59-.721 1.05-.35.437-.722.896-.394.481-.831.81-.415.305-.831.677.197 1.115.35 2.012.066.393.131.765.066.372.11.7.043.306.087.525.044.196.044.24.524-.065 1.071 0 .569.044 1.072.153.524.11.918.285.415.174.656.328 1.18.874 1.662 2.011.503 1.115.59 2.296.066.919-.153 1.837-.219.94-.743 1.771-.503.853-1.334 1.553-.81.7-1.924 1.159l.24 1.662q.11.656.197 1.268.087.634.131.874.197 1.312.153 2.143-.044.853-.328 1.378-.24.437-.568.853-.306.415-.744.743-.437.328-1.028.547-.568.219-1.312.262-.568.044-1.355-.109-.787-.131-1.51-.503-.72-.35-1.245-.962t-.59-1.509q-.045-.525.065-1.071.11-.525.371-.962.285-.416.722-.7.46-.284 1.115-.328.394-.022.787.11.416.152.766.415.35.262.568.656.219.393.263.852.065.81-.503 1.553-.569.765-1.924 1.137.218.306.83.569.613.284 1.531.284.962 0 1.837-.569.896-.568 1.378-1.421.306-.569.306-1.487 0-.897-.11-1.815-.043-.153-.13-.765-.088-.59-.198-1.247-.109-.765-.262-1.705m.46-27.705q-.854 0-1.51.809-.634.787-1.05 2.012-.393 1.224-.524 2.69-.131 1.464.066 2.82.721-.547 1.508-1.312.788-.787 1.422-1.662.656-.875 1.05-1.771.415-.897.35-1.706-.023-.262-.088-.59-.066-.328-.219-.612-.153-.285-.394-.481-.24-.197-.612-.197m-.045 26.808q.94-.328 1.465-.853t.766-1.137q.262-.612.284-1.224.044-.612.022-1.094-.044-.393-.197-.984-.131-.59-.525-1.137-.393-.546-1.115-.896-.721-.372-1.924-.306zm-1.793-7.588q-.896.044-1.487.372-.568.306-.918.766-.328.437-.46.94-.109.503-.087.896.022.394.175.81.153.415.394.765.262.371.547.656.306.306.612.459-.044.044-.088.066-.022.043-.065.087t-.066.088q-.678-.328-1.203-.788-.502-.437-.656-.634-.24-.328-.415-.59-.175-.263-.284-.569-.11-.284-.197-.634-.066-.35-.088-.83-.043-.46.066-.963.11-.525.35-1.05.262-.524.656-1.005.415-.503.962-.94.284-.22.503-.35.24-.132.437-.22.197-.109.394-.152.219-.066.46-.131l-.657-3.958q-.262.153-.853.612-.59.46-1.29 1.093-.7.634-1.4 1.378-.677.721-1.114 1.4-.788 1.246-1.225 2.295-.437 1.05-.328 2.274.087 1.378.83 2.559.766 1.203 1.947 2.012 1.18.809 2.69 1.115 1.508.328 3.127-.066-.35-2.165-.635-3.87-.13-.722-.24-1.422t-.219-1.246q-.087-.547-.13-.875z" />&#10;        </g>&#10;        <g
-   id="g4"
-   transform="translate(.133 247.042)">&#10;          <path
-   id="path3"
-   d="M1.839 53.386H-.758V14.42H1.84"
-   style="fill:none;stroke:#777;stroke-width:.870667;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />&#10;          <path
-   id="path4"
-   d="M28.635 14.421h2.597v38.965h-2.597"
-   style="fill:none;stroke:#777;stroke-width:.870667;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />&#10;        </g>&#10;      </g>&#10;    </g>&#10;    <g
-   id="g14"
-   transform="translate(637.92 -169.944)">&#10;      <g
-   id="g12"
-   transform="translate(50 5.5)">&#10;        <g
-   id="g11"
-   transform="translate(137.94 -82.406)">&#10;          <g
-   id="g10">&#10;            <g
-   id="g8"
-   aria-label="b"
-   style="font-size:21.8666px;font-family:Maestro;fill:#777;fill-opacity:.941176;stroke-width:1.33333">&#10;              <path
-   id="path7"
-   d="M24.141 520.403v5.27q.306-.284.569-.46.262-.174.503-.262.24-.11.503-.153.284-.044.634-.044.415 0 .743.175t.569.46.371.634.132.678q.022.35-.066.7-.087.327-.219.612-.153.371-.48.656-.329.284-.591.546-.088.088-.372.306-.284.219-.656.481-.35.263-.743.525-.394.285-.722.503-.328.24-.547.394l-.196.175v-12.923h.568zm1.771 5.75q-.109-.13-.306-.218-.175-.087-.393-.087t-.438.13-.393.46q-.219.416-.24 1.05v2.995l.13-.109q.132-.087.307-.262.196-.153.393-.35.219-.197.394-.35.306-.284.525-.612.218-.328.328-.831.13-.503.065-.984t-.372-.831" />&#10;            </g>&#10;          </g>&#10;          <path
-   id="path10"
-   d="M7.266 536.894H4.67v-28.465h2.597"
-   style="fill:none;stroke:#777;stroke-width:.653;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />&#10;          <path
-   id="path11"
-   d="M27.846 508.43h2.597v28.464h-2.597"
-   style="fill:none;stroke:#777;stroke-width:.653;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />&#10;        </g>&#10;      </g>&#10;      <g
-   id="g13"
-   aria-label="?"
-   style="font-size:16.4px;font-family:Maestro;fill:#777;stroke-width:1.33333">&#10;        <path
-   id="path12"
-   d="M204.11 444.331q-.148.279-.295.508-.132.23-.28.443-.147.213-.31.41-.165.213-.378.46-.213.245-.41.442-.18.197-.377.377-.18.18-.394.345-.213.18-.475.377-.328.246-.624.426-.278.18-.574.328-.278.148-.59.263-.312.131-.689.279-.377.147-.836.262-.443.131-.853.213-.476.099-.951.18l-.115-.245q.77-.263 1.542-.607.64-.295 1.344-.722.722-.41 1.247-.951 1.328-1.41 2.017-3.116.689-1.69.656-3.854 0-.492-.115-1.132-.098-.64-.377-1.213-.262-.574-.754-.984-.476-.41-1.247-.41-.443 0-.951.18-.492.18-.902.492-.41.295-.672.722-.263.41-.214.885.017.066.099.05.098-.033.262-.082.18-.05.427-.099.262-.049.606-.033.361.017.624.23.262.197.426.508.164.312.213.69.05.36-.033.704-.13.542-.492.853-.344.328-.967.328-.394 0-.771-.147-.36-.132-.64-.394-.278-.246-.459-.623-.164-.361-.164-.837-.016-.705.148-1.246.18-.541.426-.935.263-.393.541-.64.296-.262.542-.41.606-.377 1.23-.508.623-.147 1.18-.164.624 0 1.247.213.64.197 1.197.59.558.378 1 .92.443.524.673 1.18.279.738.279 1.558.016.836-.197 1.804-.066.328-.148.59-.082.263-.18.509-.099.246-.23.492-.115.246-.262.541m1.656-6.314q-.016-.377.246-.623.263-.263.64-.263.377-.016.64.23.278.246.278.623.017.377-.246.656-.262.263-.64.263-.377.016-.655-.246-.263-.263-.263-.64m0 4.133q0-.377.263-.623.262-.246.64-.263.376 0 .639.23.279.246.279.623.016.377-.246.64-.263.278-.64.278-.377.017-.656-.246-.262-.262-.279-.64" />&#10;      </g>&#10;    </g>&#10;  </g>&#10;<path
-   d="m 203.46707,84.12545 2.1875,-0.226562 q 0.0937,0.742187 0.55469,1.179687 0.46094,0.429688 1.0625,0.429688 0.6875,0 1.16406,-0.554688 0.47656,-0.5625 0.47656,-1.6875 0,-1.054687 -0.47656,-1.578125 -0.46875,-0.53125 -1.22656,-0.53125 -0.94531,0 -1.69531,0.835938 l -1.78125,-0.257813 1.125,-5.960937 h 5.80468 v 2.054687 h -4.14062 l -0.34375,1.945313 q 0.73437,-0.367188 1.5,-0.367188 1.46094,0 2.47656,1.0625 1.01563,1.0625 1.01563,2.757813 0,1.414062 -0.82032,2.523437 -1.11718,1.515625 -3.10156,1.515625 -1.58594,0 -2.58594,-0.851562 -1,-0.851563 -1.19531,-2.289063 z"
-   id="text1"
-   style="font-weight:bold;font-size:16px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';stroke-width:0.88063;stroke-opacity:0.866667"
-   aria-label="5" /></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" id="svg61035" width="1116.961" height="451.57" x="0" y="0" version="1.1" viewBox="0 0 1116.961 451.57">
+  <font id="font60842" horiz-adv-x="1000" horiz-origin-x="0" horiz-origin-y="0" vert-adv-y="1024" vert-origin-x="512" vert-origin-y="768">
+    <font-face id="font-face60826" font-family="'Maestro'" underline-position="-78" underline-thickness="9" units-per-em="1000">
+      <font-face-src>
+        <font-face-name name="Maestro"/>
+      </font-face-src>
+    </font-face>
+    <glyph id="glyph60830" d="M72 62V-87l98 32V94M43 156v163h29V166l98 32v146h29V207l39 13V116l-39-13V-45l39 12v-103l-39-13v-163h-29v154l-98-32v-148H43v138L0-214v104l43 14V53L0 39v103z" horiz-adv-x="236" unicode="#"/>
+    <glyph id="glyph60832" d="M466-252c-19-3-38-5-59-6s-42 0-62 2c-20 1-38 4-55 7q-25.5 4.5-42 12c-51 25-93 51-124 79-32 27-57 56-74 86Q24.5-27 14 21C7 52 2 84 0 116c-3 35 1 69 10 104s21 68 37 100q22.5 46.5 54 87c20 27 40 50 61 70 24 23 49 45 76 68 26 22 55 45 86 68-1 9-1 16-2 23s-3 14-4 21-3 14-4 23c-2 9-3 19-4 32 0 5-1 15-2 30-1 14-2 31-2 52-1 20 0 43 1 69s5 53 10 81c3 17 11 38 22 64 11 25 24 50 39 74s30 45 47 62 32 26 47 26c7 0 15-4 24-13s17-21 26-36q12-22.5 24-51c8-19 15-39 21-59s11-40 15-59q4.5-28.5 6-51c1-35-1-65-4-91-3-27-8-50-15-71s-14-41-23-58c-9-18-19-36-29-54-11-18-21-34-32-47-11-14-23-28-34-42-12-15-24-27-37-36-13-10-26-21-39-32 6-34 11-65 16-92 2-12 4-24 6-35s4-22 5-31c1-10 3-18 4-24 1-7 2-11 2-12 16 2 33 2 50 1 17-2 33-5 49-8 15-3 29-8 42-13 12-5 22-10 29-15 36-27 62-57 77-91 15-35 23-70 26-106 2-28 0-56-7-84q-10.5-43.5-33-81c-16-26-36-50-61-71s-55-39-89-53c4-27 8-53 11-76 3-20 6-39 9-58s5-33 6-40c6-40 8-73 7-98q-1.5-39-15-63c-7-13-16-26-25-39-10-13-22-24-35-34s-29-18-46-25c-18-7-38-11-61-12-17-1-38 0-62 5-24 4-47 12-69 23s-41 25-57 44q-24 28.5-27 69c-1 16 0 32 3 49 3 16 9 31 18 44 8 13 19 23 33 32 13 9 30 14 50 15 12 1 24-1 37-5 12-5 23-11 34-19s19-18 26-30q10.5-18 12-39c2-25-6-48-23-71s-47-41-88-52c7-9 19-18 38-26 19-9 42-13 70-13 29 0 58 9 85 26s47 39 62 65c9 17 14 40 14 68 0 27-2 55-5 83-1 5-3 16-6 35q-4.5 27-9 57-4.5 34.5-12 78m21 1267c-26 0-49-12-68-36q-30-37.5-48-93c-13-37-21-78-25-123q-6-67.5 3-129c22 17 45 37 69 61q36 34.5 66 75 28.5 40.5 48 81 18 40.5 15 78c-1 8-2 17-4 27s-5 19-10 28-11 16-18 22-17 9-28 9m-2-1226c29 10 51 23 67 39s28 33 36 52c7 19 12 37 13 56s1 35 0 50c-1 12-4 27-8 45-5 18-13 35-25 52q-18 25.5-51 42c-22 11-51 15-88 13m-26-2c-27-1-50-7-67-16-18-10-32-22-42-35-11-14-18-29-21-44-4-15-6-29-5-41s3-24 8-37 11-24 19-35c7-11 16-21 25-30s18-16 27-21l-3-3-4-4c-1-1-2-3-3-4q-31.5 15-54 36c-16 13-26 23-31 29-7 10-14 19-19 27s-10 17-13 26-6 18-8 29c-3 11-4 23-5 38q-1.5 21 3 45c3 15 9 31 17 47 7 16 17 32 30 47 12 15 26 29 43 42 9 7 17 12 24 16s13 8 19 11 12 5 19 7c6 1 13 3 20 5l-30 181c-8-5-21-14-39-28s-38-31-59-50-42-40-63-62c-21-23-39-44-52-65-24-38-43-73-56-105S65 75 68 38q4.5-63 39-117c23-37 52-67 88-92q54-37.5 123-51c46-10 94-9 143 3-11 66-20 125-29 177-4 22-8 44-11 65q-4.5 31.5-9 57c-3 17-6 30-7 41-1 10-2 15-2 15" horiz-adv-x="709" unicode="&amp;"/>
+    <glyph id="glyph60834" d="M502-262c-6-11-12-22-17-31l-18-27c-6-9-12-17-19-25-7-9-14-18-23-28q-13.5-15-24-27l-23-23c-8-7-16-14-25-21s-18-15-29-23c-13-10-26-19-37-26-12-7-24-14-35-20-12-6-24-11-37-16s-27-11-42-17-32-11-50-16c-19-5-36-10-53-13-19-4-39-8-58-11l-7 15c31 11 63 23 94 37 26 12 54 27 83 44s54 36 75 58c54 57 95 121 123 190S421-95 420-7q0 30-6 69c-5 26-12 51-23 74s-27 43-46 60c-20 17-46 25-77 25-18 0-37-4-57-11-21-7-39-17-56-29-17-13-30-27-41-44s-15-36-13-55c1-3 3-3 7-2 3 1 9 2 16 4s15 4 26 6c10 2 22 3 36 2 15-1 27-5 38-13 11-9 19-19 26-32s11-26 13-41 1-30-2-44c-5-22-15-39-29-52-15-13-35-20-60-20-16 0-31 3-46 9-15 5-29 13-40 24-11 10-20 23-27 38S48-7 48 12c-1 29 3 54 10 76s15 41 26 57c10 16 21 29 33 40 11 10 22 18 32 24 25 15 50 26 75 32q37.5 7.5 72 9c25 0 51-4 77-12q37.5-13.5 72-36c23-16 43-35 61-56 18-22 32-46 41-73 11-30 17-62 18-95 0-34-4-71-13-110q-4.5-19.5-9-36c-3-11-7-21-11-31s-8-20-13-30-11-21-17-33m101 385q-1.5 22.5 15 39 16.5 15 39 15c15 1 29-4 40-14s16-23 16-38q1.5-22.5-15-39c-11-11-24-17-39-17q-22.5-1.5-39 15c-11 11-17 24-17 39m0-252c0 15 5 28 16 38s24 15 39 16c15 0 29-5 40-14 11-10 16-23 16-38q1.5-22.5-15-39c-11-11-24-17-39-17q-22.5-1.5-39 15t-18 39" horiz-adv-x="723" unicode="?"/>
+    <glyph id="glyph60836" d="M26 354V113c9 9 18 16 26 21s16 10 23 13 15 5 24 6c8 1 17 2 28 2 13 0 24-3 34-8s19-12 26-21 13-18 17-29 6-21 6-31c1-11 0-21-3-31-3-11-6-20-10-29-5-11-12-21-22-30s-19-17-27-25c-3-3-8-7-17-14s-18-14-29-22-23-16-35-24c-12-9-23-16-33-23q-15-10.5-24-18c-7-5-10-8-10-8v591h26m81-342c-3 4-8 7-13 10-6 3-12 4-19 4s-13-2-20-6q-10.5-6-18-21c-7-13-10-28-10-47-1-19-1-37-1-52v-86s2 2 6 5q6 4.5 15 12c5 5 11 10 18 16 6 6 12 11 17 16 9 9 17 18 24 28s12 23 15 38q6 22.5 3 45c-2 15-8 27-17 38" horiz-adv-x="210" unicode="b"/>
+    <glyph id="glyph60838" d="M8-1c7 18 17 35 31 50 13 15 29 29 47 41 18 11 37 20 58 27q31.5 9 63 9c21 0 40-3 56-10s29-17 38-28c9-12 15-26 18-41 2-16 0-33-7-51s-17-35-31-50c-14-16-30-30-48-41-18-12-37-21-58-27-21-7-42-10-63-10s-40 4-55 11c-16 7-29 16-38 28Q4-75 1-51C-1-36 1-19 8-1" horiz-adv-x="319" unicode="œ"/>
+    <glyph id="glyph60840" d="M320 89c4-7 7-15 8-24s1-18 0-27-3-18-5-26-4-14-6-19c-9-25-23-48-42-67s-36-33-51-40c-33-17-72-23-117-19-7 1-14 2-23 3s-18 4-27 7-18 8-26 13c-9 5-15 12-20 20-5 9-8 18-9 27S1-46 2-37c1 8 2 16 4 23Q9-3.5 12 4c9 25 23 46 40 63s34 30 49 39q22.5 13.5 57 21 33 7.5 75 3c5-1 12-1 20-2s16-3 25-6q12-4.5 24-12 10.5-7.5 18-21m-23-17c-5 8-12 13-19 16-8 3-16 4-25 3s-19-3-28-6-18-7-26-11c-11-5-21-11-30-16s-19-11-29-16c-19-11-39-23-59-36-7-5-15-10-22-16-8-6-15-13-20-20s-9-15-10-23c-2-9-1-17 4-25s11-13 19-16 17-3 26-2 18 3 27 6 18 7 26 11c11 5 22 11 32 16 9 5 19 11 29 16s20 11 29 16 18 12 29 19c7 5 14 10 22 16 7 6 14 13 19 20s9 15 11 24c1 8 0 16-5 24" horiz-adv-x="328" unicode="˙"/>
+  </font>
+  <font id="font60876" horiz-adv-x="2048" horiz-origin-x="0" horiz-origin-y="0" vert-adv-y="1024" vert-origin-x="512" vert-origin-y="768">
+    <font-face id="font-face60844" font-family="'Times New Roman'" underline-position="-223" underline-thickness="100" units-per-em="2048">
+      <font-face-src>
+        <font-face-name name="Times New Roman"/>
+      </font-face-src>
+    </font-face>
+    <glyph id="glyph60848" horiz-adv-x="512"/>
+    <glyph id="glyph60850" d="M494 1044c-3 46-12 92-28 137-23 65-34 110-34 135 0 35 8 61 25 79q24 27 60 27 31.5 0 54-27c15-18 23-44 23-77 0-30-9-72-26-125-18-54-29-104-33-149 37 23 70 52 99 85 45 53 79 85 101 98s44 19 67 19c22 0 41-7 56-22s22-33 22-54q0-37.5-33-66c-22-19-77-39-165-58-51-11-94-24-128-39 35-18 77-32 127-41 81-15 134-33 159-55s37-46 37-72c0-20-7-37-22-52s-33-22-53-22q-30 0-66 21c-25 14-58 45-99 94-27 33-61 63-102 92 1-38 9-79 23-124 24-79 36-132 36-161 0-27-8-49-24-67-16-19-33-28-51-28-25 0-47 10-67 29-14 14-21 36-21 67 0 32 8 71 23 116s25 76 29 93 8 42 11 75c-39-26-74-55-103-87-49-55-85-89-110-104-17-11-35-16-54-16-23 0-42 8-58 23q-24 22.5-24 51c0 17 7 34 21 53 13 18 34 33 61 45 18 8 59 19 123 32 41 9 82 21 121 38q-54 27-129 42c-82 17-133 33-152 47-30 22-45 49-45 80 0 18 8 35 23 50s32 22 52 22c22 0 45-7 70-21s55-42 92-84c37-43 74-76 112-99" horiz-adv-x="1024" unicode="*"/>
+    <glyph id="glyph60852" d="M256 194c31 0 58-11 79-32 21-22 32-48 32-79s-11-57-32-78c-22-22-48-33-79-33q-46.5 0-78 33-33 31.5-33 78c0 31 11 58 33 79 21 21 47 32 78 32" horiz-adv-x="512" unicode="."/>
+    <glyph id="glyph60854" d="M74 670c0 155 23 288 70 400q70.5 166.5 186 249c60 43 122 65 186 65 104 0 197-53 280-159 103-131 155-309 155-534 0-157-23-291-68-401S780 100 710 51Q603.5-24 506-24c-129 0-237 76-323 229C110 334 74 489 74 670m196-25c0-187 23-339 69-457 38-99 95-149 170-149 36 0 73 16 112 49 39 32 68 86 88 162 31 115 46 276 46 485q0 232.5-48 387c-24 77-55 131-93 163q-40.5 33-99 33c-45 0-86-20-121-61-48-55-81-142-98-261s-26-236-26-351" horiz-adv-x="1024" unicode="0"/>
+    <glyph id="glyph60856" d="m240 1223 330 161h33V239c0-76 3-123 10-142 6-19 19-33 39-43s61-16 122-17V0H264v37c64 1 105 7 124 17q28.5 13.5 39 39c7 16 11 65 11 146v732c0 99-3 162-10 190-5 21-13 37-25 47q-19.5 15-45 15c-25 0-59-10-103-31z" horiz-adv-x="1024" unicode="1"/>
+    <glyph id="glyph60858" d="M939 261 844 0H44v37c235 215 401 390 497 526s144 260 144 373c0 86-26 157-79 212s-116 83-189 83c-67 0-126-19-179-58s-93-97-118-172H83c17 123 60 218 129 284q103.5 99 258 99c110 0 202-35 276-106 73-71 110-154 110-250 0-69-16-137-48-206-49-108-129-222-240-343-166-181-270-291-311-328h354c72 0 123 3 152 8q43.5 7.5 78 33c23 16 44 39 61 69z" horiz-adv-x="1024" unicode="2"/>
+    <glyph id="glyph60860" d="M953 500V358H771V0H606v358H32v128l629 898h110V500m-165 0v673L130 500z" horiz-adv-x="1024" unicode="4"/>
+    <glyph id="glyph60862" d="m889 1356-78-170H403l-89-182c177-26 317-92 420-197 89-91 133-197 133-320 0-71-14-137-43-198s-66-112-110-155-93-77-147-103C490-6 412-24 331-24q-121.5 0-177 42c-37 27-56 58-56 91 0 19 8 35 23 50 15 14 35 21 58 21 17 0 33-3 46-8s35-19 66-41c50-35 101-52 152-52 78 0 147 30 206 89s88 130 88 215c0 82-26 159-79 230S533 738 440 777c-73 30-172 47-297 52l260 527z" horiz-adv-x="1024" unicode="5"/>
+    <glyph id="glyph60864" d="M206 1356h727v-38L481-28H369l405 1221H401c-75 0-129-9-161-27-56-31-101-78-135-142l-29 11z" horiz-adv-x="1024" unicode="7"/>
+    <glyph id="glyph60866" d="M838 0 314 1141V235q0-124.5 27-156 37.5-42 117-42h48V0H34v37h48c57 0 98 17 122 52 15 21 22 70 22 146v886c0 60-7 103-20 130-9 19-26 36-51 49s-66 19-121 19v37h384L910 295l484 1061h384v-37h-47c-58 0-99-17-123-52-15-21-22-70-22-146V235c0-83 9-135 28-156q37.5-42 117-42h47V0h-576v37h48c58 0 99 17 122 52 15 21 22 70 22 146v906L871 0z" horiz-adv-x="1821" unicode="M"/>
+    <glyph id="glyph60868" d="M939 1387V918h-37c-12 90-33 162-64 215s-76 96-133 127-117 47-178 47c-69 0-127-21-172-63-45-43-68-91-68-145 0-41 14-79 43-113 41-50 140-117 295-200 127-68 213-120 260-156 46-37 82-80 107-129s37-101 37-155c0-103-40-191-119-265C830 6 727-31 602-31q-58.5 0-111 9c-21 3-63 16-128 37S256 46 239 46q-25.5 0-39-15c-10-10-17-31-22-62h-37v465h37c17-97 41-170 70-218 29-49 74-89 135-121q90-48 198-48 124.5 0 198 66 72 66 72 156c0 33-9 67-27 101-19 34-47 66-86 95-26 20-97 63-213 128S327 709 278 748s-87 81-112 128-38 98-38 154c0 97 37 181 112 252q112.5 105 285 105c72 0 148-18 229-53 37-17 64-25 79-25 17 0 32 5 43 16 11 10 19 31 26 62z" horiz-adv-x="1139" unicode="S"/>
+    <glyph id="glyph60870" d="m1185 1356 15-318h-38q-10.5 84-30 120c-21 39-48 67-82 86-35 18-80 27-136 27H723V235q0-124.5 27-156 37.5-42 117-42h47V0H339v37h48c57 0 98 17 122 52 15 21 22 70 22 146v1036H368c-63 0-108-5-135-14-35-13-64-37-89-73s-39-85-44-146H62l16 318z" horiz-adv-x="1251" unicode="T"/>
+    <glyph id="glyph60872" d="M335 1422V511l233 212c49 45 78 74 86 86 5 8 8 16 8 24 0 13-5 25-16 35-11 9-30 15-55 16v32h398v-32c-55-1-100-10-136-25-37-15-77-43-120-82L498 560l235-297q97.5-123 132-156c32-31 60-52 84-61 17-7 46-10 87-10V0H591v36c25 1 43 5 52 12s13 16 13 29c0 15-13 40-40 74L335 510V206c0-59 4-98 13-117 8-19 20-32 35-40s49-12 100-13V0H17v36c47 0 82 6 105 17 14 7 25 19 32 34q15 33 15 114v834c0 106-2 171-7 195-5 23-12 40-23 49s-25 13-42 13c-14 0-35-6-63-17l-17 35 272 112z" horiz-adv-x="1024" unicode="k"/>
+    <glyph id="glyph60874" d="M1041 453H-18v73h1059z" horiz-adv-x="1024" unicode="–"/>
+  </font>
+  <font id="font60890" horiz-adv-x="2048" horiz-origin-x="0" horiz-origin-y="0" vert-adv-y="1024" vert-origin-x="512" vert-origin-y="768">
+    <font-face id="font-face60878" font-family="'Times New Roman'" font-style="italic" underline-position="-223" underline-thickness="100" units-per-em="2048">
+      <font-face-src>
+        <font-face-name name="Times New Roman Kursiv"/>
+      </font-face-src>
+    </font-face>
+    <glyph id="glyph60882" d="M855 1384 533 263c-19-66-28-114-28-143 0-25 9-43 26-56s56-22 119-27L640 0H125l14 37c55 1 91 6 108 13q42 18 63 48c22 31 44 86 67 165l232 805c14 49 22 77 23 84q3 19.5 3 39c0 23-6 42-19 55s-30 20-52 20q-25.5 0-81-12l-13 36 337 94z" horiz-adv-x="1024" unicode="1"/>
+    <glyph id="glyph60884" d="M313 741v29c161 25 282 73 361 144 57 51 86 111 86 181 0 53-17 96-50 131-33 34-74 51-121 51-75 0-141-46-199-139l-37 11c35 77 79 136 134 176 54 39 113 59 178 59 79 0 142-23 191-70s73-107 73-179c0-61-23-120-68-177-46-57-125-107-236-152 69-29 122-70 157-123 35-54 53-119 53-194 0-83-24-167-72-250-48-84-114-149-197-194Q440-24 302-24c-84 0-148 15-191 44-29 20-43 43-43 70 0 23 9 43 26 60s37 25 62 25c17 0 35-3 52-8 11-3 37-17 79-40 41-23 74-39 97-46q34.5-12 72-12c60 0 110 35 149 105 39 69 58 143 58 222q0 96-39 171c-27 50-68 91-125 122s-119 48-186 52" horiz-adv-x="1024" unicode="3"/>
+    <glyph id="glyph60886" d="M997 1356 738 464h162l-36-124H700L595-24H448l106 364H64l42 140 815 876m-146-258L192 464h401z" horiz-adv-x="1024" unicode="4"/>
+    <glyph id="glyph60888" d="M528 1356h453l-46-165H528l-75-167c108-17 192-51 252-101 93-78 139-187 139-327 0-93-17-176-51-251q-52.5-112.5-126-189c-50-51-103-91-160-120Q391.5-24 273-24c-67 0-121 15-160 44-27 20-40 45-40 76 0 24 9 45 26 62s39 25 64 25c35 0 75-18 118-53 27-22 49-37 66-44 14-6 31-9 50-9 75 0 145 38 208 113s95 172 95 292c0 83-17 154-50 213-34 59-77 100-129 124s-121 41-208 50z" horiz-adv-x="1024" unicode="5"/>
+  </font>
+  <path id="line60914" d="M949.154 199.056v87.467" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60916" d="M166.738 199.056H965.78" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60918" d="M166.738 204.523H965.78" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60920" d="M166.738 209.99H965.78" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60922" d="M166.738 215.456H965.78" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60924" d="M166.738 220.923H965.78" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60926" d="M166.738 264.656H965.78" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60928" d="M166.738 270.123H965.78" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60930" d="M166.738 275.59H965.78" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60932" d="M166.738 281.056H965.78" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60934" d="M166.738 286.523H965.78" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <g id="g17" class="supplied staffN" transform="translate(22.677 -.5)">
+    <g id="text60936" aria-label="13" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333">
+      <path id="path952" d="m92.619 215.955 1.213-5.787q-.784.617-2.206.988l.177-.857q.706-.283 1.391-.738.69-.455 1.035-.794.21-.21.398-.507h.548l-1.605 7.695z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path954" d="m96.587 213.948.92-.115q.105.805.46 1.155.361.345.941.345.701 0 1.208-.502.513-.502.513-1.15 0-.564-.382-.93-.382-.372-1.025-.372-.073 0-.303.021l.162-.79q.136.022.261.022.81 0 1.245-.392.439-.398.439-.973 0-.528-.36-.889-.356-.36-.874-.36-.507 0-.915.37-.403.367-.518 1.041l-.93-.188q.23-.946.883-1.464.654-.518 1.548-.518.941 0 1.521.57.586.57.586 1.402 0 .606-.319 1.06-.314.45-.946.748.45.267.669.644.225.376.225.862 0 1.03-.774 1.788-.769.753-1.84.753-1.04 0-1.684-.58-.638-.586-.71-1.558" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    </g>
+    <g id="text60938" aria-label="14" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333">
+      <path id="path957" d="m92.619 281.555 1.213-5.787q-.784.617-2.206.988l.177-.858q.706-.282 1.391-.737.69-.455 1.035-.795.21-.209.398-.507h.548l-1.605 7.696z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path959" d="m99.201 281.555.413-1.955h-3.126l.198-.936 4.293-4.773h.774l-1.02 4.872h1.077l-.172.837h-1.077l-.413 1.955zm.586-2.792.669-3.2-2.855 3.2z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    </g>
+  </g>
+  <path id="rect60940" d="M174.482 181.516h651.67v117.99h-651.67Z" style="fill:#fff;stroke:none;stroke-width:1.33333004"/>
+  <path id="line60944" d="M867.427 193.59h9.338" style="fill:none;stroke:#000;stroke-width:.90399802"/>
+  <g id="text60946" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path964" d="M868.968 193.612c-.59 1.552.438 2.842 2.274 2.864s3.783-1.224 4.374-2.799c.568-1.552-.438-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text60948" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path967" d="M868.968 207.278c-.59 1.553.438 2.843 2.274 2.865s3.783-1.225 4.374-2.8c.568-1.552-.438-2.82-2.296-2.842-1.837-.022-3.783 1.225-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text60950" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path970" d="M868.968 212.745c-.59 1.552.438 2.843 2.274 2.864 1.837.022 3.783-1.224 4.374-2.799.568-1.552-.438-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text60952" aria-label="#" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path973" d="M865.45 205.2v3.259l-2.144.7V205.9zm-3.718-1.049v2.253l.94-.307v3.259l-.94.306v2.274l.94-.306v3.017h.634v-3.236l2.143-.7v3.368h.634v-3.564l.853-.285v-2.252l-.853.262v-3.236l.853-.284v-2.274l-.853.284v-2.996h-.634v3.193l-2.143.7v-3.346h-.634v3.564z" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line60954" d="M875.137 211.811v-48.559" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60956" d="M881.41 193.59h9.34" style="fill:none;stroke:#000;stroke-width:.90399802"/>
+  <g id="text60958" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path978" d="M882.952 190.878c-.59 1.553.437 2.843 2.274 2.865s3.783-1.225 4.374-2.8c.568-1.552-.438-2.82-2.296-2.842-1.837-.022-3.783 1.225-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text60960" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path981" d="M882.952 210.012c-.59 1.552.437 2.842 2.274 2.864s3.783-1.224 4.374-2.799c.568-1.552-.438-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text60962" aria-label="b" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path984" d="M877.923 181.388h-.568v12.923c0-.043 2.842-1.99 3.236-2.383.35-.35.874-.722 1.071-1.203.175-.372.306-.853.285-1.312-.022-.874-.722-1.968-1.815-1.946-.919.022-1.378.175-2.209.918v-1.399c.022-2.886 0-5.598 0-5.598m1.771 7.479c.416.459.481 1.158.306 1.814-.153.656-.459 1.072-.852 1.444-.438.415-1.225 1.093-1.225 1.071v-1.88c0-.678-.044-1.619.24-2.165.46-.875 1.247-.612 1.531-.284" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line60964" d="M889.121 209.078V163.79" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60966" d="M894.621 193.59h9.339" style="fill:none;stroke:#000;stroke-width:.90399802"/>
+  <g id="text60968" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path989" d="M896.163 193.612c-.59 1.552.437 2.842 2.274 2.864s3.783-1.224 4.373-2.799c.569-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.351 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text60970" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path992" d="M896.163 212.745c-.59 1.552.437 2.843 2.274 2.864 1.837.022 3.783-1.224 4.373-2.799.569-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.351 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line60972" d="M902.332 211.811v-47.47" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line60974" d="M907.832 193.59h9.34" style="fill:none;stroke:#000;stroke-width:.90399802"/>
+  <path id="line60976" d="M907.832 188.123h9.34" style="fill:none;stroke:#000;stroke-width:.90399802"/>
+  <path id="line60978" d="M907.832 182.656h9.34" style="fill:none;stroke:#000;stroke-width:.90399802"/>
+  <g id="text60980" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path999" d="M909.373 182.678c-.59 1.553.438 2.843 2.275 2.865s3.782-1.225 4.373-2.8c.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.225-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line60982" d="M907.832 193.59h9.34" style="fill:none;stroke:#000;stroke-width:.90399802"/>
+  <path id="line60984" d="M907.832 188.123h9.34" style="fill:none;stroke:#000;stroke-width:.90399802"/>
+  <g id="text60986" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1004" d="M909.373 188.145c-.59 1.552.438 2.843 2.275 2.864 1.836.022 3.782-1.224 4.373-2.798.568-1.553-.437-2.821-2.296-2.843-1.837-.022-3.783 1.224-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text60988" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1007" d="M909.373 196.345c-.59 1.552.438 2.843 2.275 2.864 1.836.022 3.782-1.224 4.373-2.798.568-1.553-.437-2.821-2.296-2.843-1.837-.022-3.783 1.224-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text60990" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1010" d="M909.373 201.812c-.59 1.552.438 2.842 2.275 2.864s3.782-1.224 4.373-2.799c.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line60992" d="M915.542 200.878v-35.99" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <g id="text60994" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1014" d="M922.585 199.078c-.59 1.553.438 2.843 2.275 2.865s3.782-1.225 4.373-2.8c.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.225-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text60996" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1017" d="M922.585 207.278c-.59 1.553.438 2.843 2.275 2.865s3.782-1.225 4.373-2.8c.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.225-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text60998" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1020" d="M922.585 212.745c-.59 1.552.438 2.843 2.275 2.864 1.836.022 3.782-1.224 4.373-2.799.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text61000" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1023" d="M922.585 218.212c-.59 1.552.438 2.842 2.275 2.864s3.782-1.224 4.373-2.799c.568-1.552-.437-2.82-2.296-2.842-1.837-.022-3.783 1.224-4.352 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text61002" aria-label="#" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1026" d="M920.066 205.2v3.259l-2.142.7V205.9zm-3.717-1.049v2.253l.94-.307v3.259l-.94.306v2.274l.94-.306v3.017h.635v-3.236l2.142-.7v3.368h.635v-3.564l.852-.285v-2.252l-.852.262v-3.236l.852-.284v-2.274l-.852.284v-2.996h-.635v3.193l-2.142.7v-3.346h-.635v3.564z" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line61004" d="M928.754 217.278v-51.842" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <g id="text61006" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1030" d="M935.796 201.812c-.59 1.552.437 2.842 2.274 2.864s3.783-1.224 4.373-2.799c.569-1.552-.437-2.82-2.296-2.842-1.836-.022-3.782 1.224-4.351 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="text61008" aria-label="œ" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1033" d="M935.796 220.945c-.59 1.552.437 2.843 2.274 2.864 1.837.022 3.783-1.224 4.373-2.799.569-1.552-.437-2.82-2.296-2.842-1.836-.022-3.782 1.224-4.351 2.777" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <path id="line61010" d="M941.965 220.011v-54.025" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="path61012" d="m874.934 161.886 67.354 2.733v2.733l-67.354-2.733z" style="fill:#000;fill-rule:nonzero;stroke:none;stroke-width:1.33333004"/>
+  <path id="line61014" d="M875.137 296.544v-31.888" style="fill:none;stroke:#000;stroke-width:.64399803"/>
+  <path id="line61020" d="M867.427 297.456h9.338" style="fill:none;stroke:#000;stroke-width:.90399802"/>
+  <path id="line61022" d="M867.427 291.99h9.338" style="fill:none;stroke:#000;stroke-width:.90399802"/>
+  <g id="text61024" aria-label="˙" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+    <path id="path1040" d="M875.79 295.51c-.415-.743-1.443-.853-1.902-.897-1.224-.153-2.23.154-2.886.525-.656.394-1.53 1.137-1.946 2.23-.153.438-.46 1.313-.022 2.056.437.7 1.509.897 2.099.94.984.088 1.88-.065 2.558-.415.678-.328 1.618-1.225 2.034-2.34.153-.415.415-1.487.066-2.099m-.502.372c.415.721-.416 1.443-1.028 1.837a16 16 0 0 1-1.268.765c-.438.24-.831.46-1.334.7-.678.35-1.706.7-2.143-.022-.416-.722.415-1.443 1.05-1.837a17 17 0 0 1 1.29-.787c.437-.24.787-.46 1.29-.7.678-.328 1.705-.678 2.143.044" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+  </g>
+  <g id="g18" class="supplied measureN">
+    <g id="text61026" aria-label="5" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" transform="translate(36.677 -.5)">
+      <path id="path1043" d="m817.33 114.775.962-.094q-.01.204-.01.246 0 .345.172.695.177.35.475.538.304.183.638.183.44 0 .894-.303.455-.303.737-.883.283-.58.283-1.15 0-.644-.382-1.03-.376-.387-.993-.387-.413 0-.784.198-.366.199-.685.596l-.826-.057 1.155-3.921h3.743l-.183.868h-2.912l-.575 1.95q.324-.236.664-.35.345-.12.706-.12.878 0 1.443.58t.565 1.589q0 .883-.387 1.631-.387.742-1.067 1.145-.674.397-1.458.397-.66 0-1.166-.298-.508-.298-.764-.82-.25-.523-.25-1.046 0-.052.004-.157z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.7074px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    </g>
+  </g>
+  <g id="g16" class="link-box">
+    <path id="rect60942" d="M174.482 181.516h651.67v117.99h-651.67Z" style="fill:none;stroke:#777;stroke-width:.910664;stroke-opacity:1"/>
+    <g id="text61028" aria-label="M* 404 Sk1 T. 12–15" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333" transform="translate(36.677 -.5)">
+      <path id="path1047" d="M353.556 243.779v-15.27h4.614l2.77 10.416 2.74-10.416h4.625v15.27h-2.865v-12.02l-3.03 12.02h-2.97l-3.02-12.02v12.02z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1049" d="m372.388 235.53-1.573-1.22q.75-.843 1.562-1.614.323-.312.406-.395-.26-.042-1.49-.344-.884-.219-1.166-.323l.615-1.833q1.364.552 2.437 1.218-.25-1.697-.25-2.77h1.854q0 .76-.281 2.791.208-.083.896-.406.937-.427 1.729-.729l.552 1.885q-1.156.26-2.677.51l1.25 1.407q.375.427.594.698l-1.594 1.052-1.406-2.323q-.636 1.125-1.458 2.396" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1051" d="M390.688 243.779v-3.073h-6.25v-2.562l6.625-9.697h2.458v9.687h1.896v2.572h-1.896v3.073zm0-5.645v-5.219l-3.51 5.219z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1053" d="M401.77 228.447q2.22 0 3.47 1.583 1.489 1.875 1.489 6.218 0 4.333-1.5 6.229-1.24 1.562-3.458 1.562-2.23 0-3.594-1.708-1.364-1.718-1.364-6.114 0-4.312 1.5-6.208 1.24-1.562 3.458-1.562m0 2.427q-.53 0-.947.343-.417.334-.646 1.209-.302 1.135-.302 3.822t.27 3.698q.272 1 .678 1.333.417.333.948.333t.948-.333q.416-.344.645-1.219.302-1.124.302-3.812t-.27-3.687q-.271-1.01-.688-1.344-.406-.343-.937-.343" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1055" d="M414.436 243.779v-3.073h-6.25v-2.562l6.625-9.697h2.459v9.687h1.895v2.572h-1.895v3.073zm0-5.645v-5.219l-3.51 5.219z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1057" d="m426.352 238.81 3-.291q.27 1.51 1.094 2.219.833.708 2.239.708 1.49 0 2.24-.625.76-.636.76-1.48 0-.54-.323-.916-.313-.385-1.104-.666-.542-.188-2.469-.667-2.479-.615-3.479-1.51-1.406-1.26-1.406-3.073 0-1.167.656-2.177.667-1.02 1.907-1.552 1.25-.531 3.01-.531 2.874 0 4.322 1.26 1.459 1.26 1.531 3.365l-3.083.135q-.198-1.177-.854-1.687-.646-.521-1.948-.521-1.343 0-2.104.552-.49.354-.49.948 0 .541.46.927.582.49 2.832 1.02 2.25.532 3.323 1.104 1.083.563 1.687 1.552.615.98.615 2.427 0 1.313-.73 2.459-.728 1.145-2.062 1.708-1.333.552-3.322.552-2.896 0-4.448-1.333-1.552-1.344-1.854-3.906" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1059" d="M441.257 243.779v-15.27h2.927v8.104l3.427-3.896h3.604l-3.781 4.042 4.052 7.02h-3.156l-2.781-4.968-1.365 1.427v3.54z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1061" d="M460.1 243.779h-2.927v-11.03q-1.604 1.5-3.781 2.218v-2.656q1.146-.375 2.49-1.416 1.343-1.052 1.843-2.448h2.375z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1063" d="M474.484 243.779v-12.687h-4.531v-2.583h12.134v2.583h-4.52v12.687z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1065" d="M481.692 243.779v-2.927h2.927v2.927z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1067" d="M500.388 243.779h-2.927v-11.03q-1.604 1.5-3.78 2.218v-2.656q1.145-.375 2.489-1.416 1.343-1.052 1.843-2.448h2.375z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1069" d="M514.658 241.06v2.719h-10.26q.167-1.542 1-2.917.833-1.385 3.292-3.666 1.979-1.844 2.426-2.5.605-.906.605-1.791 0-.98-.532-1.5-.52-.531-1.447-.531-.917 0-1.459.552-.541.552-.625 1.833l-2.916-.292q.26-2.416 1.635-3.468t3.438-1.052q2.26 0 3.551 1.218 1.292 1.22 1.292 3.031 0 1.032-.375 1.97-.365.926-1.167 1.947-.53.677-1.916 1.948t-1.76 1.687q-.365.417-.594.812z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1071" d="M515.7 239.342v-2.188h11.863v2.188z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1073" d="M536.01 243.779h-2.926v-11.03q-1.604 1.5-3.781 2.218v-2.656q1.145-.375 2.489-1.416 1.344-1.052 1.844-2.448h2.374z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+      <path id="path1075" d="m540.437 239.852 2.917-.302q.125.99.74 1.573.614.573 1.416.573.916 0 1.552-.74.635-.75.635-2.25 0-1.406-.635-2.104-.625-.708-1.636-.708-1.26 0-2.26 1.115l-2.375-.344 1.5-7.947h7.74v2.739h-5.521l-.459 2.594q.98-.49 2-.49 1.948 0 3.302 1.417 1.354 1.416 1.354 3.676 0 1.886-1.093 3.365-1.49 2.02-4.136 2.02-2.114 0-3.447-1.135t-1.594-3.052" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:21.3317px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;fill:#777;fill-opacity:1;stroke-width:1.33333"/>
+    </g>
+  </g>
+  <g id="g1" class="supplied foliation">
+    <g id="text297" aria-label="A: Bl. 1v" style="font-size:10.66670036px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;letter-spacing:0;word-spacing:0;opacity:.604762">
+      <path id="path1078" d="M118.943 114.907h-3.026l-.917 1.688h-1.614l4.318-7.636h1.744l1.24 7.636h-1.49zm-.193-1.27-.442-3.074-1.844 3.073z" style="font-style:italic;font-variant:normal;font-weight:700;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1080" d="M123.12 111.063h1.474l-.302 1.448h-1.474zm-.854 4.089h1.48l-.303 1.443h-1.479z" style="font-style:italic;font-variant:normal;font-weight:700;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1082" d="m128.198 116.595 1.6-7.636h2.364q.646 0 .958.052.51.089.86.313.354.219.547.604.192.38.192.844 0 .63-.349 1.11-.343.478-1.057.728.62.203.927.615.307.406.307.953 0 .63-.364 1.208-.36.578-.959.896-.593.313-1.328.313zm1.938-4.375h1.547q1.11 0 1.594-.355.49-.354.49-1.03 0-.324-.152-.558-.151-.234-.406-.339-.25-.109-.948-.109h-1.625zm-.734 3.51h1.74q.692 0 .931-.047.485-.083.787-.281.302-.203.474-.531t.172-.688q0-.536-.339-.812-.333-.282-1.276-.282h-1.937z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1084" d="m135.141 116.595 1.594-7.636h.943l-1.594 7.636z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1086" d="m137.85 116.595.223-1.068h1.068l-.229 1.068z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1088" d="m145.72 116.595 1.208-5.766q-.782.615-2.198.984l.177-.854q.703-.281 1.385-.734.688-.453 1.031-.792.209-.208.396-.505h.547l-1.599 7.667z" style="font-style:italic;font-variant:normal;font-weight:400;font-stretch:normal;font-size:10.66670036px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Italic&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal"/>
+      <path id="path1090" d="m150.227 112.328-.59-3.595h.596l.308 1.98q.051.325.126 1.06.176-.383.45-.877l1.202-2.163h.646l-2.058 3.595z" style="font-size:64.99999762%;baseline-shift:super"/>
+    </g>
+  </g>
+  <path id="path1093" d="M113.97 87.239V75.786h3.46l2.078 7.812 2.055-7.812h3.469v11.453h-2.149v-9.016l-2.273 9.016h-2.227l-2.265-9.016v9.016z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0"/>
+  <path id="path1095" d="m131.22 84.2 2.124-.258q.102.813.547 1.242t1.078.43q.68 0 1.14-.516.47-.515.47-1.39 0-.828-.446-1.313-.445-.484-1.086-.484-.422 0-1.008.164l.243-1.79q.89.024 1.359-.382.469-.414.469-1.094 0-.578-.344-.922-.344-.343-.914-.343-.563 0-.961.39t-.484 1.14l-2.024-.343q.211-1.039.633-1.656.43-.625 1.188-.977.765-.359 1.71-.359 1.618 0 2.594 1.031.805.844.805 1.906 0 1.508-1.649 2.407.985.21 1.57.945.595.734.595 1.773 0 1.508-1.102 2.57-1.102 1.063-2.742 1.063-1.555 0-2.578-.89-1.024-.899-1.188-2.344" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0"/>
+  <path id="path1097" d="M142.086 81.06q-.851-.36-1.242-.985-.383-.633-.383-1.383 0-1.281.89-2.117.9-.836 2.548-.836 1.633 0 2.531.836.906.836.906 2.117 0 .797-.414 1.422-.414.617-1.164.945.953.383 1.446 1.117.5.735.5 1.696 0 1.586-1.016 2.578-1.008.992-2.688.992-1.562 0-2.601-.82-1.227-.969-1.227-2.656 0-.93.461-1.704.461-.78 1.453-1.203m.453-2.212q0 .657.368 1.024.375.367.992.367.625 0 1-.367.375-.375.375-1.031 0-.618-.375-.985-.367-.375-.977-.375-.633 0-1.008.375t-.375.992m-.203 4.907q0 .906.461 1.414.469.507 1.164.507.68 0 1.125-.484.446-.492.446-1.414 0-.805-.453-1.289-.454-.492-1.149-.492-.805 0-1.203.554-.39.555-.39 1.204" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0"/>
+  <path id="path1099" d="m153.446 83.512 2.25-.218q.203 1.132.82 1.664.625.531 1.68.531 1.117 0 1.68-.469.57-.476.57-1.11 0-.405-.242-.687-.235-.289-.829-.5-.406-.14-1.851-.5-1.86-.46-2.61-1.132-1.054-.946-1.054-2.305 0-.875.492-1.633.5-.766 1.43-1.164.937-.398 2.257-.398 2.157 0 3.243.945 1.093.945 1.148 2.523l-2.312.102q-.149-.883-.641-1.266-.484-.39-1.461-.39-1.008 0-1.578.414-.367.265-.367.71 0 .407.343.696.438.367 2.125.766 1.688.398 2.493.828.812.422 1.265 1.164.461.734.461 1.82 0 .984-.547 1.844t-1.547 1.281q-1 .414-2.492.414-2.172 0-3.336-1-1.164-1.008-1.39-2.93" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0"/>
+  <path id="path1101" d="M164.625 87.239V75.786h2.196v6.078l2.57-2.922h2.703l-2.836 3.031 3.04 5.266h-2.368l-2.086-3.727-1.023 1.07v2.657z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0"/>
+  <path id="path1103" d="m173.063 84.2 2.125-.258q.101.813.547 1.242.445.43 1.078.43.68 0 1.14-.516.47-.515.47-1.39 0-.828-.446-1.313-.445-.484-1.086-.484-.422 0-1.008.164l.242-1.79q.891.024 1.36-.382.469-.414.469-1.094 0-.578-.344-.922-.344-.343-.914-.343-.563 0-.961.39-.399.39-.485 1.14l-2.023-.343q.21-1.039.633-1.656.43-.625 1.187-.977.766-.359 1.711-.359 1.617 0 2.594 1.031.805.844.805 1.906 0 1.508-1.649 2.407.985.21 1.57.945.594.734.594 1.773 0 1.508-1.101 2.57-1.102 1.063-2.742 1.063-1.555 0-2.579-.89-1.023-.899-1.187-2.344" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0"/>
+  <path id="path1105" d="M189.547 87.239v-9.516h-3.398v-1.937h9.101v1.937h-3.39v9.516z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0"/>
+  <path id="path1107" d="M194.954 87.239v-2.195h2.195v2.195z" style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:16px;line-height:1.25;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;letter-spacing:0;word-spacing:0"/>
+  <g id="g67143" class="supplied clef, supplied key" transform="translate(36.677 -.5)">
+    <g id="g1339" transform="translate(744.5 -70.408)">
+      <g id="text1317" aria-label="b" style="font-size:21.86660004px;font-family:Maestro;fill:#777;stroke-width:1.33333004">
+        <path id="path67145" d="M66.85 273.265v5.27q.306-.285.568-.46.263-.174.503-.262.24-.11.503-.153.285-.044.634-.044.416 0 .744.175t.568.46.372.634q.131.35.131.678.022.35-.065.7-.088.327-.219.612-.153.371-.481.656-.328.284-.59.546-.088.088-.372.306-.284.219-.656.481-.35.263-.744.525-.393.284-.721.503-.328.24-.547.394l-.197.175v-12.924h.569zm1.771 5.75q-.11-.13-.306-.218-.175-.087-.394-.087-.218 0-.437.13-.219.132-.394.46-.218.416-.24 1.05v2.995l.131-.109q.131-.087.306-.262.197-.153.394-.35.218-.197.393-.35.307-.284.525-.612t.328-.831q.131-.503.066-.984-.066-.481-.372-.831"/>
+      </g>
+      <g id="g1234" transform="matrix(.75 0 0 .75 49.722 71.408)">
+        <g id="text1224" aria-label="&amp;" style="font-size:21.86660004px;font-family:Maestro;fill:#777;stroke-width:1.33333004">
+          <path id="path67148" d="M12.352 291.983q-.612.11-1.312.13-.678.023-1.334-.043-.656-.043-1.224-.153-.547-.087-.897-.262-1.684-.81-2.733-1.728-1.028-.896-1.597-1.88-.568-.984-.809-2.012-.218-1.05-.284-2.1-.087-1.136.197-2.273.306-1.137.809-2.165.525-1.05 1.18-1.924.679-.875 1.356-1.531.788-.743 1.64-1.465.875-.744 1.903-1.509-.022-.284-.066-.503-.022-.218-.065-.437-.044-.24-.11-.525-.043-.284-.065-.7 0-.175-.044-.634-.044-.48-.066-1.137 0-.678.044-1.53.044-.853.219-1.772.11-.546.459-1.377.372-.853.853-1.64.503-.787 1.05-1.356.546-.569 1.027-.569.24 0 .525.307.284.284.547.787.284.48.546 1.115.263.612.46 1.268.196.656.306 1.29.13.635.153 1.116.022 1.137-.088 2.011-.11.853-.328 1.553-.218.678-.525 1.268-.284.569-.612 1.159-.35.59-.721 1.05-.35.437-.722.896-.394.481-.831.81-.415.305-.831.677.197 1.115.35 2.012.066.393.131.765.066.372.11.7.043.306.087.525.044.196.044.24.524-.065 1.071 0 .569.044 1.072.153.524.11.918.285.415.174.656.328 1.18.874 1.662 2.011.503 1.115.59 2.296.066.919-.153 1.837-.219.94-.743 1.771-.503.853-1.334 1.553-.81.7-1.924 1.159l.24 1.662q.11.656.197 1.268.087.634.131.874.197 1.312.153 2.143-.044.853-.328 1.378-.24.437-.568.853-.306.415-.744.743-.437.328-1.028.547-.568.219-1.312.262-.568.044-1.355-.109-.787-.131-1.51-.503-.72-.35-1.245-.962t-.59-1.509q-.045-.525.065-1.071.11-.525.371-.962.285-.416.722-.7.46-.284 1.115-.328.394-.022.787.11.416.152.766.415.35.262.568.656.219.393.263.852.065.81-.503 1.553-.569.765-1.924 1.137.218.306.83.569.613.284 1.531.284.962 0 1.837-.569.896-.568 1.378-1.421.306-.569.306-1.487 0-.897-.11-1.815-.043-.153-.13-.765-.088-.59-.198-1.247-.109-.765-.262-1.705m.46-27.705q-.854 0-1.51.809-.634.787-1.05 2.012-.393 1.224-.524 2.69-.131 1.464.066 2.82.721-.547 1.508-1.312.788-.787 1.422-1.662.656-.875 1.05-1.771.415-.897.35-1.706-.023-.262-.088-.59-.066-.328-.219-.612-.153-.285-.394-.481-.24-.197-.612-.197m-.045 26.808q.94-.328 1.465-.853t.766-1.137q.262-.612.284-1.224.044-.612.022-1.094-.044-.393-.197-.984-.131-.59-.525-1.137-.393-.546-1.115-.896-.721-.372-1.924-.306zm-1.793-7.588q-.896.044-1.487.372-.568.306-.918.766-.328.437-.46.94-.109.503-.087.896.022.394.175.81.153.415.394.765.262.371.547.656.306.306.612.459-.044.044-.088.066-.022.043-.065.087t-.066.088q-.678-.328-1.203-.788-.502-.437-.656-.634-.24-.328-.415-.59-.175-.263-.284-.569-.11-.284-.197-.634-.066-.35-.088-.83-.043-.46.066-.963.11-.525.35-1.05.262-.524.656-1.005.415-.503.962-.94.284-.22.503-.35.24-.132.437-.22.197-.109.394-.152.219-.066.46-.131l-.657-3.958q-.262.153-.853.612-.59.46-1.29 1.093-.7.634-1.4 1.378-.677.721-1.114 1.4-.788 1.246-1.225 2.295-.437 1.05-.328 2.274.087 1.378.83 2.559.766 1.203 1.947 2.012 1.18.809 2.69 1.115 1.508.328 3.127-.066-.35-2.165-.635-3.87-.13-.722-.24-1.422t-.219-1.246q-.087-.547-.13-.875z"/>
+        </g>
+        <g id="g1232" transform="translate(.133 247.042)">
+          <path id="path1228" d="M1.839 53.386H-.758V14.42H1.84" style="fill:none;stroke:#777;stroke-width:.87066698;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+          <path id="path1230" d="M28.635 14.421h2.597v38.965h-2.597" style="fill:none;stroke:#777;stroke-width:.87066698;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+        </g>
+      </g>
+    </g>
+    <g id="g1362-5" transform="translate(601.243 -169.445)">
+      <g id="g1313-2" transform="translate(50 5.5)">
+        <g id="g1311-1" transform="translate(137.94 -82.406)">
+          <g id="g1305-1">
+            <g id="text1297-7" aria-label="b" style="font-size:21.86660004px;font-family:Maestro;fill:#777;fill-opacity:.94117599;stroke-width:1.33333004">
+              <path id="path67151" d="M24.141 520.403v5.27q.306-.284.569-.46.262-.174.503-.262.24-.11.503-.153.284-.044.634-.044.415 0 .743.175t.569.46.371.634.132.678q.022.35-.066.7-.087.327-.219.612-.153.371-.48.656-.329.284-.591.546-.088.088-.372.306-.284.219-.656.481-.35.263-.743.525-.394.285-.722.503-.328.24-.547.394l-.196.175v-12.923h.568zm1.771 5.75q-.109-.13-.306-.218-.175-.087-.393-.087t-.438.13-.393.46q-.219.416-.24 1.05v2.995l.13-.109q.132-.087.307-.262.196-.153.393-.35.219-.197.394-.35.306-.284.525-.612.218-.328.328-.831.13-.503.065-.984t-.372-.831"/>
+            </g>
+          </g>
+          <path id="path1307-7" d="M7.266 536.894H4.67v-28.465h2.597" style="fill:none;stroke:#777;stroke-width:.653;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+          <path id="path1309-1" d="M27.846 508.43h2.597v28.464h-2.597" style="fill:none;stroke:#777;stroke-width:.653;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+        </g>
+      </g>
+      <g id="text74-8-3" aria-label="?" style="font-size:16.39999962px;font-family:Maestro;fill:#777;stroke-width:1.33333004">
+        <path id="path67154" d="M204.11 444.331q-.148.279-.295.508-.132.23-.28.443-.147.213-.31.41-.165.213-.378.46-.213.245-.41.442-.18.197-.377.377-.18.18-.394.345-.213.18-.475.377-.328.246-.624.426-.278.18-.574.328-.278.148-.59.263-.312.131-.689.279-.377.147-.836.262-.443.131-.853.213-.476.099-.951.18l-.115-.245q.77-.263 1.542-.607.64-.295 1.344-.722.722-.41 1.247-.951 1.328-1.41 2.017-3.116.689-1.69.656-3.854 0-.492-.115-1.132-.098-.64-.377-1.213-.262-.574-.754-.984-.476-.41-1.247-.41-.443 0-.951.18-.492.18-.902.492-.41.295-.672.722-.263.41-.214.885.017.066.099.05.098-.033.262-.082.18-.05.427-.099.262-.049.606-.033.361.017.624.23.262.197.426.508.164.312.213.69.05.36-.033.704-.13.542-.492.853-.344.328-.967.328-.394 0-.771-.147-.36-.132-.64-.394-.278-.246-.459-.623-.164-.361-.164-.837-.016-.705.148-1.246.18-.541.426-.935.263-.393.541-.64.296-.262.542-.41.606-.377 1.23-.508.623-.147 1.18-.164.624 0 1.247.213.64.197 1.197.59.558.378 1 .92.443.524.673 1.18.279.738.279 1.558.016.836-.197 1.804-.066.328-.148.59-.082.263-.18.509-.099.246-.23.492-.115.246-.262.541m1.656-6.314q-.016-.377.246-.623.263-.263.64-.263.377-.016.64.23.278.246.278.623.017.377-.246.656-.262.263-.64.263-.377.016-.655-.246-.263-.263-.263-.64m0 4.133q0-.377.263-.623.262-.246.64-.263.376 0 .639.23.279.246.279.623.016.377-.246.64-.263.278-.64.278-.377.017-.656-.246-.262-.262-.279-.64"/>
+      </g>
+    </g>
+  </g>
+  <g id="g955" class="tkk" transform="translate(35.677 -.5)">
+    <g id="text61016" aria-label="˙" style="font-size:16.39999962px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004">
+      <path id="path1116" d="M830.787 287.329c-.312-.558-1.083-.64-1.427-.672-.918-.115-1.673.114-2.165.393-.492.295-1.148.853-1.46 1.673-.114.328-.344.984-.016 1.542.328.524 1.132.672 1.575.705.738.065 1.41-.05 1.918-.312.509-.246 1.214-.918 1.526-1.755.114-.311.311-1.115.049-1.574m-.377.279c.311.541-.312 1.082-.771 1.377-.345.23-.623.394-.951.574s-.624.345-1 .525c-.51.263-1.28.525-1.608-.016-.312-.541.312-1.083.787-1.378.345-.23.64-.41.968-.59s.59-.345.967-.525c.509-.246 1.28-.508 1.608.033" style="font-size:16.39999962px;font-family:Maestro;fill:#777;fill-opacity:1;stroke-width:1.33333004"/>
+    </g>
+    <g id="text61018" aria-label="˙" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004">
+      <path id="path1119" d="M840.113 285.076c-.415-.744-1.443-.853-1.902-.897-1.224-.153-2.23.153-2.886.525-.656.394-1.531 1.137-1.946 2.23-.154.438-.46 1.312-.022 2.056.437.7 1.508.896 2.099.94.984.088 1.88-.065 2.558-.415.678-.328 1.618-1.225 2.034-2.34.153-.415.415-1.487.065-2.1m-.502.372c.415.721-.416 1.443-1.028 1.836-.46.306-.831.525-1.268.766-.438.24-.831.459-1.334.7-.678.35-1.706.7-2.143-.023-.416-.721.415-1.443 1.05-1.836.459-.306.852-.547 1.29-.788.437-.24.787-.459 1.29-.7.677-.327 1.705-.677 2.143.044" style="font-size:21.86660004px;font-family:Maestro;fill:#000;stroke-width:1.33333004"/>
+    </g>
+    <path id="line61014-9" d="M830.565 286.651V272.53" style="fill:none;stroke:#777;stroke-width:.64251965;stroke-miterlimit:4;stroke-dasharray:1.92755891,1.92755891;stroke-dashoffset:0;stroke-opacity:1"/>
+  </g>
+  <g id="g19" class="supplied clef, supplied key">
+    <g id="g6" transform="translate(781.176 -70.907)">
+      <g id="g2" aria-label="b" style="font-size:21.8666px;font-family:Maestro;fill:#777;stroke-width:1.33333">
+        <path id="path1" d="M66.85 273.265v5.27q.306-.285.568-.46.263-.174.503-.262.24-.11.503-.153.285-.044.634-.044.416 0 .744.175t.568.46.372.634q.131.35.131.678.022.35-.065.7-.088.327-.219.612-.153.371-.481.656-.328.284-.59.546-.088.088-.372.306-.284.219-.656.481-.35.263-.744.525-.393.284-.721.503-.328.24-.547.394l-.197.175v-12.924h.569zm1.771 5.75q-.11-.13-.306-.218-.175-.087-.394-.087-.218 0-.437.13-.219.132-.394.46-.218.416-.24 1.05v2.995l.131-.109q.131-.087.306-.262.197-.153.394-.35.218-.197.393-.35.307-.284.525-.612t.328-.831q.131-.503.066-.984-.066-.481-.372-.831"/>
+      </g>
+      <g id="g5" transform="matrix(.75 0 0 .75 49.722 71.408)">
+        <g id="g3" aria-label="&amp;" style="font-size:21.8666px;font-family:Maestro;fill:#777;stroke-width:1.33333">
+          <path id="path2" d="M12.352 291.983q-.612.11-1.312.13-.678.023-1.334-.043-.656-.043-1.224-.153-.547-.087-.897-.262-1.684-.81-2.733-1.728-1.028-.896-1.597-1.88-.568-.984-.809-2.012-.218-1.05-.284-2.1-.087-1.136.197-2.273.306-1.137.809-2.165.525-1.05 1.18-1.924.679-.875 1.356-1.531.788-.743 1.64-1.465.875-.744 1.903-1.509-.022-.284-.066-.503-.022-.218-.065-.437-.044-.24-.11-.525-.043-.284-.065-.7 0-.175-.044-.634-.044-.48-.066-1.137 0-.678.044-1.53.044-.853.219-1.772.11-.546.459-1.377.372-.853.853-1.64.503-.787 1.05-1.356.546-.569 1.027-.569.24 0 .525.307.284.284.547.787.284.48.546 1.115.263.612.46 1.268.196.656.306 1.29.13.635.153 1.116.022 1.137-.088 2.011-.11.853-.328 1.553-.218.678-.525 1.268-.284.569-.612 1.159-.35.59-.721 1.05-.35.437-.722.896-.394.481-.831.81-.415.305-.831.677.197 1.115.35 2.012.066.393.131.765.066.372.11.7.043.306.087.525.044.196.044.24.524-.065 1.071 0 .569.044 1.072.153.524.11.918.285.415.174.656.328 1.18.874 1.662 2.011.503 1.115.59 2.296.066.919-.153 1.837-.219.94-.743 1.771-.503.853-1.334 1.553-.81.7-1.924 1.159l.24 1.662q.11.656.197 1.268.087.634.131.874.197 1.312.153 2.143-.044.853-.328 1.378-.24.437-.568.853-.306.415-.744.743-.437.328-1.028.547-.568.219-1.312.262-.568.044-1.355-.109-.787-.131-1.51-.503-.72-.35-1.245-.962t-.59-1.509q-.045-.525.065-1.071.11-.525.371-.962.285-.416.722-.7.46-.284 1.115-.328.394-.022.787.11.416.152.766.415.35.262.568.656.219.393.263.852.065.81-.503 1.553-.569.765-1.924 1.137.218.306.83.569.613.284 1.531.284.962 0 1.837-.569.896-.568 1.378-1.421.306-.569.306-1.487 0-.897-.11-1.815-.043-.153-.13-.765-.088-.59-.198-1.247-.109-.765-.262-1.705m.46-27.705q-.854 0-1.51.809-.634.787-1.05 2.012-.393 1.224-.524 2.69-.131 1.464.066 2.82.721-.547 1.508-1.312.788-.787 1.422-1.662.656-.875 1.05-1.771.415-.897.35-1.706-.023-.262-.088-.59-.066-.328-.219-.612-.153-.285-.394-.481-.24-.197-.612-.197m-.045 26.808q.94-.328 1.465-.853t.766-1.137q.262-.612.284-1.224.044-.612.022-1.094-.044-.393-.197-.984-.131-.59-.525-1.137-.393-.546-1.115-.896-.721-.372-1.924-.306zm-1.793-7.588q-.896.044-1.487.372-.568.306-.918.766-.328.437-.46.94-.109.503-.087.896.022.394.175.81.153.415.394.765.262.371.547.656.306.306.612.459-.044.044-.088.066-.022.043-.065.087t-.066.088q-.678-.328-1.203-.788-.502-.437-.656-.634-.24-.328-.415-.59-.175-.263-.284-.569-.11-.284-.197-.634-.066-.35-.088-.83-.043-.46.066-.963.11-.525.35-1.05.262-.524.656-1.005.415-.503.962-.94.284-.22.503-.35.24-.132.437-.22.197-.109.394-.152.219-.066.46-.131l-.657-3.958q-.262.153-.853.612-.59.46-1.29 1.093-.7.634-1.4 1.378-.677.721-1.114 1.4-.788 1.246-1.225 2.295-.437 1.05-.328 2.274.087 1.378.83 2.559.766 1.203 1.947 2.012 1.18.809 2.69 1.115 1.508.328 3.127-.066-.35-2.165-.635-3.87-.13-.722-.24-1.422t-.219-1.246q-.087-.547-.13-.875z"/>
+        </g>
+        <g id="g4" transform="translate(.133 247.042)">
+          <path id="path3" d="M1.839 53.386H-.758V14.42H1.84" style="fill:none;stroke:#777;stroke-width:.870667;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+          <path id="path4" d="M28.635 14.421h2.597v38.965h-2.597" style="fill:none;stroke:#777;stroke-width:.870667;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+        </g>
+      </g>
+    </g>
+    <g id="g14" transform="translate(637.92 -169.944)">
+      <g id="g12" transform="translate(50 5.5)">
+        <g id="g11" transform="translate(137.94 -82.406)">
+          <g id="g10">
+            <g id="g8" aria-label="b" style="font-size:21.8666px;font-family:Maestro;fill:#777;fill-opacity:.941176;stroke-width:1.33333">
+              <path id="path7" d="M24.141 520.403v5.27q.306-.284.569-.46.262-.174.503-.262.24-.11.503-.153.284-.044.634-.044.415 0 .743.175t.569.46.371.634.132.678q.022.35-.066.7-.087.327-.219.612-.153.371-.48.656-.329.284-.591.546-.088.088-.372.306-.284.219-.656.481-.35.263-.743.525-.394.285-.722.503-.328.24-.547.394l-.196.175v-12.923h.568zm1.771 5.75q-.109-.13-.306-.218-.175-.087-.393-.087t-.438.13-.393.46q-.219.416-.24 1.05v2.995l.13-.109q.132-.087.307-.262.196-.153.393-.35.219-.197.394-.35.306-.284.525-.612.218-.328.328-.831.13-.503.065-.984t-.372-.831"/>
+            </g>
+          </g>
+          <path id="path10" d="M7.266 536.894H4.67v-28.465h2.597" style="fill:none;stroke:#777;stroke-width:.653;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+          <path id="path11" d="M27.846 508.43h2.597v28.464h-2.597" style="fill:none;stroke:#777;stroke-width:.653;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+        </g>
+      </g>
+      <g id="g13" aria-label="?" style="font-size:16.4px;font-family:Maestro;fill:#777;stroke-width:1.33333">
+        <path id="path12" d="M204.11 444.331q-.148.279-.295.508-.132.23-.28.443-.147.213-.31.41-.165.213-.378.46-.213.245-.41.442-.18.197-.377.377-.18.18-.394.345-.213.18-.475.377-.328.246-.624.426-.278.18-.574.328-.278.148-.59.263-.312.131-.689.279-.377.147-.836.262-.443.131-.853.213-.476.099-.951.18l-.115-.245q.77-.263 1.542-.607.64-.295 1.344-.722.722-.41 1.247-.951 1.328-1.41 2.017-3.116.689-1.69.656-3.854 0-.492-.115-1.132-.098-.64-.377-1.213-.262-.574-.754-.984-.476-.41-1.247-.41-.443 0-.951.18-.492.18-.902.492-.41.295-.672.722-.263.41-.214.885.017.066.099.05.098-.033.262-.082.18-.05.427-.099.262-.049.606-.033.361.017.624.23.262.197.426.508.164.312.213.69.05.36-.033.704-.13.542-.492.853-.344.328-.967.328-.394 0-.771-.147-.36-.132-.64-.394-.278-.246-.459-.623-.164-.361-.164-.837-.016-.705.148-1.246.18-.541.426-.935.263-.393.541-.64.296-.262.542-.41.606-.377 1.23-.508.623-.147 1.18-.164.624 0 1.247.213.64.197 1.197.59.558.378 1 .92.443.524.673 1.18.279.738.279 1.558.016.836-.197 1.804-.066.328-.148.59-.082.263-.18.509-.099.246-.23.492-.115.246-.262.541m1.656-6.314q-.016-.377.246-.623.263-.263.64-.263.377-.016.64.23.278.246.278.623.017.377-.246.656-.262.263-.64.263-.377.016-.655-.246-.263-.263-.263-.64m0 4.133q0-.377.263-.623.262-.246.64-.263.376 0 .639.23.279.246.279.623.016.377-.246.64-.263.278-.64.278-.377.017-.656-.246-.262-.262-.279-.64"/>
+      </g>
+    </g>
+  </g>
+  <path id="text1" d="m203.467 84.125 2.188-.226q.093.742.554 1.18.461.43 1.063.43.687 0 1.164-.555.476-.563.476-1.688 0-1.055-.476-1.578-.469-.531-1.227-.531-.945 0-1.695.836l-1.781-.258 1.125-5.961h5.804v2.055h-4.14l-.344 1.945q.734-.367 1.5-.367 1.46 0 2.477 1.062 1.015 1.063 1.015 2.758 0 1.414-.82 2.523-1.117 1.516-3.102 1.516-1.586 0-2.586-.851-1-.852-1.195-2.29" aria-label="5" style="font-weight:700;font-size:16px;font-family:Arial;-inkscape-font-specification:&quot;Arial, Bold&quot;;stroke-width:.88063;stroke-opacity:.866667"/>
+</svg>


### PR DESCRIPTION
This PR optimizes the formatting (no content changed) of the updated svg files in #1748 and fixes a typo in the textcritics for m38.

