### PR TITLE
feat(edition): add disclaimer button to WE textcritics

### DIFF
--- a/src/app/shared/disclaimer-workeditions/disclaimer-workeditions.component.html
+++ b/src/app/shared/disclaimer-workeditions/disclaimer-workeditions.component.html
@@ -1,0 +1,3 @@
+<span class="text-danger"
+    ><fa-icon [icon]="faCalendarXmark" [ngbPopover]="disclaimer" popoverTitle="Disclaimer"></fa-icon>
+</span>

--- a/src/app/shared/disclaimer-workeditions/disclaimer-workeditions.component.spec.ts
+++ b/src/app/shared/disclaimer-workeditions/disclaimer-workeditions.component.spec.ts
@@ -1,0 +1,93 @@
+import { DebugElement, NgModule } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { IconDefinition } from '@fortawesome/angular-fontawesome';
+import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
+import { faCalendarXmark } from '@fortawesome/free-solid-svg-icons';
+
+import { NgbConfig, NgbPopoverModule } from '@ng-bootstrap/ng-bootstrap';
+
+import { expectToBe, expectToContain, expectToEqual, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+
+import { DisclaimerWorkeditionsComponent } from './disclaimer-workeditions.component';
+
+describe('DisclaimerWorkeditionsComponent', () => {
+    let component: DisclaimerWorkeditionsComponent;
+    let fixture: ComponentFixture<DisclaimerWorkeditionsComponent>;
+    let compDe: DebugElement;
+
+    let expectedDisclaimer: string;
+    let expectedFaCalendarXmark: IconDefinition;
+
+    // global NgbConfigModule
+    @NgModule({ imports: [NgbPopoverModule], exports: [NgbPopoverModule] })
+    class NgbConfigModule {
+        constructor(config: NgbConfig) {
+            // Set animations to false
+            config.animation = false;
+        }
+    }
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [FontAwesomeTestingModule, NgbConfigModule],
+            declarations: [DisclaimerWorkeditionsComponent],
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(DisclaimerWorkeditionsComponent);
+        component = fixture.componentInstance;
+        compDe = fixture.debugElement;
+
+        // Test data
+        expectedDisclaimer =
+            'Werkeditionen sind aus rechtlichen Gründen frühestens ab 2049 online verfügbar. Bis dahin konsultieren Sie bitte die entsprechende Printausgabe.';
+        expectedFaCalendarXmark = faCalendarXmark;
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    describe('BEFORE initial data binding', () => {
+        it('... should have `disclaimer`', () => {
+            expectToEqual(component.disclaimer, expectedDisclaimer);
+        });
+
+        it('... should have `faCalendarXmark`', () => {
+            expectToEqual(component.faCalendarXmark, expectedFaCalendarXmark);
+        });
+
+        it('... should have correct NgbPopoverConfig', () => {
+            expectToBe(component.config.placement, 'top');
+            expectToBe(component.config.container, 'body');
+            expectToBe(component.config.triggers, 'mouseenter:mouseleave');
+        });
+    });
+
+    describe('AFTER initial data binding', () => {
+        beforeEach(() => {
+            // Trigger initial data binding
+            fixture.detectChanges();
+        });
+
+        describe('VIEW', () => {
+            it('... should contain a text-danger span', () => {
+                const spanDes = getAndExpectDebugElementByCss(compDe, 'span', 1, 1);
+                const spanEl: HTMLSpanElement = spanDes[0].nativeElement;
+
+                expectToContain(spanEl.classList, 'text-danger');
+            });
+
+            it('... should contain a fa-icon with Xmark in text-danger span', () => {
+                const spanDes = getAndExpectDebugElementByCss(compDe, 'span', 1, 1);
+
+                const faIconDes = getAndExpectDebugElementByCss(spanDes[0], 'fa-icon', 1, 1);
+                const faIconIns = faIconDes[0].componentInstance.icon;
+
+                expectToEqual(faIconIns, expectedFaCalendarXmark);
+            });
+        });
+    });
+});

--- a/src/app/shared/disclaimer-workeditions/disclaimer-workeditions.component.ts
+++ b/src/app/shared/disclaimer-workeditions/disclaimer-workeditions.component.ts
@@ -1,0 +1,45 @@
+import { Component } from '@angular/core';
+
+import { faCalendarXmark } from '@fortawesome/free-solid-svg-icons';
+import { NgbPopoverConfig } from '@ng-bootstrap/ng-bootstrap';
+
+/**
+ * The DisclaimerWorkeditions component.
+ *
+ * It contains the disclaimer for work editions.
+ */
+@Component({
+    selector: 'awg-disclaimer-workeditions',
+    templateUrl: './disclaimer-workeditions.component.html',
+    styleUrls: ['./disclaimer-workeditions.component.scss'],
+})
+export class DisclaimerWorkeditionsComponent {
+    /**
+     * Public variable: disclaimer.
+     *
+     *
+     * It keeps the disclaimer for work editions.
+     */
+    disclaimer =
+        'Werkeditionen sind aus rechtlichen Gründen frühestens ab 2049 online verfügbar. Bis dahin konsultieren Sie bitte die entsprechende Printausgabe.';
+
+    /**
+     * Public variable: faCalendarXmark.
+     *
+     * It instantiates fontawesome's faCalendarXmark icon.
+     */
+    faCalendarXmark = faCalendarXmark;
+
+    /**
+     * Constructor of the DisclaimerWorkeditionsComponent.
+     *
+     * It declares an instance of the NgbPopoverConfig.
+     *
+     * @param {NgbPopoverConfig} config Instance of the NgbPopoverConfig.
+     */
+    constructor(public config: NgbPopoverConfig) {
+        config.placement = 'top';
+        config.container = 'body';
+        config.triggers = 'mouseenter:mouseleave';
+    }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -17,6 +17,7 @@ import { CompileHtmlModule } from './compile-html';
 import { AddressComponent } from './address/address.component';
 import { AlertErrorComponent } from './alert-error/alert-error.component';
 import { AlertInfoComponent } from './alert-info/alert-info.component';
+import { DisclaimerWorkeditionsComponent } from './disclaimer-workeditions/disclaimer-workeditions.component';
 import { FullscreenToggleComponent } from './fullscreen-toggle/fullscreen-toggle.component';
 import { HeadingComponent } from './heading/heading.component';
 import { JsonViewerComponent } from './json-viewer/json-viewer.component';
@@ -63,6 +64,7 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
         AddressComponent,
         AlertErrorComponent,
         AlertInfoComponent,
+        DisclaimerWorkeditionsComponent,
         FullscreenToggleComponent,
         HeadingComponent,
         JsonViewerComponent,
@@ -96,6 +98,7 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
         AddressComponent,
         AlertErrorComponent,
         AlertInfoComponent,
+        DisclaimerWorkeditionsComponent,
         FullscreenToggleComponent,
         HeadingComponent,
         JsonViewerComponent,

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.html
@@ -1,6 +1,6 @@
 @if (textcriticsData) {
     <div ngbAccordion>
-        @for (textcritics of textcriticsData.textcritics; track textcritics) {
+        @for (textcritics of textcriticsData.textcritics; track textcritics.id) {
             <div [ngbAccordionItem]="textcritics.id" [collapsed]="true">
                 <div
                     ngbAccordionHeader
@@ -8,12 +8,20 @@
                     <button ngbAccordionToggle class="btn btn-link text-start p-0">
                         <span [compile-html]="textcritics.label" [compile-html-ref]="ref"></span>
                     </button>
-                    <button
-                        type="button"
-                        class="btn btn-sm btn-outline-info"
-                        (click)="selectSvgSheet({ complexId: '', sheetId: textcritics.id })">
-                        Zum edierten Notentext
-                    </button>
+                    <div class="btn-group" role="group" aria-label="Button to sheets">
+                        @if (isWorkEditionId(textcritics.id)) {
+                            <button type="button" class="btn btn-sm btn-outline-info">
+                                <awg-disclaimer-workeditions></awg-disclaimer-workeditions>
+                            </button>
+                        }
+                        <button
+                            type="button"
+                            class="btn btn-sm btn-outline-info"
+                            [disabled]="isWorkEditionId(textcritics.id)"
+                            (click)="selectSvgSheet({ complexId: '', sheetId: textcritics.id })">
+                            Zum edierten Notentext
+                        </button>
+                    </div>
                 </div>
                 <div ngbAccordionCollapse>
                     <div ngbAccordionBody>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.spec.ts
@@ -24,6 +24,9 @@ import { TextcriticalCommentBlock, TextcriticsList } from '@awg-views/edition-vi
 import { TextcriticsListComponent } from './textcritics-list.component';
 
 // Mock components
+@Component({ selector: 'awg-disclaimer-workeditions', template: '' })
+class DisclaimerWorkeditionsStubComponent {}
+
 @Component({ selector: 'awg-edition-tka-description', template: '' })
 class EditionTkaDescriptionStubComponent {
     @Input()
@@ -98,6 +101,7 @@ describe('TextcriticsListComponent (DONE)', () => {
             declarations: [
                 TextcriticsListComponent,
                 CompileHtmlComponent,
+                DisclaimerWorkeditionsStubComponent,
                 EditionTkaDescriptionStubComponent,
                 EditionTkaLabelStubComponent,
                 EditionTkaTableStubComponent,
@@ -172,14 +176,16 @@ describe('TextcriticsListComponent (DONE)', () => {
                 getAndExpectDebugElementByCss(compDe, 'div.accordion', 1, 1);
             });
 
-            it('... should contain two items in div.accordion', () => {
+            it('... should contain as many items in div.accordion as there are textcritics', () => {
+                const totalItems = expectedTextcriticsData.textcritics.length;
                 const accordionDes = getAndExpectDebugElementByCss(compDe, 'div.accordion', 1, 1);
 
-                getAndExpectDebugElementByCss(accordionDes[0], 'div.accordion-item', 2, 2);
+                getAndExpectDebugElementByCss(accordionDes[0], 'div.accordion-item', totalItems, totalItems);
             });
 
             it('... should contain item header with collapsed body', () => {
-                const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', 2, 2);
+                const totalItems = expectedTextcriticsData.textcritics.length;
+                const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', totalItems, totalItems);
 
                 getAndExpectDebugElementByCss(
                     itemDes[0],
@@ -213,8 +219,9 @@ describe('TextcriticsListComponent (DONE)', () => {
                 expectToContain(itemBodyEl2.classList, 'collapse');
             });
 
-            it('... should contain CompileHtmlComponent in first item header button', () => {
-                const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', 2, 2);
+            it('... should contain an item header button with CompileHtmlComponent', () => {
+                const totalItems = expectedTextcriticsData.textcritics.length;
+                const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', totalItems, totalItems);
 
                 itemDes.forEach((itemDe, index) => {
                     const itemHeaderDes = getAndExpectDebugElementByCss(
@@ -227,15 +234,16 @@ describe('TextcriticsListComponent (DONE)', () => {
                     const btnDes = getAndExpectDebugElementByCss(
                         itemHeaderDes[0],
                         'div.accordion-button > button.btn',
-                        2,
-                        2
+                        1,
+                        1
                     );
                     getAndExpectDebugElementByDirective(btnDes[0], CompileHtmlComponent, 1, 1);
                 });
             });
 
-            it('... should display item header buttons', () => {
-                const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', 2, 2);
+            it('... should display item header button', () => {
+                const totalItems = expectedTextcriticsData.textcritics.length;
+                const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', totalItems, totalItems);
 
                 itemDes.forEach((itemDe, index) => {
                     const itemHeaderDes = getAndExpectDebugElementByCss(
@@ -248,27 +256,123 @@ describe('TextcriticsListComponent (DONE)', () => {
                     const btnDes = getAndExpectDebugElementByCss(
                         itemHeaderDes[0],
                         'div.accordion-button > button.btn',
-                        2,
-                        2
+                        1,
+                        1
                     );
-                    const btnEl0: HTMLButtonElement = btnDes[0].nativeElement;
-                    const btnEl1: HTMLButtonElement = btnDes[1].nativeElement;
+                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
-                    const expectedButtonLabel0 = mockDocument.createElement('span');
-                    expectedButtonLabel0.innerHTML = expectedTextcriticsData.textcritics[index].label;
+                    const expectedButtonLabel = mockDocument.createElement('span');
+                    expectedButtonLabel.innerHTML = expectedTextcriticsData.textcritics[index].label;
 
-                    const expectedButtonLabel1 = 'Zum edierten Notentext';
+                    expect(btnEl).toHaveClass('text-start');
+                    expectToBe(btnEl.textContent.trim(), expectedButtonLabel.textContent.trim());
+                });
+            });
 
-                    expect(btnEl0).toHaveClass('text-start');
-                    expectToBe(btnEl0.textContent.trim(), expectedButtonLabel0.textContent.trim());
+            it('... should contain a button group with sheet button', () => {
+                const totalItems = expectedTextcriticsData.textcritics.length;
+                const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', totalItems, totalItems);
 
-                    expect(btnEl1).toHaveClass('btn-outline-info');
-                    expectToBe(btnEl1.textContent.trim(), expectedButtonLabel1);
+                itemDes.forEach((itemDe, index) => {
+                    const itemHeaderDes = getAndExpectDebugElementByCss(
+                        itemDe,
+                        `div#${expectedTextcriticsData.textcritics[index].id} > div.accordion-header`,
+                        1,
+                        1
+                    );
+
+                    const btnGrpDes = getAndExpectDebugElementByCss(
+                        itemHeaderDes[0],
+                        'div.accordion-button > div.btn-group',
+                        1,
+                        1
+                    );
+                    const btnDes = getAndExpectDebugElementByCss(btnGrpDes[0], 'button.btn', 1, 1);
+                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
+
+                    const expectedButtonLabel = 'Zum edierten Notentext';
+
+                    expect(btnEl).toHaveClass('btn-outline-info');
+                    expectToBe(btnEl.disabled, false);
+                    expectToBe(btnEl.textContent.trim(), expectedButtonLabel);
+                });
+            });
+
+            describe('... if textcritics are related to work edition', () => {
+                let textcriticsDataWithWorkEdition: TextcriticsList;
+
+                beforeEach(() => {
+                    textcriticsDataWithWorkEdition = JSON.parse(JSON.stringify(expectedTextcriticsData));
+                    textcriticsDataWithWorkEdition.textcritics[0].id = 'op12_WE';
+                    textcriticsDataWithWorkEdition.textcritics[1].id = 'op25_WE';
+
+                    component.textcriticsData = textcriticsDataWithWorkEdition;
+                    detectChangesOnPush(fixture);
+                });
+
+                it('... should contain another button with DisclaimerWorkeditions component in button group ', () => {
+                    const totalItems = expectedTextcriticsData.textcritics.length;
+                    const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', totalItems, totalItems);
+
+                    itemDes.forEach((itemDe, index) => {
+                        const itemHeaderDes = getAndExpectDebugElementByCss(
+                            itemDe,
+                            `div#${textcriticsDataWithWorkEdition.textcritics[index].id} > div.accordion-header`,
+                            1,
+                            1
+                        );
+
+                        const btnGrpDes = getAndExpectDebugElementByCss(
+                            itemHeaderDes[0],
+                            'div.accordion-button > div.btn-group',
+                            1,
+                            1
+                        );
+                        const btnDes = getAndExpectDebugElementByCss(btnGrpDes[0], 'button.btn', 2, 2);
+                        const btnEl1: HTMLButtonElement = btnDes[1].nativeElement;
+                        const expectedButtonLabel = 'Zum edierten Notentext';
+
+                        getAndExpectDebugElementByDirective(btnDes[0], DisclaimerWorkeditionsStubComponent, 1, 1);
+
+                        expect(btnEl1).toHaveClass('btn-outline-info');
+                        expectToBe(btnEl1.textContent.trim(), expectedButtonLabel);
+                    });
+                });
+
+                it('... should disable sheet button', () => {
+                    const totalItems = expectedTextcriticsData.textcritics.length;
+                    const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', totalItems, totalItems);
+
+                    itemDes.forEach((itemDe, index) => {
+                        const itemHeaderDes = getAndExpectDebugElementByCss(
+                            itemDe,
+                            `div#${textcriticsDataWithWorkEdition.textcritics[index].id} > div.accordion-header`,
+                            1,
+                            1
+                        );
+
+                        const btnGrpDes = getAndExpectDebugElementByCss(
+                            itemHeaderDes[0],
+                            'div.accordion-button > div.btn-group',
+                            1,
+                            1
+                        );
+                        const btnDes = getAndExpectDebugElementByCss(btnGrpDes[0], 'button.btn', 2, 2);
+                        const btnEl1: HTMLButtonElement = btnDes[1].nativeElement;
+                        const expectedButtonLabel = 'Zum edierten Notentext';
+
+                        getAndExpectDebugElementByDirective(btnDes[0], DisclaimerWorkeditionsStubComponent, 1, 1);
+
+                        expect(btnEl1).toHaveClass('btn-outline-info');
+                        expectToBe(btnEl1.disabled, true);
+                        expectToBe(btnEl1.textContent.trim(), expectedButtonLabel);
+                    });
                 });
             });
 
             it('... should toggle first item body on click on first header', () => {
-                const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', 2, 2);
+                const totalItems = expectedTextcriticsData.textcritics.length;
+                const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', totalItems, totalItems);
 
                 const headerDes0 = getAndExpectDebugElementByCss(
                     itemDes[0],
@@ -277,7 +381,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                     1
                 );
 
-                const btnDes = getAndExpectDebugElementByCss(headerDes0[0], 'div.accordion-button > button.btn', 2, 2);
+                const btnDes = getAndExpectDebugElementByCss(headerDes0[0], 'div.accordion-button > button.btn', 1, 1);
                 const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Item body is closed
@@ -326,7 +430,8 @@ describe('TextcriticsListComponent (DONE)', () => {
             });
 
             it('... should toggle second item body on click on second header', () => {
-                const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', 2, 2);
+                const totalItems = expectedTextcriticsData.textcritics.length;
+                const itemDes = getAndExpectDebugElementByCss(compDe, 'div.accordion-item', totalItems, totalItems);
 
                 const headerDes1 = getAndExpectDebugElementByCss(
                     itemDes[1],
@@ -335,7 +440,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                     1
                 );
 
-                const btnDes = getAndExpectDebugElementByCss(headerDes1[0], 'div.accordion-button > button.btn', 2, 2);
+                const btnDes = getAndExpectDebugElementByCss(headerDes1[0], 'div.accordion-button > button.btn', 1, 1);
                 const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Item body is closed
@@ -402,14 +507,14 @@ describe('TextcriticsListComponent (DONE)', () => {
                     const btnDes0 = getAndExpectDebugElementByCss(
                         headerDes0[0],
                         'div.accordion-button > button.btn',
-                        2,
-                        2
+                        1,
+                        1
                     );
                     const btnDes1 = getAndExpectDebugElementByCss(
                         headerDes1[0],
                         'div.accordion-button > button.btn',
-                        2,
-                        2
+                        1,
+                        1
                     );
                     const btnEl0: HTMLButtonElement = btnDes0[0].nativeElement;
                     const btnEl1: HTMLButtonElement = btnDes1[0].nativeElement;
@@ -702,6 +807,44 @@ describe('TextcriticsListComponent (DONE)', () => {
             });
         });
 
+        describe('#isWorkEditionId()', () => {
+            it('... should have a method `isWorkEditionId`', () => {
+                expect(component.isWorkEditionId).toBeDefined();
+            });
+
+            describe('... should return false if', () => {
+                it('... id is undefined', () => {
+                    const result = component.isWorkEditionId(undefined);
+
+                    expect(result).toBeFalse();
+                });
+
+                it('... id is null', () => {
+                    const result = component.isWorkEditionId(null);
+
+                    expect(result).toBeFalse();
+                });
+
+                it('... id is empty string', () => {
+                    const result = component.isWorkEditionId('');
+
+                    expect(result).toBeFalse();
+                });
+
+                it('... id is not a work edition id', () => {
+                    const result = component.isWorkEditionId('test_id');
+
+                    expect(result).toBeFalse();
+                });
+            });
+
+            it('... should return true if id is a work edition id', () => {
+                const result = component.isWorkEditionId('op12_WE');
+
+                expect(result).toBeTrue();
+            });
+        });
+
         describe('#navigateToReportFragment()', () => {
             it('... should have a method `navigateToReportFragment`', () => {
                 expect(component.navigateToReportFragment).toBeDefined();
@@ -717,16 +860,16 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1
                     );
 
-                    const btnDes1 = getAndExpectDebugElementByCss(
+                    const btnDes = getAndExpectDebugElementByCss(
                         headerDes1[0],
                         'div.accordion-button > button.btn',
-                        2,
-                        2
+                        1,
+                        1
                     );
-                    const btnEl1: HTMLButtonElement = btnDes1[0].nativeElement;
+                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl1 as HTMLElement);
+                    click(btnEl as HTMLElement);
                     detectChangesOnPush(fixture);
 
                     const editionTkaDescriptionDes = getAndExpectDebugElementByDirective(
@@ -755,16 +898,16 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1
                     );
 
-                    const btnDes1 = getAndExpectDebugElementByCss(
+                    const btnDes = getAndExpectDebugElementByCss(
                         headerDes1[0],
                         'div.accordion-button > button.btn',
-                        2,
-                        2
+                        1,
+                        1
                     );
-                    const btnEl1: HTMLButtonElement = btnDes1[0].nativeElement;
+                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl1 as HTMLElement);
+                    click(btnEl as HTMLElement);
                     detectChangesOnPush(fixture);
 
                     const editionTkaTableDes = getAndExpectDebugElementByDirective(
@@ -855,16 +998,16 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1
                     );
 
-                    const btnDes1 = getAndExpectDebugElementByCss(
+                    const btnDes = getAndExpectDebugElementByCss(
                         headerDes1[0],
                         'div.accordion-button > button.btn',
-                        2,
-                        2
+                        1,
+                        1
                     );
-                    const btnEl1: HTMLButtonElement = btnDes1[0].nativeElement;
+                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl1 as HTMLElement);
+                    click(btnEl as HTMLElement);
                     detectChangesOnPush(fixture);
 
                     const editionTkaDescriptionDes = getAndExpectDebugElementByDirective(
@@ -891,16 +1034,16 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1
                     );
 
-                    const btnDes1 = getAndExpectDebugElementByCss(
+                    const btnDes = getAndExpectDebugElementByCss(
                         headerDes1[0],
                         'div.accordion-button > button.btn',
-                        2,
-                        2
+                        1,
+                        1
                     );
-                    const btnEl1: HTMLButtonElement = btnDes1[0].nativeElement;
+                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl1 as HTMLElement);
+                    click(btnEl as HTMLElement);
                     detectChangesOnPush(fixture);
 
                     const editionTkaTableDes = getAndExpectDebugElementByDirective(
@@ -960,16 +1103,16 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1
                     );
 
-                    const btnDes1 = getAndExpectDebugElementByCss(
+                    const btnDes = getAndExpectDebugElementByCss(
                         headerDes1[0],
                         'div.accordion-button > button.btn',
-                        2,
-                        2
+                        1,
+                        1
                     );
-                    const btnEl1: HTMLButtonElement = btnDes1[0].nativeElement;
+                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl1 as HTMLElement);
+                    click(btnEl as HTMLElement);
                     detectChangesOnPush(fixture);
 
                     const editionTkaDescriptionDes = getAndExpectDebugElementByDirective(
@@ -997,16 +1140,16 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1
                     );
 
-                    const btnDes1 = getAndExpectDebugElementByCss(
+                    const btnDes = getAndExpectDebugElementByCss(
                         headerDes1[0],
                         'div.accordion-button > button.btn',
-                        2,
-                        2
+                        1,
+                        1
                     );
-                    const btnEl1: HTMLButtonElement = btnDes1[0].nativeElement;
+                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl1 as HTMLElement);
+                    click(btnEl as HTMLElement);
                     detectChangesOnPush(fixture);
 
                     const editionTkaTableDes = getAndExpectDebugElementByDirective(

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.ts
@@ -68,6 +68,21 @@ export class TextcriticsListComponent {
     }
 
     /**
+     * Public method: isWorkEditionId.
+     *
+     * It checks if the given id is a work edition id.
+     *
+     * @param {string} id The given id.
+     * @returns {boolean} The result of the check.
+     */
+    isWorkEditionId(id: string): boolean {
+        if (!id) {
+            return false;
+        }
+        return id.includes('_WE');
+    }
+
+    /**
      * Public method: navigateToReportFragment.
      *
      * It emits the given ids of a selected edition complex and report fragment

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-nav/edition-svg-sheet-nav-item/edition-svg-sheet-nav-item.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-nav/edition-svg-sheet-nav-item/edition-svg-sheet-nav-item.component.html
@@ -1,14 +1,7 @@
 <h6 class="card-title">
     {{ navItemLabel }}:
     @if (navItemLabel === 'Werkeditionen') {
-        <span class="text-danger"
-            >&nbsp;<fa-icon
-                [icon]="faCalendarXmark"
-                [ngbPopover]="disclaimerWorkEditions"
-                popoverTitle="Disclaimer"
-                placement="end"
-                triggers="mouseenter:mouseleave"></fa-icon>
-        </span>
+        <awg-disclaimer-workeditions></awg-disclaimer-workeditions>
     } @else if (!utils.isNotEmptyArray(svgSheets)) {
         <span>---</span>
     }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-nav/edition-svg-sheet-nav-item/edition-svg-sheet-nav-item.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-nav/edition-svg-sheet-nav-item/edition-svg-sheet-nav-item.component.spec.ts
@@ -1,10 +1,6 @@
-import { DebugElement, NgModule } from '@angular/core';
+import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
 import Spy = jasmine.Spy;
-
-import { IconDefinition } from '@fortawesome/angular-fontawesome';
-import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
-import { faCalendarXmark } from '@fortawesome/free-solid-svg-icons';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
@@ -14,13 +10,17 @@ import {
     expectToContain,
     expectToEqual,
     getAndExpectDebugElementByCss,
+    getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
 import { mockEditionData } from '@testing/mock-data';
 
 import { EditionSvgSheet } from '@awg-views/edition-view/models';
 
-import { NgbConfig, NgbPopoverModule } from '@ng-bootstrap/ng-bootstrap';
 import { EditionSvgSheetNavItemComponent } from './edition-svg-sheet-nav-item.component';
+
+// Mock components
+@Component({ selector: 'awg-disclaimer-workeditions', template: '' })
+class DisclaimerWorkeditionsStubComponent {}
 
 describe('EditionSvgSheetNavItemComponent (DONE)', () => {
     let component: EditionSvgSheetNavItemComponent;
@@ -31,8 +31,7 @@ describe('EditionSvgSheetNavItemComponent (DONE)', () => {
     let selectSvgSheetRequestEmitSpy: Spy;
 
     let expectedComplexId: string;
-    let expectedDisclaimerWorkEditions: string;
-    let expectedFaCalendarXmark: IconDefinition;
+
     let expectedNextComplexId: string;
     let expectedNavItemLabel: string;
     let expectedSvgSheets: EditionSvgSheet[];
@@ -43,19 +42,9 @@ describe('EditionSvgSheetNavItemComponent (DONE)', () => {
     let expectedSvgSheetWithPartialA: EditionSvgSheet;
     let expectedNextSvgSheet: EditionSvgSheet;
 
-    // global NgbConfigModule
-    @NgModule({ imports: [NgbPopoverModule], exports: [NgbPopoverModule] })
-    class NgbConfigModule {
-        constructor(config: NgbConfig) {
-            // Set animations to false
-            config.animation = false;
-        }
-    }
-
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            imports: [FontAwesomeTestingModule, NgbConfigModule],
-            declarations: [EditionSvgSheetNavItemComponent],
+            declarations: [EditionSvgSheetNavItemComponent, DisclaimerWorkeditionsStubComponent],
         }).compileComponents();
     }));
 
@@ -65,9 +54,6 @@ describe('EditionSvgSheetNavItemComponent (DONE)', () => {
         compDe = fixture.debugElement;
 
         // Test data
-        expectedDisclaimerWorkEditions =
-            'Werkeditionen sind aus rechtlichen Gründen frühestens ab 2049 online verfügbar. Bis dahin konsultieren Sie bitte die entsprechende Printausgabe.';
-        expectedFaCalendarXmark = faCalendarXmark;
         expectedNavItemLabel = 'Testeditionslabel';
         expectedComplexId = 'testComplex1';
         expectedNextComplexId = 'testComplex2';
@@ -103,14 +89,6 @@ describe('EditionSvgSheetNavItemComponent (DONE)', () => {
 
         it('... should not have selectedSvgSheet', () => {
             expect(component.selectedSvgSheet).toBeUndefined();
-        });
-
-        it('... should have disclaimerWorkEditions', () => {
-            expectToEqual(component.disclaimerWorkEditions, expectedDisclaimerWorkEditions);
-        });
-
-        it('... should have faCalendarXmark', () => {
-            expectToEqual(component.faCalendarXmark, expectedFaCalendarXmark);
         });
 
         describe('VIEW', () => {
@@ -159,20 +137,13 @@ describe('EditionSvgSheetNavItemComponent (DONE)', () => {
                 expectToBe(hEl.textContent.trim(), expectedNavItemLabel + ':');
             });
 
-            it('... should contain an text-danger xMark icon if navItemLabel=`Werkeditionen` ', () => {
+            it('... should contain a DisclaimerWorkeditions component if navItemLabel=`Werkeditionen` ', () => {
                 component.navItemLabel = 'Werkeditionen';
                 detectChangesOnPush(fixture);
 
                 const hDes = getAndExpectDebugElementByCss(compDe, 'h6.card-title', 1, 1);
-                const spanDes = getAndExpectDebugElementByCss(hDes[0], 'span', 1, 1);
-                const spanEl: HTMLSpanElement = spanDes[0].nativeElement;
 
-                expectToContain(spanEl.classList, 'text-danger');
-
-                const faIconDes = getAndExpectDebugElementByCss(spanDes[0], 'fa-icon', 1, 1);
-                const faIconIns = faIconDes[0].componentInstance.icon;
-
-                expectToEqual(faIconIns, expectedFaCalendarXmark);
+                getAndExpectDebugElementByDirective(hDes[0], DisclaimerWorkeditionsStubComponent, 1, 1);
             });
 
             it('... should contain a span in h6.card-title with "---" if svgSheets is empty', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-nav/edition-svg-sheet-nav-item/edition-svg-sheet-nav-item.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-nav/edition-svg-sheet-nav-item/edition-svg-sheet-nav-item.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
-import { faCalendarXmark } from '@fortawesome/free-solid-svg-icons';
 
 import { UtilityService } from '@awg-core/services';
 import { EditionSvgSheet } from '@awg-views/edition-view/models';
@@ -49,22 +48,6 @@ export class EditionSvgSheetNavItemComponent {
      */
     @Output()
     selectSvgSheetRequest: EventEmitter<{ complexId: string; sheetId: string }> = new EventEmitter();
-
-    /**
-     * Public variable: disclaimerWorkEditions.
-     *
-     *
-     * It keeps the disclaimer for work editions.
-     */
-    disclaimerWorkEditions =
-        'Werkeditionen sind aus rechtlichen Gründen frühestens ab 2049 online verfügbar. Bis dahin konsultieren Sie bitte die entsprechende Printausgabe.';
-
-    /**
-     * Public variable: faCalendarXmark.
-     *
-     * It instantiates fontawesome's faCalendarXmark icon.
-     */
-    faCalendarXmark = faCalendarXmark;
 
     /**
      * Constructor of the EditionSvgSheetNavItemComponent.


### PR DESCRIPTION
This PR moves the workedition disclaimer into a separate component to reuse it where needed. It also adds the disclaimer to the tka for work editions.