### PR TITLE
fix(assets): fix empty item links in AWG I/5

### DIFF
--- a/src/assets/data/edition/series/1/section/5/op23/source-description.json
+++ b/src/assets/data/edition/series/1/section/5/op23/source-description.json
@@ -1599,7 +1599,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von <em>Drei Gesänge aus</em> Viae Inviae <em>von Hildegard Jone</em> op. 23",
                         "folios": [
                             {
@@ -1618,7 +1618,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "I „Das dunkle Herz“ M 314: <span class='link-todo'>einzige Textfassung</span>",
                         "folios": [
                             {
@@ -1814,7 +1814,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "II „Es stürzt aus Höhen Frische“ M 313: <span class='link-todo'>einzige Textfassung</span>",
                         "folios": [
                             {
@@ -1933,7 +1933,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "III „Herr Jesus mein“ M 312: <span class='link-todo'>einzige Textfassung</span>",
                         "folios": [
                             {
@@ -2118,7 +2118,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Druck von <em>Drei Gesänge aus</em> Viae Inviae <em>von Hildegard Jone</em> op. 23",
                         "folios": [
                             {
@@ -2132,7 +2132,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "I „Das dunkle Herz“ M 314: <span class='link-todo'>einzige Textfassung</span>",
                         "folios": [
                             {
@@ -2312,7 +2312,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "II „Es stürzt aus Höhen Frische“ M 313: <span class='link-todo'>einzige Textfassung</span>",
                         "folios": [
                             {
@@ -2391,7 +2391,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "III „Herr Jesus mein“ M 312: <span class='link-todo'>einzige Textfassung</span>",
                         "folios": [
                             {

--- a/src/assets/data/edition/series/1/section/5/op3/source-description.json
+++ b/src/assets/data/edition/series/1/section/5/op3/source-description.json
@@ -27,7 +27,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Dies ist ein Lied“ M 133: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_133_TF1'})\">Textfassung 1</a>→<a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_133_TF2'})\">2</a> (<strong>A<sup>a</sup></strong>)",
                         "folios": [
                             {
@@ -83,7 +83,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Im Windesweben“ M 134: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_134_TF1'})\">Textfassung 1</a>→<a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_134_TF2'})\">2</a> (<strong>A<sup>b</sup></strong>)",
                         "folios": [
                             {
@@ -454,7 +454,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Dies ist ein Lied“ M 133: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_133_TF2'})\">Textfassung 2</a>",
                         "folios": [
                             {
@@ -584,7 +584,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Dies ist ein Lied“ M 133: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_133_TF2'})\">Textfassung 2</a>→<span class='link-todo'>3</span>",
                         "folios": [
                             {
@@ -1048,7 +1048,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "",
                         "folios": [
                             {
@@ -1061,7 +1061,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Dies ist ein Lied“ M 133: <span class='link-todo'>Textfassung 4</span> (<strong>E<sup>a</sup></strong>)",
                         "folios": [
                             {
@@ -1117,7 +1117,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Im Windesweben“ M 134: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_134_TF2'})\">Textfassung 2</a> (<strong>E<sup>b</sup></strong>)",
                         "folios": [
                             {
@@ -1179,7 +1179,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „An Bachesranft“ M 135: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_135_TF1'})\">Textfassung 1</a> (<strong>E<sup>c</sup></strong>)",
                         "folios": [
                             {
@@ -1249,7 +1249,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "nicht identifizierte Skizze (violetter Buntstift)",
                         "folios": [
                             {
@@ -1270,7 +1270,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Im Morgentaun“ M 136: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_136_TF1'})\">Textfassung 1</a> (<strong>E<sup>d</sup></strong>)",
                         "folios": [
                             {
@@ -1340,7 +1340,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Kahl reckt der Baum“ M 137: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_137_TF1'})\">Textfassung 1</a>→<a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_137_TF2'})\">2</a> (<strong>E<sup>e</sup></strong>)",
                         "folios": [
                             {
@@ -1417,7 +1417,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "[<em>Sieben Lieder nach Gedichten von Stefan George op. 2</em> (siehe Einleitung)]",
                         "folios": [
                             {
@@ -2535,7 +2535,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Abschrift fremder Hand von „Dies ist ein Lied“ M 133: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_133_TF2'})\">Textfassung 2</a>→<a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_133_TF1'})\">3</a>→<span class='link-todo'>4</span> (<strong>F<sup>a</sup></strong>)",
                         "folios": [
                             {
@@ -2604,7 +2604,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Abschrift fremder Hand von „Im Windesweben“ M 134: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_134_TF2'})\">Textfassung 2</a> (<strong>F<sup>b</sup></strong>)",
                         "folios": [
                             {
@@ -2666,7 +2666,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Abschrift fremder Hand von „Kahl reckt der Baum“ M 137: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_137_TF1'})\">Textfassung 1</a> (<strong>F<sup>c</sup></strong>)",
                         "folios": [
                             {
@@ -3969,7 +3969,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Im Windesweben“ M 134: <span class='link-todo'>Textfassung 3</span> (<strong>G<sup>a</sup></strong>)",
                         "folios": [
                             {
@@ -4025,7 +4025,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Kahl reckt der Baum“ M 137: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_137_TF2'})\">Textfassung 2</a>→<a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_137_TF3'})\">3</a> (<strong>G<sup>c</sup></strong>)",
                         "folios": [
                             {
@@ -4081,7 +4081,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Im Morgentaun“ M 136: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_136_TF1'})\">Textfassung 1</a>→<a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_136_TF2'})\">2</a> (<strong>G<sup>b</sup></strong>)",
                         "folios": [
                             {
@@ -4165,7 +4165,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von <em>Eingang</em> („Welt der Gestalten“) M 138 aus <em>Fünf Lieder nach Gedichten von Stefan George</em> op. 4",
                         "folios": [
                             {
@@ -4615,7 +4615,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „An Bachesranft“ M 135: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_135_TF2'})\">Textfassung 2</a>",
                         "folios": [
                             {
@@ -4892,7 +4892,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Im Morgentaun“ M 136: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_136_TF2'})\">Textfassung 2</a>",
                         "folios": [
                             {
@@ -5183,7 +5183,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Kahl reckt der Baum“ M 137: <a (click)=\"ref.selectSvgSheet({complexId: 'op3', sheetId: 'M_137_TF4'})\">Textfassung 4</a>",
                         "folios": [
                             {
@@ -5311,7 +5311,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Druck der <em>Fünf Lieder aus</em> Der siebente Ring <em>von Stefan George</em> op. 3",
                         "folios": [
                             {
@@ -5325,7 +5325,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "I „Dies ist ein Lied“ M 133: <span class='link-todo'>Textfassung 4</span>",
                         "folios": [
                             {
@@ -5368,7 +5368,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "II „Im Windesweben“ M 134: <span class='link-todo'>Textfassung 3</span>",
                         "folios": [
                             {
@@ -5433,7 +5433,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "III „An Bachesranft“ M 135: <span class='link-todo'>Textfassung 3</span>",
                         "folios": [
                             {
@@ -5476,7 +5476,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "IV „Im Morgentaun“ M 136: <span class='link-todo'>Textfassung 3</span>",
                         "folios": [
                             {
@@ -5519,7 +5519,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "V „Kahl reckt der Baum“ M 137: <span class='link-todo'>Textfassung 5</span>",
                         "folios": [
                             {

--- a/src/assets/data/edition/series/1/section/5/op4/source-description.json
+++ b/src/assets/data/edition/series/1/section/5/op4/source-description.json
@@ -33,7 +33,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autographe von „Im Windesweben“ M 134, „Im Morgentaun“ M 136 und „Kahl reckt der Baum“ M 137 aus <em>Fünf Lieder aus</em> Der siebente Ring <em>von Stefan George</em> op. 3",
                         "folios": [
                             {
@@ -46,7 +46,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von <em>Eingang</em> („Welt der Gestalten“) M 138: <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_138_TF1'})\">Textfassung 1</a>→<a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_138_TF2'})\">2</a>",
                         "folios": [
                             {
@@ -585,7 +585,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Noch zwingt mich Treue“ M 139: <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_139_TF1'})\">Textfassung 1</a>→<a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_139_TF2'})\">2</a> (<strong>B<sup>a</sup></strong>)",
                         "folios": [
                             {
@@ -702,7 +702,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „Ja Heil und Dank dir“ M 140: <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_140_TF1'})\">Textfassung 1</a>→<span class='link-todo'>2</span> (<strong>B<sup>b</sup></strong>)",
                         "folios": [
                             {
@@ -820,7 +820,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Autograph von „So ich traurig bin“ M 141: <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_141_TF1'})\">Textfassung 1</a> (<strong>B<sup>c</sup></strong>)",
                         "folios": [
                             {
@@ -1441,7 +1441,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Abschrift fremder Hand von <em>Eingang</em> („Welt der Gestalten“) M 138: <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_138_TF1'})\">Textfassung 1</a> (<strong>D<sup>a</sup></strong>)",
                         "folios": [
                             {
@@ -1580,7 +1580,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Abschrift fremder Hand von „Noch zwingt mich Treue“ M 139: <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_139_TF1'})\">Textfassung 1</a> (<strong>D<sup>b</sup></strong>)",
                         "folios": [
                             {
@@ -2300,7 +2300,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Druck von „Ihr tratet zu dem Herde“ M 142: <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_142_TF1'})\">Textfassung 1</a>",
                         "folios": [
                             {
@@ -4677,7 +4677,7 @@
                 "contents": [
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "Druck von <em>Fünf Lieder nach Gedichten von Stefan George</em> op. 4",
                         "folios": [
                             {
@@ -4691,7 +4691,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "I <em>Eingang</em> („Welt der Gestalten“) M 138: <span class='link-todo'>Textfassung 3</span>",
                         "folios": [
                             {
@@ -4785,7 +4785,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "II „Noch zwingt mich Treue“ M 139: <span class='link-todo'>Textfassung 3</span>",
                         "folios": [
                             {
@@ -4857,7 +4857,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "III „Ja Heil und Dank dir“ M 140: <span class='link-todo'>Textfassung 2</span>",
                         "folios": [
                             {
@@ -4929,7 +4929,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "IV „So ich traurig bin“ M 141: <span class='link-todo'>Textfassung 2</span>",
                         "folios": [
                             {
@@ -4972,7 +4972,7 @@
                     },
                     {
                         "item": "",
-                        "itemLinkTo": "",
+                        "itemLinkTo": {},
                         "itemDescription": "V „Ihr tratet zu dem Herde“ M 142: <span class='link-todo'>Textfassung 3</span>",
                         "folios": [
                             {


### PR DESCRIPTION
This PR fixes some wrong syntax for empty item links that was overlooked in AWG I/5.