### PR TITLE
fix(edition): add missing glyphs for note values

### DIFF
--- a/src/app/views/edition-view/data/edition-glyphs.data.ts
+++ b/src/app/views/edition-view/data/edition-glyphs.data.ts
@@ -84,6 +84,51 @@ export const EDITION_GLYPHS_DATA = {
     },
 
     /**
+     * The glyph of a musical eighth note symbol.
+     * Cf. https://graphemica.com/%F0%9D%85%A0
+     */
+    NOTE_EIGHTH: {
+        alt: '[Achtelnote]',
+        hex: '\uD834\uDD60',
+    },
+
+    /**
+     * The glyph of a musical half note symbol.
+     * Cf. https://graphemica.com/%F0%9D%85%9E
+     */
+    NOTE_HALF: {
+        alt: '[Halbe Note]',
+        hex: '\uD834\uDD5E',
+    },
+
+    /**
+     * The glyph of a musical quarter note symbol.
+     * Cf. https://graphemica.com/%F0%9D%85%9F
+     */
+    NOTE_QUARTER: {
+        alt: '[Viertelnote]',
+        hex: '\uD834\uDD5F',
+    },
+
+    /**
+     * The glyph of a musical sixteenth note symbol.
+     * Cf. https://graphemica.com/%F0%9D%85%A1
+     */
+    NOTE_SIXTEENTH: {
+        alt: '[Sechzehntelnote]',
+        hex: '\uD834\uDD61',
+    },
+
+    /**
+     * The glyph of a musical whole note symbol.
+     * Cf. https://graphemica.com/%F0%9D%85%9D
+     */
+    NOTE_WHOLE: {
+        alt: '[Ganze Note]',
+        hex: '\uD834\uDD5D',
+    },
+
+    /**
      * The glyph of a musical mezzo forte symbol.
      * Cf. https://graphemica.com/%F0%9D%86%90
      */

--- a/src/assets/data/edition/series/1/section/5/op3/source-description.json
+++ b/src/assets/data/edition/series/1/section/5/op3/source-description.json
@@ -663,7 +663,7 @@
                                         "measure": "1",
                                         "system": "",
                                         "position": "Taktanfang",
-                                        "comment": "<em>Ganz wenig bewegt (</em>[Achtelnote]<em>)</em> auf Rasur."
+                                        "comment": "<em>Ganz wenig bewegt (</em>{{ref.getGlyph('[Achtelnote]')}}<em>)</em> auf Rasur."
                                     },
                                     {
                                         "measure": "1",
@@ -2733,7 +2733,7 @@
                                         "measure": "1",
                                         "system": "",
                                         "position": "Taktanfang",
-                                        "comment": "<em>Ganz wenig bewegt (</em>[Achtelnote]<em>)</em> hinzugefügt."
+                                        "comment": "<em>Ganz wenig bewegt (</em>{{ref.getGlyph('[Achtelnote]')}}<em>)</em> hinzugefügt."
                                     },
                                     {
                                         "measure": "1",


### PR DESCRIPTION
This PR adds missing glyphs for note values and applies them in the assets where needed.