### PR TITLE
fix(app): make fields only assigned in the constructor readonly

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -373,9 +373,9 @@ describe('AppComponent (DONE)', () => {
             });
         });
 
-        describe('#hasSideOutlet()', () => {
-            it('... should have a method `hasSideOutlet`', () => {
-                expect(component.hasSideOutlet).toBeDefined();
+        describe('#_hasSideOutlet()', () => {
+            it('... should have a method `_hasSideOutlet`', () => {
+                expect((component as any)._hasSideOutlet).toBeDefined();
             });
 
             it('... should return true if route has side outlet', () => {
@@ -384,7 +384,7 @@ describe('AppComponent (DONE)', () => {
                     children: [],
                 } as any;
 
-                expectToBe(component.hasSideOutlet(mockRoute), true);
+                expectToBe((component as any)._hasSideOutlet(mockRoute), true);
             });
 
             it('... should return true if any child route has side outlet', () => {
@@ -398,7 +398,7 @@ describe('AppComponent (DONE)', () => {
                     ],
                 } as any;
 
-                expectToBe(component.hasSideOutlet(mockRoute), true);
+                expectToBe((component as any)._hasSideOutlet(mockRoute), true);
             });
 
             it('... should return false if route has no side outlet', () => {
@@ -412,7 +412,7 @@ describe('AppComponent (DONE)', () => {
                     ],
                 } as any;
 
-                expectToBe(component.hasSideOutlet(mockRoute), false);
+                expectToBe((component as any)._hasSideOutlet(mockRoute), false);
             });
         });
     });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, ActivatedRouteSnapshot, NavigationEnd, Router } from '@angular/router';
 
@@ -27,47 +27,74 @@ export class AppComponent {
     activateSideOutlet = false;
 
     /**
-     * Constructor of the AppComponent.
+     * Private injection variable: _activatedRoute.
      *
-     * It declares private instances of the Angular router and the AnalyticsService.
-     *
-     * @param {ActivatedRoute} activatedRoute Instance of the Angular ActivatedRoute.
-     * @param {AnalyticsService} analyticsService Instance of the AnalyticsService.
-     * @param {NgbConfig} ngbConfig Instance of the NGBootstrap NgbConfig.
-     * @param {Router} router Instance of the Angular router.
-     * @param {Title} titleService Instance of the Angular Title.
+     * It injects the ActivatedRoute.
      */
-    constructor(
-        private readonly activatedRoute: ActivatedRoute,
-        private readonly router: Router,
-        private analyticsService: AnalyticsService,
-        private editionInitService: EditionInitService,
-        ngbConfig: NgbConfig,
-        private titleService: Title
-    ) {
+    private _activatedRoute = inject(ActivatedRoute);
+
+    /**
+     * Private injection variable: _analyticsService.
+     *
+     * It injects the AnalyticsService.
+     */
+    private _analyticsService = inject(AnalyticsService);
+
+    /**
+     * Private injection variable: _editionInitService.
+     *
+     * It injects the EditionInitService.
+     */
+    private _editionInitService = inject(EditionInitService);
+
+    /**
+     * Private injection variable: _ngbConfig.
+     *
+     * It injects the NgbConfig.
+     */
+    private _ngbConfig = inject(NgbConfig);
+
+    /**
+     * Private injection variable: _router.
+     *
+     * It injects the Router.
+     */
+    private _router = inject(Router);
+
+    /**
+     * Private injection variable: _titleService.
+     *
+     * It injects the Angular Title.
+     */
+    private _titleService = inject(Title);
+
+    /**
+     * Constructor of the AppComponent.
+     */
+    constructor() {
         // Disable Bootstrap animation
-        ngbConfig.animation = false;
+        this._ngbConfig.animation = false;
 
         // Get app title from index.html
         // Cf. https://blog.bitsrc.io/dynamic-page-titles-in-angular-98ce20b5c334
-        const appTitle = this.titleService.getTitle();
+        const appTitle = this._titleService.getTitle();
 
         // Init analytics
-        this.analyticsService.initializeAnalytics();
+        this._analyticsService.initializeAnalytics();
 
         // Init edition complexes and outline
-        this.editionInitService.initializeEdition();
+        this._editionInitService.initializeEdition();
 
         // Track router events
-        this.router.events
+        this._router.events
             .pipe(
                 filter(event => event instanceof NavigationEnd),
                 map((event: NavigationEnd) => {
                     // Track page view on every NavigationEnd
-                    this.analyticsService.trackPageView(event.urlAfterRedirects);
+                    this._analyticsService.trackPageView(event.urlAfterRedirects);
 
                     // Get page title from route data
-                    let child = this.activatedRoute.firstChild;
+                    let child = this._activatedRoute.firstChild;
                     while (child.firstChild) {
                         child = child.firstChild;
                     }
@@ -80,17 +107,17 @@ export class AppComponent {
             .subscribe({
                 next: (pageTitle: string) => {
                     // Set page title
-                    this.titleService.setTitle(pageTitle);
+                    this._titleService.setTitle(pageTitle);
 
                     // Activate side outlet
-                    const currentRoute = this.router.routerState.snapshot.root;
-                    this.activateSideOutlet = this.hasSideOutlet(currentRoute);
+                    const currentRoute = this._router.routerState.snapshot.root;
+                    this.activateSideOutlet = this._hasSideOutlet(currentRoute);
                 },
             });
     }
 
     /**
-     * Public method: hasSideOutlet.
+     * Private method: hasSideOutlet.
      *
      * It checks if a route has a side outlet.
      *
@@ -98,12 +125,12 @@ export class AppComponent {
      *
      * @returns {boolean} The result of the check.
      */
-    hasSideOutlet(route: ActivatedRouteSnapshot): boolean {
+    private _hasSideOutlet(route: ActivatedRouteSnapshot): boolean {
         if (route.outlet === 'side') {
             return true;
         }
         for (const child of route.children) {
-            if (this.hasSideOutlet(child)) {
+            if (this._hasSideOutlet(child)) {
                 return true;
             }
         }

--- a/src/app/core/footer/footer.component.ts
+++ b/src/app/core/footer/footer.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 
 import { Logos, MetaPage, MetaSectionTypes } from '@awg-core/core-models';
 import { CoreService } from '@awg-core/services';
@@ -33,14 +33,11 @@ export class FooterComponent implements OnInit {
     pageMetaData: MetaPage;
 
     /**
-     * Constructor of the FooterComponent.
+     * Private injection variable: _coreService.
      *
-     * It declares a private CoreService instance
-     * to get the metadata and logos.
-     *
-     * @param {CoreService} coreService Instance of the CoreService.
+     * It injects the CoreService.
      */
-    constructor(private coreService: CoreService) {}
+    private _coreService = inject(CoreService);
 
     /**
      * Angular life cycle hook: ngOnInit.
@@ -61,7 +58,7 @@ export class FooterComponent implements OnInit {
      * @returns {void} Sets the pageMetaData and logos variables.
      */
     provideMetaData(): void {
-        this.pageMetaData = this.coreService.getMetaDataSection(MetaSectionTypes.page);
-        this.logos = this.coreService.getLogos();
+        this.pageMetaData = this._coreService.getMetaDataSection(MetaSectionTypes.page);
+        this.logos = this._coreService.getLogos();
     }
 }

--- a/src/app/core/interceptors/caching/caching.interceptor.ts
+++ b/src/app/core/interceptors/caching/caching.interceptor.ts
@@ -6,7 +6,7 @@ import {
     HttpRequest,
     HttpResponse,
 } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 
 import { Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
@@ -23,14 +23,11 @@ import { HttpCacheService } from '@awg-core/services';
 @Injectable()
 export class CachingInterceptor implements HttpInterceptor {
     /**
-     * Constructor of the CachingInterceptor.
+     * Private injection variable: _cache.
      *
-     * It declares a private {@link HttpCacheService} instance
-     * to handle the caching of http responses.
-     *
-     * @param {HttpCacheService} cache Instance of the HttpCacheService.
+     * It injects the HttpCacheService.
      */
-    constructor(private cache: HttpCacheService) {}
+    private _cache = inject(HttpCacheService);
 
     /**
      * Public method: intercept.
@@ -49,7 +46,7 @@ export class CachingInterceptor implements HttpInterceptor {
         }
 
         // Check the cache for existing responses
-        const cachedResponse = this.cache.get(req);
+        const cachedResponse = this._cache.get(req);
         if (cachedResponse) {
             // Serve existing cached response
             return observableOf(cachedResponse.clone());
@@ -61,7 +58,7 @@ export class CachingInterceptor implements HttpInterceptor {
                 // Remember, there may be other events besides just the response
                 if (event instanceof HttpResponse) {
                     // Update the cache
-                    this.cache.put(req, event.clone());
+                    this._cache.put(req, event.clone());
                 }
             }),
             catchError(response => {

--- a/src/app/core/interceptors/loading/loading.interceptor.ts
+++ b/src/app/core/interceptors/loading/loading.interceptor.ts
@@ -1,5 +1,5 @@
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs';
 
@@ -22,17 +22,14 @@ export class LoadingInterceptor implements HttpInterceptor {
      *
      * It stores the array of pending requests.
      */
-    private _pendingRequests: HttpRequest<any>[] = [];
+    private readonly _pendingRequests: HttpRequest<any>[] = [];
 
     /**
-     * Constructor of the LoadingInterceptor.
+     * Private injection variable: _loadingService.
      *
-     * It declares a private {@link LoadingService} instance
-     * to handle the loading status.
-     *
-     * @param {LoadingService} loadingService Instance of the LoadingService.
+     * It injects the LoadingService.
      */
-    constructor(private loadingService: LoadingService) {}
+    private _loadingService = inject(LoadingService);
 
     /**
      * Public method: intercept.
@@ -50,7 +47,7 @@ export class LoadingInterceptor implements HttpInterceptor {
         this._pendingRequests.push(req);
 
         // Start loading and update status
-        this.loadingService.updateLoadingStatus(true);
+        this._loadingService.updateLoadingStatus(true);
 
         // Create a new observable to return instead of the original
         return new Observable(observer => {
@@ -105,6 +102,6 @@ export class LoadingInterceptor implements HttpInterceptor {
         }
 
         // Update loading status depending on the pending requests
-        this.loadingService.updateLoadingStatus(this._pendingRequests.length > 0);
+        this._loadingService.updateLoadingStatus(this._pendingRequests.length > 0);
     }
 }

--- a/src/app/core/navbar/navbar.component.html
+++ b/src/app/core/navbar/navbar.component.html
@@ -109,12 +109,6 @@
 
         <!-- right nav links, auto vertical align -->
         <ul class="navbar-nav my-auto">
-            <!-- <li class="nav-item">
-                <a class="nav-link" [routerLink]="['/data']" routerLinkActive="active">
-                    <span class="d-sm-none d-lg-inline">{{ navbarLabels.search }}</span>
-                    <fa-icon [icon]="navbarIcons.search"></fa-icon>
-                </a>
-            </li> -->
             <li class="nav-item">
                 <a class="nav-link" [routerLink]="['/contact']" routerLinkActive="active">
                     <span class="d-sm-none d-lg-inline">{{ navbarLabels.contact }}</span>

--- a/src/app/core/navbar/navbar.component.ts
+++ b/src/app/core/navbar/navbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { faEnvelope, faFileAlt, faHome, faNetworkWired, faSearch } from '@fortawesome/free-solid-svg-icons';
@@ -83,17 +83,18 @@ export class NavbarComponent implements OnInit {
     ];
 
     /**
-     * Constructor of the HeaderComponent.
+     * Private injection variable: _coreService.
      *
-     * It declares private instances of the CoreService and the Angular Router.
-     *
-     * @param {CoreService} coreService Instance of the CoreService.
-     * @param {Router} router Instance of the Angular Router.
+     * It injects the CoreService.
      */
-    constructor(
-        private coreService: CoreService,
-        private router: Router
-    ) {}
+    private _coreService = inject(CoreService);
+
+    /**
+     * Private injection variable: _router.
+     *
+     * It injects the Angular Router.
+     */
+    private _router = inject(Router);
 
     /**
      * Getter variable: editionRouteConstants.
@@ -124,7 +125,7 @@ export class NavbarComponent implements OnInit {
      * @returns {boolean} The boolean value of the check.
      */
     isActiveRoute(route: string): boolean {
-        return this.router.isActive(route, {
+        return this._router.isActive(route, {
             paths: 'subset',
             queryParams: 'subset',
             fragment: 'ignored',
@@ -141,7 +142,7 @@ export class NavbarComponent implements OnInit {
      * @returns {void} Sets the logos variable.
      */
     provideMetaData(): void {
-        this.logos = this.coreService.getLogos();
+        this.logos = this._coreService.getLogos();
     }
 
     /**


### PR DESCRIPTION
This PR is a test to fix a SonarCloud analysis issue stating fields that are only assigned in the constructor should be made read-only.