### PR TITLE
fix(edition): improve formatting and display of sourceDesc corrections

### DIFF
--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.html
@@ -12,14 +12,16 @@
                     [compile-html]="description"
                     [compile-html-ref]="ref"></p>
             }
-            <awg-edition-tka-table
-                [textcriticalCommentBlocks]="correction.comments"
-                [isCorrections]="true"
-                [isRowTable]="correction.rowtable"
-                (navigateToReportFragmentRequest)="navigateToReportFragment($event)"
-                (openModalRequest)="openModal($event)"
-                (selectSvgSheetRequest)="selectSvgSheet($event)">
-            </awg-edition-tka-table>
+            @if (correction.comments.length > 0) {
+                <awg-edition-tka-table
+                    [textcriticalCommentBlocks]="correction.comments"
+                    [isCorrections]="true"
+                    [isRowTable]="correction.rowtable"
+                    (navigateToReportFragmentRequest)="navigateToReportFragment($event)"
+                    (openModalRequest)="openModal($event)"
+                    (selectSvgSheetRequest)="selectSvgSheet($event)">
+                </awg-edition-tka-table>
+            }
         </details>
     }
 </div>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.spec.ts
@@ -1,7 +1,9 @@
+import { DOCUMENT } from '@angular/common';
 import { Component, DebugElement, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Spy = jasmine.Spy;
 
+import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
     expectToBe,
@@ -14,7 +16,6 @@ import { mockEditionData } from '@testing/mock-data';
 import { CompileHtmlComponent } from '@awg-shared/compile-html';
 import { TextcriticalCommentBlock, Textcritics } from '@awg-views/edition-view/models';
 
-import { DOCUMENT } from '@angular/common';
 import { SourceDescriptionCorrectionsComponent } from './source-description-corrections.component';
 
 // Mock components
@@ -222,7 +223,23 @@ describe('SourceDescriptionCorrectionsComponent (DONE)', () => {
                 });
             });
 
