### PR TITLE
build(app): clean up

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -86,9 +86,9 @@ jobs:
                   flags: unittests
                   env_vars: ${{ matrix.os }},${{ matrix.node-version }}
 
-            - name: Perform SonarCloud Analysis
+            - name: Perform SonarQube scan
               if: matrix.node-version == 22.11 && github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER # perform SonarCloud analysis only for current node version and not with pull requests or forks(token issue)
-              uses: SonarSource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 # v4.0.0
+              uses: SonarSource/sonarqube-scan-action@1b442ee39ac3fa7c2acdd410208dcb2bcfaae6c4 # v4.1.0
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -87,7 +87,7 @@ jobs:
                   env_vars: ${{ matrix.os }},${{ matrix.node-version }}
 
             - name: Perform SonarQube scan
-              if: matrix.node-version == 22.11 && github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER # perform SonarCloud analysis only for current node version and not with pull requests or forks(token issue)
+              if: matrix.node-version == 22.11 && github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER # perform SonarQube scan only for current node version and not with pull requests or forks(token issue)
               uses: SonarSource/sonarqube-scan-action@1b442ee39ac3fa7c2acdd410208dcb2bcfaae6c4 # v4.1.0
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any

--- a/angular.json
+++ b/angular.json
@@ -22,7 +22,7 @@
                             "browser": ""
                         },
                         "index": "src/index.html",
-                        "polyfills": ["src/polyfills.ts"],
+                        "polyfills": ["src/polyfills.ts", "@angular/localize/init"],
                         "tsConfig": "tsconfig.app.json",
                         "inlineStyleLanguage": "scss",
                         "aot": false,
@@ -114,7 +114,7 @@
                     "builder": "@angular-devkit/build-angular:karma",
                     "options": {
                         "main": "src/test.ts",
-                        "polyfills": "src/polyfills.ts",
+                        "polyfills": ["src/polyfills.ts", "@angular/localize/init"],
                         "tsConfig": "tsconfig.spec.json",
                         "karmaConfig": "karma.conf.js",
                         "inlineStyleLanguage": "scss",

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -16,11 +16,6 @@
  */
 
 /***************************************************************************************************
- * Load `$localize` onto the global scope - used if i18n tags appear in Angular templates.
- */
-import '@angular/localize/init';
-
-/***************************************************************************************************
  * BROWSER POLYFILLS
  */
 


### PR DESCRIPTION
This PR replaces the deprecated sonarcloud-github-action with the sonarqube-scan-action and moves the polyfills for localize to the angular.json as recommended.