-            it('... should contain one EditionTkaTableComponent in each corrections detail', () => {
+            it('... should contain no EditionTkaTableComponent in corrections detail if no comments are given', () => {
+                component.corrections[0].comments = [];
+                detectChangesOnPush(fixture);
+
+                const detailsDes = getAndExpectDebugElementByCss(
+                    compDe,
+                    'details.awg-source-description-correction-details',
+                    expectedCorrections.length,
+                    expectedCorrections.length
+                );
+
+                detailsDes.forEach((detailsDe, _index) => {
+                    getAndExpectDebugElementByDirective(detailsDe, EditionTkaTableStubComponent, 0, 0);
+                });
+            });
+
+            it('... should contain one EditionTkaTableComponent in each corrections detail if comments are given', () => {
                 const detailsDes = getAndExpectDebugElementByCss(
                     compDe,
                     'details.awg-source-description-correction-details',

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-table/edition-tka-table.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-table/edition-tka-table.component.html
@@ -12,7 +12,7 @@
         <tbody>
             @for (textcriticalCommentBlock of textcriticalCommentBlocks; track $index) {
                 @if (textcriticalCommentBlock.blockHeader) {
-                    <tr>
+                    <tr class="table-light table-group-divider">
                         <td colspan="4" class="awg-edition-tka-table-block-header">
                             <span [compile-html]="textcriticalCommentBlock.blockHeader" [compile-html-ref]="ref"></span>
                         </td>

--- a/src/assets/data/edition/series/1/section/5/op12/source-description.json
+++ b/src/assets/data/edition/series/1/section/5/op12/source-description.json
@@ -1594,260 +1594,262 @@
                     }
                 ],
                 "corrections": [
-        {
-            "id": "source_Ca_corr",
-            "label": "Korrekturen in <strong>C<sup>a</sup></strong>",
-            "description": ["Die Beschreibung der Korrekturen bezieht sich auf „Der Tag ist vergangen“ M 212: Textfassung 2."],
-            "comments": [
-                {
-                    "blockHeader": "",
-                    "blockComments": [
-                        {                            
-                            "measure": "3",
-                            "system": "Ges.",
-                            "position": "5/8",
-                            "comment": "Rasur über System."
-                        },
-                        {                            
-                            "measure": "5",
-                            "system": "Klav. o.",
-                            "position": "1. Note",
-                            "comment": "Auf Rasur."
-                        },
-                        {                            
-                            "measure": "5",
-                            "system": "Ges.",
-                            "position": "3–4/8",
-                            "comment": "e<sup>1</sup> und fis<sup>1</sup> überschreiben nicht zu identifizierende Tonhöhen."
-                        },
-                        {                            
-                            "measure": "7",
-                            "system": "Klav. o.",
-                            "position": "2/8",
-                            "comment": "Auf Rasur."
-                        },
-                        {                            
-                            "measure": "7",
-                            "system": "Klav. u.",
-                            "position": "3/8",
-                            "comment": "Staccatopunkt auf Rasur."
-                        },
-                        {                            
-                            "measure": "8",
-                            "system": "Ges.",
-                            "position": "3–4/8",
-                            "comment": "Auf Rasur."
-                        },
-                        {                            
-                            "measure": "9",
-                            "system": "Ges.",
-                            "position": "1.–3. Note",
-                            "comment": "Crescendogabel gestrichen."
-                        },
-                        {                            
-                            "measure": "9",
-                            "system": "Klav.",
-                            "position": "4/8",
-                            "comment": "<em>Ped.</em> gestrichen mit blauer Tinte."
-                        },
-                        {                            
-                            "measure": "10",
-                            "system": "Klav. u.",
-                            "position": "",
-                            "comment": "Rasuren unter dem System."
-                        },
-                        {                            
-                            "measure": "10",
-                            "system": "Klav.",
-                            "position": "2/4",
-                            "comment": "Pedalaufhebung gestrichen mit blauer Tinte."
-                        },
-                        {                            
-                            "measure": "11 <br /> bis 12",
-                            "system": "",
-                            "position": "",
-                            "comment": "<em>sehr langsam</em> in T. 11 3/4 gestrichen und geändert zu <em>rit.</em> (T. 11), <em>molto</em> (T. 12) und Geltungsstrichelung mit blauer Tinte."
-                        },
-                        {                            
-                            "measure": "11",
-                            "system": "Klav. o.",
-                            "position": "1. Note",
-                            "comment": "({{ref.getGlyph('[b]')}}) zu es<sup>1</sup>/as<sup>1</sup> gestrichen mit blauer Tinte. <br /> <em>zögernd</em> gestrichen mit blauer Tinte."
-                        },
-                        {                            
-                            "measure": "11",
-                            "system": "Klav. o.",
-                            "position": "1. Note",
-                            "comment": "Crescendogabel geändert zu Decrescendogabel mit Bleistift."
-                        },
-                        {                            
-                            "measure": "11",
-                            "system": "Klav. u.",
-                            "position": "1. Note",
-                            "comment": "({{ref.getGlyph('[a]')}}) zu F/e gestrichen mit blauer Tinte."
-                        },
-                        {                            
-                            "measure": "13",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>I. Zeitmaß </em>geändert zu <em>tempo</em> mit blauer Tinte."
-                        },
-                        {                            
-                            "measure": "13",
-                            "system": "Ges.",
-                            "position": "1/8",
-                            "comment": "Auf Rasur."
-                        },
-                        {                            
-                            "measure": "13",
-                            "system": "Ges.",
-                            "position": "",
-                            "comment": "Rasur über dem System."
-                        },
-                        {                            
-                            "measure": "14",
-                            "system": "Ges.",
-                            "position": "1.–2. Note",
-                            "comment": "Crescendogabel gestrichen mit blauer Tinte."
-                        },
-                        {                            
-                            "measure": "14",
-                            "system": "Ges.",
-                            "position": "1.–3. Note",
-                            "comment": "Triolenklammer hinzugefügt mit Bleistift (Hs.?)"
-                        },
-                        {                            
-                            "measure": "14",
-                            "system": "Klav. u.",
-                            "position": "1/8",
-                            "comment": "Auf Rasur. <br /> ({{ref.getGlyph('[a]')}}) zu e/a gestrichen mit blauer Tinte."
-                        },
-                        {                            
-                            "measure": "14 <br /> bis 15",
-                            "system": "Ges.",
-                            "position": "4. Note <br /> 2/8",
-                            "comment": "Crescendogabel ergänzt mit blauer Tinte."
-                        },
-                        {                            
-                            "measure": "15",
-                            "system": "Klav. o.",
-                            "position": "(2/4)",
-                            "comment": "Triolenklammer hinzugefügt mit Bleistift (Hs.?)"
-                        },
-                        {                            
-                            "measure": "15",
-                            "system": "Klav. o.",
-                            "position": "2. Note",
-                            "comment": "Auf Rasur."
-                        },
-                        {                            
-                            "measure": "15",
-                            "system": "Klav. u.",
-                            "position": "4/8",
-                            "comment": "Auf Rasur."
-                        },
-                        {                            
-                            "measure": "16",
-                            "system": "Klav. o.",
-                            "position": "3/4",
-                            "comment": "Unterstimmenschicht: fis<sup>1</sup> geändert zu ges<sup>1</sup>."
-                        },
-                        {                            
-                            "measure": "16",
-                            "system": "Klav. u.",
-                            "position": "3/4",
-                            "comment": "cis geändert zu des."
-                        },
-                        {                            
-                            "measure": "17",
-                            "system": "Klav. o.",
-                            "position": "1. Note",
-                            "comment": "Crescendogabel gestrichen mit Bleistift."
-                        },
-                        {                            
-                            "measure": "17",
-                            "system": "Klav. o.",
-                            "position": "2. Note",
-                            "comment": "Unterstimmenschicht: des<sup>1</sup>/ges<sup>1</sup> überschreibt cis<sup>1</sup>/fis<sup>1</sup>; Pfeil zu Notennamen <em>ges | <u>des</u></em><u> am rechten Seitenrand. </u>"
-                        },
-                        {                            
-                            "measure": "20",
-                            "system": "Klav. o.",
-                            "position": "(2/4)",
-                            "comment": "Decrescendogabel gestrichen mit blauer Tinte."
-                        },
-                        {                            
-                            "measure": "21",
-                            "system": "Klav. o.",
-                            "position": "1. Note",
-                            "comment": "{{ref.getGlyph('[p]')}} geändert zu {{ref.getGlyph('[pp]')}} mit blauer Tinte."
-                        },
-                        {                            
-                            "measure": "21 <br /> bis 22",
-                            "system": "Klav. o.",
-                            "position": "1. Note <br /> 2/4",
-                            "comment": "Legatobogen ergänzt mit Bleistift."
-                        },
-                        {                            
-                            "measure": "22",
-                            "system": "Klav. o.",
-                            "position": "1/4",
-                            "comment": "({{ref.getGlyph('[b]')}}) zu es<sup>1</sup> und ({{ref.getGlyph('[a]')}}) zu c<sup>2</sup> (nach Akkoladenwechsel) gestrichen mit Bleistift (Hs. ?)."
-                        },
-                        {                            
-                            "measure": "22",
-                            "system": "Klav. o.",
-                            "position": "1–2/4",
-                            "comment": "Decrescendogabel gestrichen mit Bleistift."
-                        },
-                        {                            
-                            "measure": "22",
-                            "system": "Klav. u.",
-                            "position": "",
-                            "comment": "({{ref.getGlyph('[a]')}}) zu H/g (nach Akkoladenwechsel) gestrichen mit Bleistift (Hs. ?)."
-                        },
-                        {                            
-                            "measure": "22",
-                            "system": "Klav. o.",
-                            "position": "2/4",
-                            "comment": "{{ref.getGlyph('[pp]')}} geändert zu {{ref.getGlyph('[ppp]')}} mit blauer Tinte."
-                        },
-                        {
-                            "measure": "22 <br /> bis 23",
-                            "system": "Klav. o.",
-                            "position": "2/4",
-                            "comment": "Gis<sub>1</sub>/Cis geändert zu As<sub>1</sub>/Des."
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "id": "source_Cb_corr",
-            "label": "Korrekturen in <strong>C<sup>b</sup></strong>",
-            "description": [
-                "<strong>C<sup>b</sup></strong> weist zwei voneinander unterscheidbare Korrekturschichten auf: mit Tinte ggf. auf Rasur (Korrekturen 1) und mit Bleistift (Korrekturen 2). Der Zustand vor und nach Korrekturen 1 ist nicht eindeutig entzifferbar. Korrekturen 2 betreffen die Überarbeitung zu der in <strong>F</strong> etablierten Textfassung von <em>Die geheimnisvolle Flöte</em> M 217. Auf eine tabellarische Darstellung der beiden Korrekturschichten wird verzichtet, da sie auf Grund der zahlreichen Abweichungen der Grundschicht zu der edierten einzigen Textfassung nicht praktikabel ist."
-            ],
-            "comments": [ ]
-        },
-        {
-            "id": "source_Cc_corr",
-            "label": "Korrekturen in <strong>C<sup>c</sup></strong>",
-            "description": [
-                "<strong>C<sup>c</sup></strong> weist zwei voneinander unterscheidbare Korrekturschichten auf: mit Tinte ggf. auf Rasur bzw. auf Tektur (Korrekturen 1) und mit Bleistift (Korrekturen 2). Der Zustand vor und nach Korrekturen 1 ist nicht eindeutig entzifferbar. Korrekturen 2 betreffen die Überarbeitung zu der in <strong>F</strong> etablierten Textfassung von „Schien mir’s, als ich sah die Sonne“ M 213. Auf eine tabellarische Darstellung der beiden Korrekturschichten wird verzichtet, da sie auf Grund der zahlreichen Abweichungen der Grundschicht zu der edierten einzigen Textfassung nicht praktikabel ist."
-            ],
-            "comments": [ ]
-        },
-        {
-            "id": "source_Cd_corr",
-            "label": "Korrekturen in <strong>C<sup>d</sup></strong>",
-            "description": [
-                "<strong>C<sup>d</sup></strong> weist drei voneinander unterscheidbare Korrekturschichten auf: mit Tinte ggf. auf Rasur (Korrekturen 1), mit Bleistift (Korrekturen 2) und mit Kopierstift (Korrekturen 3). Der Zustand vor und nach Korrekturen 1 ist nicht eindeutig entzifferbar, post correcturam entspricht er in weiten Teilen Textfassung 1 von <em>Gleich und Gleich</em> („Ein Blumenglöckchen“) M 216. Korrekturen 2 und 3 betreffen die Überarbeitung zu der in <strong>F</strong> etablierten Textfassung 2. Auf eine tabellarische Darstellung der verschiedenen Korrekturschichten wird verzichtet, da sie auf Grund der zahlreichen Abweichungen der Grundschicht zu den beiden edierten Textfassungen nicht praktikabel ist."
-            ],
-            "comments": [ ]
-        }
-    ]
-}
+                    {
+                        "id": "source_Ca_corr",
+                        "label": "Korrekturen in <strong>C<sup>a</sup></strong>",
+                        "description": [
+                            "Die Beschreibung der Korrekturen bezieht sich auf „Der Tag ist vergangen“ M 212: Textfassung 2."
+                        ],
+                        "comments": [
+                            {
+                                "blockHeader": "",
+                                "blockComments": [
+                                    {
+                                        "measure": "3",
+                                        "system": "Ges.",
+                                        "position": "5/8",
+                                        "comment": "Rasur über System."
+                                    },
+                                    {
+                                        "measure": "5",
+                                        "system": "Klav. o.",
+                                        "position": "1. Note",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "5",
+                                        "system": "Ges.",
+                                        "position": "3–4/8",
+                                        "comment": "e<sup>1</sup> und fis<sup>1</sup> überschreiben nicht zu identifizierende Tonhöhen."
+                                    },
+                                    {
+                                        "measure": "7",
+                                        "system": "Klav. o.",
+                                        "position": "2/8",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "7",
+                                        "system": "Klav. u.",
+                                        "position": "3/8",
+                                        "comment": "Staccatopunkt auf Rasur."
+                                    },
+                                    {
+                                        "measure": "8",
+                                        "system": "Ges.",
+                                        "position": "3–4/8",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "9",
+                                        "system": "Ges.",
+                                        "position": "1.–3. Note",
+                                        "comment": "Crescendogabel gestrichen."
+                                    },
+                                    {
+                                        "measure": "9",
+                                        "system": "Klav.",
+                                        "position": "4/8",
+                                        "comment": "<em>Ped.</em> gestrichen mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "10",
+                                        "system": "Klav. u.",
+                                        "position": "",
+                                        "comment": "Rasuren unter dem System."
+                                    },
+                                    {
+                                        "measure": "10",
+                                        "system": "Klav.",
+                                        "position": "2/4",
+                                        "comment": "Pedalaufhebung gestrichen mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "11 <br /> bis 12",
+                                        "system": "",
+                                        "position": "",
+                                        "comment": "<em>sehr langsam</em> in T. 11 3/4 gestrichen und geändert zu <em>rit.</em> (T. 11), <em>molto</em> (T. 12) und Geltungsstrichelung mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "11",
+                                        "system": "Klav. o.",
+                                        "position": "1. Note",
+                                        "comment": "({{ref.getGlyph('[b]')}}) zu es<sup>1</sup>/as<sup>1</sup> gestrichen mit blauer Tinte. <br /> <em>zögernd</em> gestrichen mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "11",
+                                        "system": "Klav. o.",
+                                        "position": "1. Note",
+                                        "comment": "Crescendogabel geändert zu Decrescendogabel mit Bleistift."
+                                    },
+                                    {
+                                        "measure": "11",
+                                        "system": "Klav. u.",
+                                        "position": "1. Note",
+                                        "comment": "({{ref.getGlyph('[a]')}}) zu F/e gestrichen mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "13",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>I. Zeitmaß </em>geändert zu <em>tempo</em> mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "13",
+                                        "system": "Ges.",
+                                        "position": "1/8",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "13",
+                                        "system": "Ges.",
+                                        "position": "",
+                                        "comment": "Rasur über dem System."
+                                    },
+                                    {
+                                        "measure": "14",
+                                        "system": "Ges.",
+                                        "position": "1.–2. Note",
+                                        "comment": "Crescendogabel gestrichen mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "14",
+                                        "system": "Ges.",
+                                        "position": "1.–3. Note",
+                                        "comment": "Triolenklammer hinzugefügt mit Bleistift (Hs.?)"
+                                    },
+                                    {
+                                        "measure": "14",
+                                        "system": "Klav. u.",
+                                        "position": "1/8",
+                                        "comment": "Auf Rasur. <br /> ({{ref.getGlyph('[a]')}}) zu e/a gestrichen mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "14 <br /> bis 15",
+                                        "system": "Ges.",
+                                        "position": "4. Note <br /> 2/8",
+                                        "comment": "Crescendogabel ergänzt mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "15",
+                                        "system": "Klav. o.",
+                                        "position": "(2/4)",
+                                        "comment": "Triolenklammer hinzugefügt mit Bleistift (Hs.?)"
+                                    },
+                                    {
+                                        "measure": "15",
+                                        "system": "Klav. o.",
+                                        "position": "2. Note",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "15",
+                                        "system": "Klav. u.",
+                                        "position": "4/8",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "16",
+                                        "system": "Klav. o.",
+                                        "position": "3/4",
+                                        "comment": "Unterstimmenschicht: fis<sup>1</sup> geändert zu ges<sup>1</sup>."
+                                    },
+                                    {
+                                        "measure": "16",
+                                        "system": "Klav. u.",
+                                        "position": "3/4",
+                                        "comment": "cis geändert zu des."
+                                    },
+                                    {
+                                        "measure": "17",
+                                        "system": "Klav. o.",
+                                        "position": "1. Note",
+                                        "comment": "Crescendogabel gestrichen mit Bleistift."
+                                    },
+                                    {
+                                        "measure": "17",
+                                        "system": "Klav. o.",
+                                        "position": "2. Note",
+                                        "comment": "Unterstimmenschicht: des<sup>1</sup>/ges<sup>1</sup> überschreibt cis<sup>1</sup>/fis<sup>1</sup>; Pfeil zu Notennamen <em>ges | <u>des</u></em><u> am rechten Seitenrand. </u>"
+                                    },
+                                    {
+                                        "measure": "20",
+                                        "system": "Klav. o.",
+                                        "position": "(2/4)",
+                                        "comment": "Decrescendogabel gestrichen mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "21",
+                                        "system": "Klav. o.",
+                                        "position": "1. Note",
+                                        "comment": "{{ref.getGlyph('[p]')}} geändert zu {{ref.getGlyph('[pp]')}} mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "21 <br /> bis 22",
+                                        "system": "Klav. o.",
+                                        "position": "1. Note <br /> 2/4",
+                                        "comment": "Legatobogen ergänzt mit Bleistift."
+                                    },
+                                    {
+                                        "measure": "22",
+                                        "system": "Klav. o.",
+                                        "position": "1/4",
+                                        "comment": "({{ref.getGlyph('[b]')}}) zu es<sup>1</sup> und ({{ref.getGlyph('[a]')}}) zu c<sup>2</sup> (nach Akkoladenwechsel) gestrichen mit Bleistift (Hs. ?)."
+                                    },
+                                    {
+                                        "measure": "22",
+                                        "system": "Klav. o.",
+                                        "position": "1–2/4",
+                                        "comment": "Decrescendogabel gestrichen mit Bleistift."
+                                    },
+                                    {
+                                        "measure": "22",
+                                        "system": "Klav. u.",
+                                        "position": "",
+                                        "comment": "({{ref.getGlyph('[a]')}}) zu H/g (nach Akkoladenwechsel) gestrichen mit Bleistift (Hs. ?)."
+                                    },
+                                    {
+                                        "measure": "22",
+                                        "system": "Klav. o.",
+                                        "position": "2/4",
+                                        "comment": "{{ref.getGlyph('[pp]')}} geändert zu {{ref.getGlyph('[ppp]')}} mit blauer Tinte."
+                                    },
+                                    {
+                                        "measure": "22 <br /> bis 23",
+                                        "system": "Klav. o.",
+                                        "position": "2/4",
+                                        "comment": "Gis<sub>1</sub>/Cis geändert zu As<sub>1</sub>/Des."
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "id": "source_Cb_corr",
+                        "label": "Korrekturen in <strong>C<sup>b</sup></strong>",
+                        "description": [
+                            "<strong>C<sup>b</sup></strong> weist zwei voneinander unterscheidbare Korrekturschichten auf: mit Tinte ggf. auf Rasur (Korrekturen 1) und mit Bleistift (Korrekturen 2). Der Zustand vor und nach Korrekturen 1 ist nicht eindeutig entzifferbar. Korrekturen 2 betreffen die Überarbeitung zu der in <strong>F</strong> etablierten Textfassung von <em>Die geheimnisvolle Flöte</em> M 217. Auf eine tabellarische Darstellung der beiden Korrekturschichten wird verzichtet, da sie auf Grund der zahlreichen Abweichungen der Grundschicht zu der edierten einzigen Textfassung nicht praktikabel ist."
+                        ],
+                        "comments": []
+                    },
+                    {
+                        "id": "source_Cc_corr",
+                        "label": "Korrekturen in <strong>C<sup>c</sup></strong>",
+                        "description": [
+                            "<strong>C<sup>c</sup></strong> weist zwei voneinander unterscheidbare Korrekturschichten auf: mit Tinte ggf. auf Rasur bzw. auf Tektur (Korrekturen 1) und mit Bleistift (Korrekturen 2). Der Zustand vor und nach Korrekturen 1 ist nicht eindeutig entzifferbar. Korrekturen 2 betreffen die Überarbeitung zu der in <strong>F</strong> etablierten Textfassung von „Schien mir’s, als ich sah die Sonne“ M 213. Auf eine tabellarische Darstellung der beiden Korrekturschichten wird verzichtet, da sie auf Grund der zahlreichen Abweichungen der Grundschicht zu der edierten einzigen Textfassung nicht praktikabel ist."
+                        ],
+                        "comments": []
+                    },
+                    {
+                        "id": "source_Cd_corr",
+                        "label": "Korrekturen in <strong>C<sup>d</sup></strong>",
+                        "description": [
+                            "<strong>C<sup>d</sup></strong> weist drei voneinander unterscheidbare Korrekturschichten auf: mit Tinte ggf. auf Rasur (Korrekturen 1), mit Bleistift (Korrekturen 2) und mit Kopierstift (Korrekturen 3). Der Zustand vor und nach Korrekturen 1 ist nicht eindeutig entzifferbar, post correcturam entspricht er in weiten Teilen Textfassung 1 von <em>Gleich und Gleich</em> („Ein Blumenglöckchen“) M 216. Korrekturen 2 und 3 betreffen die Überarbeitung zu der in <strong>F</strong> etablierten Textfassung 2. Auf eine tabellarische Darstellung der verschiedenen Korrekturschichten wird verzichtet, da sie auf Grund der zahlreichen Abweichungen der Grundschicht zu den beiden edierten Textfassungen nicht praktikabel ist."
+                        ],
+                        "comments": []
+                    }
+                ]
+            }
         },
         {
             "id": "source_D",

--- a/src/assets/data/edition/series/1/section/5/op25/source-description.json
+++ b/src/assets/data/edition/series/1/section/5/op25/source-description.json
@@ -2182,915 +2182,915 @@
                     }
                 ],
                 "corrections": [
-        {
-            "id": "source_E_corr1",
-            "label": "Korrekturen 1 in <strong>E</strong>",
-            "description": [
-                "Die Beschreibung der Korrekturen bezieht sich auf „Wie bin ich froh“ M 317: Textfassung 1."
-            ],
-            "comments": [
-                {
-                    "blockHeader": "",
-                    "blockComments": [
-                        {
-                            "measure": "1",
-                            "system": "",
-                            "position": "(5/8)",
-                            "comment": "Geltungsstrichelung von <em>rit.</em> auf Rasur. Ante correcturam: <em>rit.</em> vermutlich versetzt von T. 1 5/8. Siehe TkA zu 4/8."
-                        },
-                        {
-                            "measure": "10",
-                            "system": "",
-                            "position": "(3/4)",
-                            "comment": "Geltungsstrichelung von <em>rit.</em> auf Rasur. Ante correcturam: <em>rit.</em> vermutlich versetzt von T. 10 3/4 zu Taktanfang."
-                        },
-                        {
-                            "measure": "11 <br /> bis 12",
-                            "system": "",
-                            "position": "(4/4)",
-                            "comment": "T. 11 4/4 wurde zum Teil auf handgezogenen Systemen am Akkoladenende ergänzt; am vom Systemanfang nach rechts verschobenen Akkoladenanfang vor T. 12 steht eine großflächige Rasur; weitere Rasuren in T. 12 Ges.; radierter Taktstrich nach T. 12 2/8. Ante correcturam: vermutlich eine dreitaktige Variante (T. [11–13]) mit Taktstrichen nach T. 11 6/8 (vor T. [12]) und nach T. 12 2/8 (vor T. [13]). Siehe <strong>M 317 Sk4</strong> T. 13–15."
-                        },
-                        {
-                            "measure": "12",
-                            "system": "Klav. u.",
-                            "position": "2.–5. Note",
-                            "comment": "Auf Rasur. Ante correcturam: Tonhöhen vermutlich im Violinschlüssel notiert. Siehe <strong>M 317 Sk4</strong> T. 13–15."
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "id": "source_E_corr2",
-            "label": "Korrekturen 2 in <strong>E</strong>",
-            "description": [
-                "Die Beschreibung der Korrekturen bezieht sich auf die Textfassungen der Werkedition von <em>Drei Lieder nach Gedichten von Hildegard Jone</em> op. 25."
-            ],
-            "comments": [
-                {
-                    "blockHeader": "I „Wie bin ich froh“ M 317",
-                    "blockComments": [
-                        {
-                            "measure": "1",
-                            "system": "Klav.",
-                            "position": "5–6/8",
-                            "comment": "Auf Rasur. Ante correcturam: Aufteilung der Noten auf die Systeme vermutlich wie in Textfassung 1."
-                        },
-                        {
-                            "measure": "2",
-                            "system": "Ges.",
-                            "position": "2.–3. Note",
-                            "comment": "Bogen rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "3",
-                            "system": "Ges.",
-                            "position": "1.–3. Note",
-                            "comment": "Bogen rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "3",
-                            "system": "Ges.",
-                            "position": "5–6/8",
-                            "comment": "Tenutostriche rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "vor 4",
-                            "system": "Klav. u.",
-                            "position": "",
-                            "comment": "Violinschlüssel versetzt von T. 4 vor 1. Note (dort Rasur; siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "4",
-                            "system": "Ges.",
-                            "position": "1.–3. Note",
-                            "comment": "Bogen rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "4",
-                            "system": "Ges.",
-                            "position": "8/8",
-                            "comment": "Tenutostrich rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "5",
-                            "system": "Ges.",
-                            "position": "1.–3. Note",
-                            "comment": "Bogen rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "5 <br /> bis 6",
-                            "system": "Klav.",
-                            "position": "5/8 <br /> 1/8",
-                            "comment": "Auf Rasur. Ante correcturam: Aufteilung der Noten auf die Systeme vermutlich wie in Textfassung 1."
-                        },
-                        {
-                            "measure": "6",
-                            "system": "Klav.",
-                            "position": "2. Note",
-                            "comment": "Bleistiftskizzen über und unter der Akkolade (System 5 und 9) rasiert."
-                        },
-                        {
-                            "measure": "6 <br /> bis 7",
-                            "system": "Ges.",
-                            "position": "2. Note <br /> 2/8",
-                            "comment": "Bogen rasiert (siehe Textfassung 1). Möglicherweise steht der Silbenbogen in T. 7 1–2/8 im Zusammenhang mit dieser Korrektur."
-                        },
-                        {
-                            "measure": "7",
-                            "system": "Ges.",
-                            "position": "4–6/8",
-                            "comment": "Bogen rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "8",
-                            "system": "Klav. u.",
-                            "position": "nach 3/8",
-                            "comment": "Violinschlüssel versetzt von vor 2. Note (dort Rasur; siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "8",
-                            "system": "Ges.",
-                            "position": "1.–4. Note",
-                            "comment": "Bogen rasiert (siehe Textfassung 1). Möglicherweise steht der Silbenbogen in T. 8 3.–4. Note im Zusammenhang mit dieser Korrektur."
-                        },
-                        {
-                            "measure": "8",
-                            "system": "Ges.",
-                            "position": "5.–6. Note",
-                            "comment": "Tenutostriche rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "9",
-                            "system": "Ges.",
-                            "position": "3.–5. Note",
-                            "comment": "Tenutostriche rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "9 <br /> bis 10",
-                            "system": "Ges.",
-                            "position": "8/8 <br /> 2/8",
-                            "comment": "Bogen rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "10",
-                            "system": "Ges.",
-                            "position": "3.–5. Note",
-                            "comment": "Bogen rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "11",
-                            "system": "Ges.",
-                            "position": "6/8",
-                            "comment": "Tenutostrich rasiert (siehe Textfassung 1)."
-                        },
-                        {
-                            "measure": "12",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>tempo I.</em> ersetzt <em>wieder tempo I.</em> auf Rasur (siehe Textfassung 1)."
-                        }
-                    ]
-                },
-                {
-                    "blockHeader": "II „Des Herzens Purpurvogel“ M 322",
-                    "blockComments": [
-                        {
-                            "measure": "1",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "Metronomangabe auf Rasur."
-                        },
-                        {
-                            "measure": "2",
-                            "system": "Klav. u.",
-                            "position": "1/16",
-                            "comment": "Auf Rasur."
-                        },
-                        {
-                            "measure": "3",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit.</em> auf Rasur."
-                        },
-                        {
-                            "measure": "3 <br /> bis 6",
-                            "system": "Ges.",
-                            "position": "6/16 <br /> 3/8",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "6",
-                            "system": "Klav. u.",
-                            "position": "1–2/8",
-                            "comment": "Auf Rasur. Ante correcturam: Hals- und Bogenausrichtung umgekehrt?"
-                        },
-                        {
-                            "measure": "7 <br /> bis 8",
-                            "system": "Ges.",
-                            "position": "2/8 <br /> 2/8",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "9",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit.</em> auf Rasur."
-                        },
-                        {
-                            "measure": "10",
-                            "system": "Klav. u.",
-                            "position": "1/16",
-                            "comment": "{{ref.getGlyph('[f]')}} auf Rasur."
-                        },
-                        {
-                            "measure": "10",
-                            "system": "",
-                            "position": "4/16",
-                            "comment": "<em>rit.</em> auf Rasur."
-                        },
-                        {
-                            "measure": "10 <br /> bis 11",
-                            "system": "Ges.",
-                            "position": "6/16 <br /> 3/8",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "11",
-                            "system": "Klav.",
-                            "position": "2–6/16",
-                            "comment": "Auf Rasur. Bleistiftskizzen über und unter dem Klav.-System (System 4 und 7) radiert."
-                        },
-                        {
-                            "measure": "12",
-                            "system": "Ges.",
-                            "position": "2–3/8",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "13",
-                            "system": "Klav.",
-                            "position": "",
-                            "comment": "Crescendo- und Decrescendogabel auf Rasur."
-                        },
-                        {
-                            "measure": "13 <br /> bis 14",
-                            "system": "Ges.",
-                            "position": "2/8 <br /> 6/16",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "15",
-                            "system": "Ges.",
-                            "position": "1.–2. Note",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "15",
-                            "system": "Klav.",
-                            "position": "1–5/16",
-                            "comment": "Rasur zwischen den Systemen. Ante correcturam: Gabel?"
-                        },
-                        {
-                            "measure": "16",
-                            "system": "Ges.",
-                            "position": "1.–2. Note",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "16 <br /> bis 17",
-                            "system": "Ges.",
-                            "position": "3/8 <br /> 6/16",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "16",
-                            "system": "Klav. u.",
-                            "position": "3/8",
-                            "comment": "{{ref.getGlyph('[f]')}} auf Rasur."
-                        },
-                        {
-                            "measure": "16 <br /> bis 17",
-                            "system": "Klav. u.",
-                            "position": "3/8 <br /> 1/16",
-                            "comment": "Auf Rasur."
-                        },
-                        {
-                            "measure": "18 <br /> bis 19",
-                            "system": "Ges.",
-                            "position": "2/16 <br /> 2. Note",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "19",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit.</em> auf Rasur."
-                        },
-                        {
-                            "measure": "20",
-                            "system": "Ges.",
-                            "position": "1.–2. Note",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "21",
-                            "system": "Klav. o.",
-                            "position": "1/16",
-                            "comment": "Auf Rasur."
-                        },
-                        {
-                            "measure": "21",
-                            "system": "Klav. u.",
-                            "position": "2/16",
-                            "comment": "Auf Rasur."
-                        },
-                        {
-                            "measure": "23–24",
-                            "system": "",
-                            "position": "",
-                            "comment": "<em>rit. - - - tempo</em> auf Rasur (bis Ende T. 24)."
-                        },
-                        {
-                            "measure": "23",
-                            "system": "Ges.",
-                            "position": "2/16–2/8",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "23 <br /> bis 24",
-                            "system": "Ges.",
-                            "position": "3/8 <br /> 1. Note",
-                            "comment": "Anfang der Decrescendogabel auf Rasur. Ante correcturam: Ausdehnung der Gabel von T. 23 2/8 bis Taktende?"
-                        },
-                        {
-                            "measure": "23 <br /> bis 24",
-                            "system": "Klav. o.",
-                            "position": "6/16 <br /> 1/16",
-                            "comment": "Auf Rasur. Ante correcturam: ges<sup>1</sup>? (Siehe <strong>M 322 Sk4</strong> T. 12.)"
-                        },
-                        {
-                            "measure": "24",
-                            "system": "Klav. u.",
-                            "position": "2/8",
-                            "comment": "Auf Rasur."
-                        },
-                        {
-                            "measure": "25 <br /> bis 26",
-                            "system": "Ges.",
-                            "position": "1. Note <br /> 3/8",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "26",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit.</em> auf Rasur."
-                        },
-                        {
-                            "measure": "27",
-                            "system": "Klav.",
-                            "position": "2.–3. Note",
-                            "comment": "Auf Rasur."
-                        },
-                        {
-                            "measure": "27 <br /> bis 28",
-                            "system": "Ges.",
-                            "position": "4/16 <br /> 2/16",
-                            "comment": "Bogen rasiert. Crescendo- (T. 27 3/8) und Decrescendogabel auf Rasur."
-                        },
-                        {
-                            "measure": "27 <br /> bis 28",
-                            "system": "Klav.",
-                            "position": "6/16 <br /> 2/16",
-                            "comment": "Bogen auf Rasur."
-                        },
-                        {
-                            "measure": "29",
-                            "system": "Ges.",
-                            "position": "2–3/16",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "29 <br /> bis 30",
-                            "system": "Ges.",
-                            "position": "4/16 <br /> 4/16",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "30",
-                            "system": "",
-                            "position": "6/16",
-                            "comment": "<em>tempo</em> auf Rasur."
-                        },
-                        {
-                            "measure": "30 <br /> bis 31",
-                            "system": "Ges.",
-                            "position": "6/16 <br /> 3/16",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "31",
-                            "system": "",
-                            "position": "2/16",
-                            "comment": "<em>rit.</em> auf Rasur."
-                        },
-                        {
-                            "measure": "32",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "Geltungsstrichelung von<em> rit</em>. (T. 31) auf Rasur."
-                        },
-                        {
-                            "measure": "33",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>langsamer</em> auf Rasur."
-                        },
-                        {
-                            "measure": "33",
-                            "system": "Ges.",
-                            "position": "1.–2. Note",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "33",
-                            "system": "Ges.",
-                            "position": "5–6/16",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "34",
-                            "system": "Klav.",
-                            "position": "2–4/16",
-                            "comment": "Bogen rasiert. Staccatopunkt zu 4/16 auf Rasur."
-                        },
-                        {
-                            "measure": "34",
-                            "system": "Ges.",
-                            "position": "4/16–3/8",
-                            "comment": "Bogen rasiert. Tenutostrich zu 3/8 auf Rasur."
-                        },
-                        {
-                            "measure": "35",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit.</em> auf Rasur."
-                        },
-                        {
-                            "measure": "35",
-                            "system": "Ges.",
-                            "position": "2–4/16",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "36",
-                            "system": "Klav.",
-                            "position": "2–4/16",
-                            "comment": "{{ref.getGlyph('[pp]')}} und Decrescendogabel auf Rasur."
-                        },
-                        {
-                            "measure": "37",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit.</em> auf Rasur."
-                        },
-                        {
-                            "measure": "37",
-                            "system": "Ges.",
-                            "position": "1.–2. Note",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "37",
-                            "system": "Klav.",
-                            "position": "2/16",
-                            "comment": "{{ref.getGlyph('[pp]')}} auf Rasur."
-                        },
-                        {
-                            "measure": "38",
-                            "system": "",
-                            "position": "3/16",
-                            "comment": "<em>immer langsamer</em> auf Rasur."
-                        },
-                        {
-                            "measure": "38",
-                            "system": "Klav. o.",
-                            "position": "3/8",
-                            "comment": "{{ref.getGlyph('[p]')}} auf Rasur."
-                        },
-                        {
-                            "measure": "39",
-                            "system": "Ges.",
-                            "position": "1.–3. Note",
-                            "comment": "Bogen rasiert. Tenutostrich zu 3/8 auf Rasur."
-                        },
-                        {
-                            "measure": "39",
-                            "system": "Klav. u.",
-                            "position": "2/8–6/16",
-                            "comment": "Auf Rasur."
-                        },
-                        {
-                            "measure": "40",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "Rasur über Akkolade. Ante correcturam: Tempoangabe?"
-                        },
-                        {
-                            "measure": "40",
-                            "system": "Ges.",
-                            "position": "2–5/16",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "40",
-                            "system": "Klav.",
-                            "position": "4–6/16",
-                            "comment": "{{ref.getGlyph('[pp]')}} und Decrescendogabel auf Rasur."
-                        },
-                        {
-                            "measure": "41",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>verlöschend</em> auf Rasur."
-                        },
-                        {
-                            "measure": "41",
-                            "system": "Ges.",
-                            "position": "1.–3. Note",
-                            "comment": "Bogen rasiert. Silbenbogen 2.–3. Note auf Rasur. <br /> {{ref.getGlyph('[pp]')}}, Decrescendogabel (?) rasiert."
-                        },
-                        {
-                            "measure": "nach 42",
-                            "system": "",
-                            "position": "",
-                            "comment": "Bleistiftnotiz nach Schlusstaktstrich radiert."
-                        }
-                    ]
-                },
-                {
-                    "blockHeader": "III „Sterne, ihr silbernen Bienen“ M 321",
-                    "blockComments": [
-                        {
-                            "measure": "4–6",
-                            "system": "Ges.",
-                            "position": "",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "8",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit.</em> auf Rasur."
-                        },
-                        {
-                            "measure": "9 <br /> bis 14",
-                            "system": "Ges.",
-                            "position": "2/4 <br /> 2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "13",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit.</em> auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 5: <em>calando</em>."
-                        },
-                        {
-                            "measure": "13 <br /> bis 14",
-                            "system": "Klav.",
-                            "position": "2/4 <br /> 2/4",
-                            "comment": "Auf Rasur."
-                        },
-                        {
-                            "measure": "15 <br /> bis 16",
-                            "system": "Ges.",
-                            "position": "2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "15–21",
-                            "system": "Klav.",
-                            "position": "",
-                            "comment": "Teilweise auf Rasur. Ante correcturam: alternative Aufteilung der Noten auf die Systeme?"
-                        },
-                        {
-                            "measure": "17",
-                            "system": "",
-                            "position": "",
-                            "comment": "Geltungstrichelung von <em>rit.</em> (T. 13) und <em>viel mäßiger</em> (2/4) auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 6 2. TH: <em>tempo</em>."
-                        },
-                        {
-                            "measure": "17 <br /> bis 20",
-                            "system": "Ges.",
-                            "position": "2/4 <br /> 2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "19",
-                            "system": "Klav. u.",
-                            "position": "",
-                            "comment": "Bleistifteintragung (Text) radiert."
-                        },
-                        {
-                            "measure": "20",
-                            "system": "",
-                            "position": "",
-                            "comment": "Rasur über der Akkolade. Ante correcturam: Tempoangabe?"
-                        },
-                        {
-                            "measure": "21",
-                            "system": "Ges.",
-                            "position": "1/4",
-                            "comment": "Viertelpause ersetzt Viertelnote e<sup>2</sup> mit Ligaturbogen von T. 20 2/4 auf Rasur."
-                        },
-                        {
-                            "measure": "22",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit. - - -</em> auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 8A: <em>calando</em>."
-                        },
-                        {
-                            "measure": "22–24",
-                            "system": "Ges.",
-                            "position": "",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "26–28",
-                            "system": "",
-                            "position": "",
-                            "comment": "Bleistifteintragung (Text) radiert."
-                        },
-                        {
-                            "measure": "28",
-                            "system": "",
-                            "position": "",
-                            "comment": "Rasur über der Akkolade. Ante correcturam: Tempoangabe?"
-                        },
-                        {
-                            "measure": "29 <br /> bis 31",
-                            "system": "",
-                            "position": "Taktanfang <br /> 1/4",
-                            "comment": "<em>rit.- - -</em> auf Rasur."
-                        },
-                        {
-                            "measure": "29 <br /> bis 30",
-                            "system": "Ges.",
-                            "position": "2/4 <br /> 2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "31",
-                            "system": "",
-                            "position": "2/4",
-                            "comment": "<em>wieder viel mäßiger</em> auf Rasur."
-                        },
-                        {
-                            "measure": "31 <br /> bis 33",
-                            "system": "Ges.",
-                            "position": "2/4 <br /> 1/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "33 <br /> bis 34",
-                            "system": "Ges.",
-                            "position": "2/4 <br /> 2. Note",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "34",
-                            "system": "Klav. o.",
-                            "position": "1.–2. Note",
-                            "comment": "Auf Rasur. Bleistiftskizze im System darüber radiert."
-                        },
-                        {
-                            "measure": "35",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit. - - -</em> auf Rasur."
-                        },
-                        {
-                            "measure": "35",
-                            "system": "Klav. u.",
-                            "position": "1/4",
-                            "comment": "Auf Rasur."
-                        },
-                        {
-                            "measure": "35 <br /> bis 36",
-                            "system": "Ges.",
-                            "position": "2/4 <br /> 2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "37",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>tempo I.</em> auf Rasur."
-                        },
-                        {
-                            "measure": "37 <br /> bis 38",
-                            "system": "Ges.",
-                            "position": "2/4 <br /> 2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "39",
-                            "system": "",
-                            "position": "2/4",
-                            "comment": "<em>rit. - - -</em> auf Rasur (ab Taktanfang)."
-                        },
-                        {
-                            "measure": "39 <br /> bis 41",
-                            "system": "Ges.",
-                            "position": "2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "42 <br /> bis 45",
-                            "system": "Ges.",
-                            "position": "1. Note <br /> 2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "43",
-                            "system": "Klav. u.",
-                            "position": "1.–2. Note",
-                            "comment": "Auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 15: h–b<sup>1</sup>."
-                        },
-                        {
-                            "measure": "46 <br /> bis 49",
-                            "system": "Ges.",
-                            "position": "1. Note <br /> 2. Note",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "48 <br /> bis 49",
-                            "system": "Ges.",
-                            "position": "2. Note <br /> 2. Note",
-                            "comment": "Drecrescendogabel auf Rasur."
-                        },
-                        {
-                            "measure": "48 <br /> bis 49",
-                            "system": "Klav.",
-                            "position": "2/4 <br /> 2/4",
-                            "comment": "Drecrescendogabel auf Rasur."
-                        },
-                        {
-                            "measure": "50 <br /> bis 51",
-                            "system": "Ges.",
-                            "position": "1. Note",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "51",
-                            "system": "",
-                            "position": "2/4",
-                            "comment": "<em>tempo</em> auf Rasur (ab Taktanfang)."
-                        },
-                        {
-                            "measure": "51",
-                            "system": "Klav. u.",
-                            "position": "2/4",
-                            "comment": "Auf Rasur."
-                        },
-                        {
-                            "measure": "55",
-                            "system": "Klav. o.",
-                            "position": "vor 2/4",
-                            "comment": "Rasur. Siehe <strong>M 321 Sk8</strong> T. 19B vor 2/8: Vorschlagsnote e<sup>1</sup>."
-                        },
-                        {
-                            "measure": "56",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "Rasur über der Akkolade. Ante correcturam: Tempoangabe?"
-                        },
-                        {
-                            "measure": "56",
-                            "system": "Ges.",
-                            "position": "2/4",
-                            "comment": "{{ref.getGlyph('[ff]')}} auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 19B 1. Note: {{ref.getGlyph('[f]')}}."
-                        },
-                        {
-                            "measure": "57",
-                            "system": "",
-                            "position": "",
-                            "comment": "Rasur über der Akkolade. Ante correcturam: Tempoangabe?"
-                        },
-                        {
-                            "measure": "57",
-                            "system": "Klav.",
-                            "position": "",
-                            "comment": "Auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 19B 2. TH."
-                        },
-                        {
-                            "measure": "58 <br /> bis 60",
-                            "system": "Ges.",
-                            "position": "2/4 <br /> 2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "61",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>wieder viel mäßiger</em> auf Rasur (bis Ende T.63)."
-                        },
-                        {
-                            "measure": "61 <br /> bis 63",
-                            "system": "Ges.",
-                            "position": "2/4 <br /> 2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "62 <br /> bis 63",
-                            "system": "Klav. u.",
-                            "position": "2/4 <br /> 2/4",
-                            "comment": "Bogen rasiert. Staccatopunkte möglicherweise nach Rasur hinzugefügt."
-                        },
-                        {
-                            "measure": "63 <br /> bis 64",
-                            "system": "Klav. o.",
-                            "position": "1/4 <br /> 1/4",
-                            "comment": "Bogen rasiert. Staccatopunkte möglicherweise nach Rasur hinzugefügt."
-                        },
-                        {
-                            "measure": "65 <br /> bis 68",
-                            "system": "Ges.",
-                            "position": "2/4 <br /> 1/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "67",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit. - - -</em> auf Rasur."
-                        },
-                        {
-                            "measure": "67–68",
-                            "system": "Klav.",
-                            "position": "",
-                            "comment": "Auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 23B."
-                        },
-                        {
-                            "measure": "69",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "Geltungsstrichelung auf Rasur (bis <em>tempo</em>)."
-                        },
-                        {
-                            "measure": "69 <br /> bis 74",
-                            "system": "Ges.",
-                            "position": "2/4 <br /> 2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "71 <br /> bis 73",
-                            "system": "Klav.",
-                            "position": "1/4",
-                            "comment": "Auf Rasur."
-                        },
-                        {
-                            "measure": "73",
-                            "system": "",
-                            "position": "Taktanfang",
-                            "comment": "<em>rit. - - -</em> auf Rasur (bis Taktende)."
-                        },
-                        {
-                            "measure": "74 <br /> bis 75",
-                            "system": "Klav.",
-                            "position": "1/4 <br /> 1/4",
-                            "comment": "Bogen rasiert. Bogen T. 74 1–2/4 auf Rasur."
-                        },
-                        {
-                            "measure": "75 <br /> bis 76",
-                            "system": "Ges.",
-                            "position": "2/4",
-                            "comment": "Bogen rasiert."
-                        },
-                        {
-                            "measure": "76",
-                            "system": "Ges.",
-                            "position": "",
-                            "comment": "&lt; &gt; auf Rasur."
-                        },
-                        {
-                            "measure": "76",
-                            "system": "",
-                            "position": "2/4",
-                            "comment": "<em>tempo I.</em> [...] auf Rasur (ab Taktanfang)."
-                        },
-                        {
-                            "measure": "nach 78",
-                            "system": "",
-                            "position": "",
-                            "comment": "Bleistifteintragung <em>2’</em> nach dem Schlusstaktstrich radiert."
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+                    {
+                        "id": "source_E_corr1",
+                        "label": "Korrekturen 1 in <strong>E</strong>",
+                        "description": [
+                            "Die Beschreibung der Korrekturen bezieht sich auf „Wie bin ich froh“ M 317: Textfassung 1."
+                        ],
+                        "comments": [
+                            {
+                                "blockHeader": "",
+                                "blockComments": [
+                                    {
+                                        "measure": "1",
+                                        "system": "",
+                                        "position": "(5/8)",
+                                        "comment": "Geltungsstrichelung von <em>rit.</em> auf Rasur. Ante correcturam: <em>rit.</em> vermutlich versetzt von T. 1 5/8. Siehe TkA zu 4/8."
+                                    },
+                                    {
+                                        "measure": "10",
+                                        "system": "",
+                                        "position": "(3/4)",
+                                        "comment": "Geltungsstrichelung von <em>rit.</em> auf Rasur. Ante correcturam: <em>rit.</em> vermutlich versetzt von T. 10 3/4 zu Taktanfang."
+                                    },
+                                    {
+                                        "measure": "11 <br /> bis 12",
+                                        "system": "",
+                                        "position": "(4/4)",
+                                        "comment": "T. 11 4/4 wurde zum Teil auf handgezogenen Systemen am Akkoladenende ergänzt; am vom Systemanfang nach rechts verschobenen Akkoladenanfang vor T. 12 steht eine großflächige Rasur; weitere Rasuren in T. 12 Ges.; radierter Taktstrich nach T. 12 2/8. Ante correcturam: vermutlich eine dreitaktige Variante (T. [11–13]) mit Taktstrichen nach T. 11 6/8 (vor T. [12]) und nach T. 12 2/8 (vor T. [13]). Siehe <a (click)=\"ref.selectSvgSheet({complexId: 'op25', sheetId: 'M_317_Sk4d'})\"><strong>M 317 Sk4</strong> T. 13–15</a>."
+                                    },
+                                    {
+                                        "measure": "12",
+                                        "system": "Klav. u.",
+                                        "position": "2.–5. Note",
+                                        "comment": "Auf Rasur. Ante correcturam: Tonhöhen vermutlich im Violinschlüssel notiert. Siehe <a (click)=\"ref.selectSvgSheet({complexId: 'op25', sheetId: 'M_317_Sk4d'})\"><strong>M 317 Sk4</strong> T. 13–15</a>."
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "id": "source_E_corr2",
+                        "label": "Korrekturen 2 in <strong>E</strong>",
+                        "description": [
+                            "Die Beschreibung der Korrekturen bezieht sich auf die Textfassungen der Werkedition von <em>Drei Lieder nach Gedichten von Hildegard Jone</em> op. 25."
+                        ],
+                        "comments": [
+                            {
+                                "blockHeader": "I „Wie bin ich froh“ M 317",
+                                "blockComments": [
+                                    {
+                                        "measure": "1",
+                                        "system": "Klav.",
+                                        "position": "5–6/8",
+                                        "comment": "Auf Rasur. Ante correcturam: Aufteilung der Noten auf die Systeme vermutlich wie in Textfassung 1."
+                                    },
+                                    {
+                                        "measure": "2",
+                                        "system": "Ges.",
+                                        "position": "2.–3. Note",
+                                        "comment": "Bogen rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "3",
+                                        "system": "Ges.",
+                                        "position": "1.–3. Note",
+                                        "comment": "Bogen rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "3",
+                                        "system": "Ges.",
+                                        "position": "5–6/8",
+                                        "comment": "Tenutostriche rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "vor 4",
+                                        "system": "Klav. u.",
+                                        "position": "",
+                                        "comment": "Violinschlüssel versetzt von T. 4 vor 1. Note (dort Rasur; siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "4",
+                                        "system": "Ges.",
+                                        "position": "1.–3. Note",
+                                        "comment": "Bogen rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "4",
+                                        "system": "Ges.",
+                                        "position": "8/8",
+                                        "comment": "Tenutostrich rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "5",
+                                        "system": "Ges.",
+                                        "position": "1.–3. Note",
+                                        "comment": "Bogen rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "5 <br /> bis 6",
+                                        "system": "Klav.",
+                                        "position": "5/8 <br /> 1/8",
+                                        "comment": "Auf Rasur. Ante correcturam: Aufteilung der Noten auf die Systeme vermutlich wie in Textfassung 1."
+                                    },
+                                    {
+                                        "measure": "6",
+                                        "system": "Klav.",
+                                        "position": "2. Note",
+                                        "comment": "Bleistiftskizzen über und unter der Akkolade (System 5 und 9) rasiert."
+                                    },
+                                    {
+                                        "measure": "6 <br /> bis 7",
+                                        "system": "Ges.",
+                                        "position": "2. Note <br /> 2/8",
+                                        "comment": "Bogen rasiert (siehe Textfassung 1). Möglicherweise steht der Silbenbogen in T. 7 1–2/8 im Zusammenhang mit dieser Korrektur."
+                                    },
+                                    {
+                                        "measure": "7",
+                                        "system": "Ges.",
+                                        "position": "4–6/8",
+                                        "comment": "Bogen rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "8",
+                                        "system": "Klav. u.",
+                                        "position": "nach 3/8",
+                                        "comment": "Violinschlüssel versetzt von vor 2. Note (dort Rasur; siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "8",
+                                        "system": "Ges.",
+                                        "position": "1.–4. Note",
+                                        "comment": "Bogen rasiert (siehe Textfassung 1). Möglicherweise steht der Silbenbogen in T. 8 3.–4. Note im Zusammenhang mit dieser Korrektur."
+                                    },
+                                    {
+                                        "measure": "8",
+                                        "system": "Ges.",
+                                        "position": "5.–6. Note",
+                                        "comment": "Tenutostriche rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "9",
+                                        "system": "Ges.",
+                                        "position": "3.–5. Note",
+                                        "comment": "Tenutostriche rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "9 <br /> bis 10",
+                                        "system": "Ges.",
+                                        "position": "8/8 <br /> 2/8",
+                                        "comment": "Bogen rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "10",
+                                        "system": "Ges.",
+                                        "position": "3.–5. Note",
+                                        "comment": "Bogen rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "11",
+                                        "system": "Ges.",
+                                        "position": "6/8",
+                                        "comment": "Tenutostrich rasiert (siehe Textfassung 1)."
+                                    },
+                                    {
+                                        "measure": "12",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>tempo I.</em> ersetzt <em>wieder tempo I.</em> auf Rasur (siehe Textfassung 1)."
+                                    }
+                                ]
+                            },
+                            {
+                                "blockHeader": "II „Des Herzens Purpurvogel“ M 322",
+                                "blockComments": [
+                                    {
+                                        "measure": "1",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "Metronomangabe auf Rasur."
+                                    },
+                                    {
+                                        "measure": "2",
+                                        "system": "Klav. u.",
+                                        "position": "1/16",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "3",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit.</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "3 <br /> bis 6",
+                                        "system": "Ges.",
+                                        "position": "6/16 <br /> 3/8",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "6",
+                                        "system": "Klav. u.",
+                                        "position": "1–2/8",
+                                        "comment": "Auf Rasur. Ante correcturam: Hals- und Bogenausrichtung umgekehrt?"
+                                    },
+                                    {
+                                        "measure": "7 <br /> bis 8",
+                                        "system": "Ges.",
+                                        "position": "2/8 <br /> 2/8",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "9",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit.</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "10",
+                                        "system": "Klav. u.",
+                                        "position": "1/16",
+                                        "comment": "{{ref.getGlyph('[f]')}} auf Rasur."
+                                    },
+                                    {
+                                        "measure": "10",
+                                        "system": "",
+                                        "position": "4/16",
+                                        "comment": "<em>rit.</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "10 <br /> bis 11",
+                                        "system": "Ges.",
+                                        "position": "6/16 <br /> 3/8",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "11",
+                                        "system": "Klav.",
+                                        "position": "2–6/16",
+                                        "comment": "Auf Rasur. Bleistiftskizzen über und unter dem Klav.-System (System 4 und 7) radiert."
+                                    },
+                                    {
+                                        "measure": "12",
+                                        "system": "Ges.",
+                                        "position": "2–3/8",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "13",
+                                        "system": "Klav.",
+                                        "position": "",
+                                        "comment": "Crescendo- und Decrescendogabel auf Rasur."
+                                    },
+                                    {
+                                        "measure": "13 <br /> bis 14",
+                                        "system": "Ges.",
+                                        "position": "2/8 <br /> 6/16",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "15",
+                                        "system": "Ges.",
+                                        "position": "1.–2. Note",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "15",
+                                        "system": "Klav.",
+                                        "position": "1–5/16",
+                                        "comment": "Rasur zwischen den Systemen. Ante correcturam: Gabel?"
+                                    },
+                                    {
+                                        "measure": "16",
+                                        "system": "Ges.",
+                                        "position": "1.–2. Note",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "16 <br /> bis 17",
+                                        "system": "Ges.",
+                                        "position": "3/8 <br /> 6/16",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "16",
+                                        "system": "Klav. u.",
+                                        "position": "3/8",
+                                        "comment": "{{ref.getGlyph('[f]')}} auf Rasur."
+                                    },
+                                    {
+                                        "measure": "16 <br /> bis 17",
+                                        "system": "Klav. u.",
+                                        "position": "3/8 <br /> 1/16",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "18 <br /> bis 19",
+                                        "system": "Ges.",
+                                        "position": "2/16 <br /> 2. Note",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "19",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit.</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "20",
+                                        "system": "Ges.",
+                                        "position": "1.–2. Note",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "21",
+                                        "system": "Klav. o.",
+                                        "position": "1/16",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "21",
+                                        "system": "Klav. u.",
+                                        "position": "2/16",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "23–24",
+                                        "system": "",
+                                        "position": "",
+                                        "comment": "<em>rit. - - - tempo</em> auf Rasur (bis Ende T. 24)."
+                                    },
+                                    {
+                                        "measure": "23",
+                                        "system": "Ges.",
+                                        "position": "2/16–2/8",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "23 <br /> bis 24",
+                                        "system": "Ges.",
+                                        "position": "3/8 <br /> 1. Note",
+                                        "comment": "Anfang der Decrescendogabel auf Rasur. Ante correcturam: Ausdehnung der Gabel von T. 23 2/8 bis Taktende?"
+                                    },
+                                    {
+                                        "measure": "23 <br /> bis 24",
+                                        "system": "Klav. o.",
+                                        "position": "6/16 <br /> 1/16",
+                                        "comment": "Auf Rasur. Ante correcturam: ges<sup>1</sup>? (Siehe <strong>M 322 Sk4</strong> T. 12.)"
+                                    },
+                                    {
+                                        "measure": "24",
+                                        "system": "Klav. u.",
+                                        "position": "2/8",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "25 <br /> bis 26",
+                                        "system": "Ges.",
+                                        "position": "1. Note <br /> 3/8",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "26",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit.</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "27",
+                                        "system": "Klav.",
+                                        "position": "2.–3. Note",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "27 <br /> bis 28",
+                                        "system": "Ges.",
+                                        "position": "4/16 <br /> 2/16",
+                                        "comment": "Bogen rasiert. Crescendo- (T. 27 3/8) und Decrescendogabel auf Rasur."
+                                    },
+                                    {
+                                        "measure": "27 <br /> bis 28",
+                                        "system": "Klav.",
+                                        "position": "6/16 <br /> 2/16",
+                                        "comment": "Bogen auf Rasur."
+                                    },
+                                    {
+                                        "measure": "29",
+                                        "system": "Ges.",
+                                        "position": "2–3/16",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "29 <br /> bis 30",
+                                        "system": "Ges.",
+                                        "position": "4/16 <br /> 4/16",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "30",
+                                        "system": "",
+                                        "position": "6/16",
+                                        "comment": "<em>tempo</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "30 <br /> bis 31",
+                                        "system": "Ges.",
+                                        "position": "6/16 <br /> 3/16",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "31",
+                                        "system": "",
+                                        "position": "2/16",
+                                        "comment": "<em>rit.</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "32",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "Geltungsstrichelung von<em> rit</em>. (T. 31) auf Rasur."
+                                    },
+                                    {
+                                        "measure": "33",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>langsamer</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "33",
+                                        "system": "Ges.",
+                                        "position": "1.–2. Note",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "33",
+                                        "system": "Ges.",
+                                        "position": "5–6/16",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "34",
+                                        "system": "Klav.",
+                                        "position": "2–4/16",
+                                        "comment": "Bogen rasiert. Staccatopunkt zu 4/16 auf Rasur."
+                                    },
+                                    {
+                                        "measure": "34",
+                                        "system": "Ges.",
+                                        "position": "4/16–3/8",
+                                        "comment": "Bogen rasiert. Tenutostrich zu 3/8 auf Rasur."
+                                    },
+                                    {
+                                        "measure": "35",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit.</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "35",
+                                        "system": "Ges.",
+                                        "position": "2–4/16",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "36",
+                                        "system": "Klav.",
+                                        "position": "2–4/16",
+                                        "comment": "{{ref.getGlyph('[pp]')}} und Decrescendogabel auf Rasur."
+                                    },
+                                    {
+                                        "measure": "37",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit.</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "37",
+                                        "system": "Ges.",
+                                        "position": "1.–2. Note",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "37",
+                                        "system": "Klav.",
+                                        "position": "2/16",
+                                        "comment": "{{ref.getGlyph('[pp]')}} auf Rasur."
+                                    },
+                                    {
+                                        "measure": "38",
+                                        "system": "",
+                                        "position": "3/16",
+                                        "comment": "<em>immer langsamer</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "38",
+                                        "system": "Klav. o.",
+                                        "position": "3/8",
+                                        "comment": "{{ref.getGlyph('[p]')}} auf Rasur."
+                                    },
+                                    {
+                                        "measure": "39",
+                                        "system": "Ges.",
+                                        "position": "1.–3. Note",
+                                        "comment": "Bogen rasiert. Tenutostrich zu 3/8 auf Rasur."
+                                    },
+                                    {
+                                        "measure": "39",
+                                        "system": "Klav. u.",
+                                        "position": "2/8–6/16",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "40",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "Rasur über Akkolade. Ante correcturam: Tempoangabe?"
+                                    },
+                                    {
+                                        "measure": "40",
+                                        "system": "Ges.",
+                                        "position": "2–5/16",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "40",
+                                        "system": "Klav.",
+                                        "position": "4–6/16",
+                                        "comment": "{{ref.getGlyph('[pp]')}} und Decrescendogabel auf Rasur."
+                                    },
+                                    {
+                                        "measure": "41",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>verlöschend</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "41",
+                                        "system": "Ges.",
+                                        "position": "1.–3. Note",
+                                        "comment": "Bogen rasiert. Silbenbogen 2.–3. Note auf Rasur. <br /> {{ref.getGlyph('[pp]')}}, Decrescendogabel (?) rasiert."
+                                    },
+                                    {
+                                        "measure": "nach 42",
+                                        "system": "",
+                                        "position": "",
+                                        "comment": "Bleistiftnotiz nach Schlusstaktstrich radiert."
+                                    }
+                                ]
+                            },
+                            {
+                                "blockHeader": "III „Sterne, ihr silbernen Bienen“ M 321",
+                                "blockComments": [
+                                    {
+                                        "measure": "4–6",
+                                        "system": "Ges.",
+                                        "position": "",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "8",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit.</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "9 <br /> bis 14",
+                                        "system": "Ges.",
+                                        "position": "2/4 <br /> 2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "13",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit.</em> auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 5: <em>calando</em>."
+                                    },
+                                    {
+                                        "measure": "13 <br /> bis 14",
+                                        "system": "Klav.",
+                                        "position": "2/4 <br /> 2/4",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "15 <br /> bis 16",
+                                        "system": "Ges.",
+                                        "position": "2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "15–21",
+                                        "system": "Klav.",
+                                        "position": "",
+                                        "comment": "Teilweise auf Rasur. Ante correcturam: alternative Aufteilung der Noten auf die Systeme?"
+                                    },
+                                    {
+                                        "measure": "17",
+                                        "system": "",
+                                        "position": "",
+                                        "comment": "Geltungstrichelung von <em>rit.</em> (T. 13) und <em>viel mäßiger</em> (2/4) auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 6 2. TH: <em>tempo</em>."
+                                    },
+                                    {
+                                        "measure": "17 <br /> bis 20",
+                                        "system": "Ges.",
+                                        "position": "2/4 <br /> 2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "19",
+                                        "system": "Klav. u.",
+                                        "position": "",
+                                        "comment": "Bleistifteintragung (Text) radiert."
+                                    },
+                                    {
+                                        "measure": "20",
+                                        "system": "",
+                                        "position": "",
+                                        "comment": "Rasur über der Akkolade. Ante correcturam: Tempoangabe?"
+                                    },
+                                    {
+                                        "measure": "21",
+                                        "system": "Ges.",
+                                        "position": "1/4",
+                                        "comment": "Viertelpause ersetzt Viertelnote e<sup>2</sup> mit Ligaturbogen von T. 20 2/4 auf Rasur."
+                                    },
+                                    {
+                                        "measure": "22",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit. - - -</em> auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 8A: <em>calando</em>."
+                                    },
+                                    {
+                                        "measure": "22–24",
+                                        "system": "Ges.",
+                                        "position": "",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "26–28",
+                                        "system": "",
+                                        "position": "",
+                                        "comment": "Bleistifteintragung (Text) radiert."
+                                    },
+                                    {
+                                        "measure": "28",
+                                        "system": "",
+                                        "position": "",
+                                        "comment": "Rasur über der Akkolade. Ante correcturam: Tempoangabe?"
+                                    },
+                                    {
+                                        "measure": "29 <br /> bis 31",
+                                        "system": "",
+                                        "position": "Taktanfang <br /> 1/4",
+                                        "comment": "<em>rit.- - -</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "29 <br /> bis 30",
+                                        "system": "Ges.",
+                                        "position": "2/4 <br /> 2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "31",
+                                        "system": "",
+                                        "position": "2/4",
+                                        "comment": "<em>wieder viel mäßiger</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "31 <br /> bis 33",
+                                        "system": "Ges.",
+                                        "position": "2/4 <br /> 1/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "33 <br /> bis 34",
+                                        "system": "Ges.",
+                                        "position": "2/4 <br /> 2. Note",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "34",
+                                        "system": "Klav. o.",
+                                        "position": "1.–2. Note",
+                                        "comment": "Auf Rasur. Bleistiftskizze im System darüber radiert."
+                                    },
+                                    {
+                                        "measure": "35",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit. - - -</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "35",
+                                        "system": "Klav. u.",
+                                        "position": "1/4",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "35 <br /> bis 36",
+                                        "system": "Ges.",
+                                        "position": "2/4 <br /> 2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "37",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>tempo I.</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "37 <br /> bis 38",
+                                        "system": "Ges.",
+                                        "position": "2/4 <br /> 2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "39",
+                                        "system": "",
+                                        "position": "2/4",
+                                        "comment": "<em>rit. - - -</em> auf Rasur (ab Taktanfang)."
+                                    },
+                                    {
+                                        "measure": "39 <br /> bis 41",
+                                        "system": "Ges.",
+                                        "position": "2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "42 <br /> bis 45",
+                                        "system": "Ges.",
+                                        "position": "1. Note <br /> 2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "43",
+                                        "system": "Klav. u.",
+                                        "position": "1.–2. Note",
+                                        "comment": "Auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 15: h–b<sup>1</sup>."
+                                    },
+                                    {
+                                        "measure": "46 <br /> bis 49",
+                                        "system": "Ges.",
+                                        "position": "1. Note <br /> 2. Note",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "48 <br /> bis 49",
+                                        "system": "Ges.",
+                                        "position": "2. Note <br /> 2. Note",
+                                        "comment": "Drecrescendogabel auf Rasur."
+                                    },
+                                    {
+                                        "measure": "48 <br /> bis 49",
+                                        "system": "Klav.",
+                                        "position": "2/4 <br /> 2/4",
+                                        "comment": "Drecrescendogabel auf Rasur."
+                                    },
+                                    {
+                                        "measure": "50 <br /> bis 51",
+                                        "system": "Ges.",
+                                        "position": "1. Note",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "51",
+                                        "system": "",
+                                        "position": "2/4",
+                                        "comment": "<em>tempo</em> auf Rasur (ab Taktanfang)."
+                                    },
+                                    {
+                                        "measure": "51",
+                                        "system": "Klav. u.",
+                                        "position": "2/4",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "55",
+                                        "system": "Klav. o.",
+                                        "position": "vor 2/4",
+                                        "comment": "Rasur. Siehe <strong>M 321 Sk8</strong> T. 19B vor 2/8: Vorschlagsnote e<sup>1</sup>."
+                                    },
+                                    {
+                                        "measure": "56",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "Rasur über der Akkolade. Ante correcturam: Tempoangabe?"
+                                    },
+                                    {
+                                        "measure": "56",
+                                        "system": "Ges.",
+                                        "position": "2/4",
+                                        "comment": "{{ref.getGlyph('[ff]')}} auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 19B 1. Note: {{ref.getGlyph('[f]')}}."
+                                    },
+                                    {
+                                        "measure": "57",
+                                        "system": "",
+                                        "position": "",
+                                        "comment": "Rasur über der Akkolade. Ante correcturam: Tempoangabe?"
+                                    },
+                                    {
+                                        "measure": "57",
+                                        "system": "Klav.",
+                                        "position": "",
+                                        "comment": "Auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 19B 2. TH."
+                                    },
+                                    {
+                                        "measure": "58 <br /> bis 60",
+                                        "system": "Ges.",
+                                        "position": "2/4 <br /> 2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "61",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>wieder viel mäßiger</em> auf Rasur (bis Ende T.63)."
+                                    },
+                                    {
+                                        "measure": "61 <br /> bis 63",
+                                        "system": "Ges.",
+                                        "position": "2/4 <br /> 2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "62 <br /> bis 63",
+                                        "system": "Klav. u.",
+                                        "position": "2/4 <br /> 2/4",
+                                        "comment": "Bogen rasiert. Staccatopunkte möglicherweise nach Rasur hinzugefügt."
+                                    },
+                                    {
+                                        "measure": "63 <br /> bis 64",
+                                        "system": "Klav. o.",
+                                        "position": "1/4 <br /> 1/4",
+                                        "comment": "Bogen rasiert. Staccatopunkte möglicherweise nach Rasur hinzugefügt."
+                                    },
+                                    {
+                                        "measure": "65 <br /> bis 68",
+                                        "system": "Ges.",
+                                        "position": "2/4 <br /> 1/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "67",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit. - - -</em> auf Rasur."
+                                    },
+                                    {
+                                        "measure": "67–68",
+                                        "system": "Klav.",
+                                        "position": "",
+                                        "comment": "Auf Rasur. Siehe <strong>M 321 Sk8</strong> T. 23B."
+                                    },
+                                    {
+                                        "measure": "69",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "Geltungsstrichelung auf Rasur (bis <em>tempo</em>)."
+                                    },
+                                    {
+                                        "measure": "69 <br /> bis 74",
+                                        "system": "Ges.",
+                                        "position": "2/4 <br /> 2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "71 <br /> bis 73",
+                                        "system": "Klav.",
+                                        "position": "1/4",
+                                        "comment": "Auf Rasur."
+                                    },
+                                    {
+                                        "measure": "73",
+                                        "system": "",
+                                        "position": "Taktanfang",
+                                        "comment": "<em>rit. - - -</em> auf Rasur (bis Taktende)."
+                                    },
+                                    {
+                                        "measure": "74 <br /> bis 75",
+                                        "system": "Klav.",
+                                        "position": "1/4 <br /> 1/4",
+                                        "comment": "Bogen rasiert. Bogen T. 74 1–2/4 auf Rasur."
+                                    },
+                                    {
+                                        "measure": "75 <br /> bis 76",
+                                        "system": "Ges.",
+                                        "position": "2/4",
+                                        "comment": "Bogen rasiert."
+                                    },
+                                    {
+                                        "measure": "76",
+                                        "system": "Ges.",
+                                        "position": "",
+                                        "comment": "&lt; &gt; auf Rasur."
+                                    },
+                                    {
+                                        "measure": "76",
+                                        "system": "",
+                                        "position": "2/4",
+                                        "comment": "<em>tempo I.</em> [...] auf Rasur (ab Taktanfang)."
+                                    },
+                                    {
+                                        "measure": "nach 78",
+                                        "system": "",
+                                        "position": "",
+                                        "comment": "Bleistifteintragung <em>2’</em> nach dem Schlusstaktstrich radiert."
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
             }
         },
         {


### PR DESCRIPTION
This PR adjusts the formatting of the recently added corrections.

It also hides the tka table if there are no corrections provided.

In addition, it slightly highlights the blockHeaders in the tka tables to give them some more visual separation functionality.