### PR TITLE
fix(assets): fix folio overview for m34-41

### DIFF
--- a/src/assets/data/edition/series/2/section/2a/m34/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m34/folio-convolute.json
@@ -888,7 +888,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 1–3",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -902,7 +902,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 4–7",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -916,7 +916,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 8–12 → T. 8, {9–12}",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -930,7 +930,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 13–16 → T. {13–14}, 13–14",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -944,7 +944,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 17–19 → T. 15–17",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -973,7 +973,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 16–17(1–2/4)",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -988,7 +988,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 17(3–4/4)–19",
                             "selectable": false,
                             "sectionPartition": 2,

--- a/src/assets/data/edition/series/2/section/2a/m35_42/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m35_42/folio-convolute.json
@@ -888,7 +888,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 1–3",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -902,7 +902,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 4–7",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -916,7 +916,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 8–12 → T. 8, {9–12}",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -930,7 +930,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 13–16 → T. {13–14}, 13–14",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -944,7 +944,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 17–19 → T. 15–17",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -973,7 +973,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 16–17(1–2/4)",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -988,7 +988,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 17(3–4/4)–19",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -1592,7 +1592,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 9–11",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -1606,7 +1606,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 12",
                             "selectable": false,
                             "sectionPartition": 1,

--- a/src/assets/data/edition/series/2/section/2a/m35_42/svg-sheets.json
+++ b/src/assets/data/edition/series/2/section/2a/m35_42/svg-sheets.json
@@ -4,19 +4,19 @@
         "textEditions": [
             {
                 "id": "M_35_42_TF1",
-                "label": "M 35/42",
+                "label": "M 35/42 einzige Textfassung",
                 "content": [
                     {
                         "svg": "assets/img/edition/series/2/section/2a/m35_42/M35_42_Textfassung1-1von2-final.svg",
                         "image": "",
                         "partial": "a",
-                        "convolute": ""
+                        "convolute": "B"
                     },
                     {
                         "svg": "assets/img/edition/series/2/section/2a/m35_42/M35_42_Textfassung1-2von2-final.svg",
                         "image": "",
                         "partial": "b",
-                        "convolute": ""
+                        "convolute": "D"
                     }
                 ]
             }

--- a/src/assets/data/edition/series/2/section/2a/m36/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m36/folio-convolute.json
@@ -888,7 +888,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 1–3",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -902,7 +902,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 4–7",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -916,7 +916,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 8–12 → T. 8, {9–12}",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -930,7 +930,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 13–16 → T. {13–14}, 13–14",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -944,7 +944,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 17–19 → T. 15–17",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -973,7 +973,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 16–17(1–2/4)",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -988,7 +988,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 17(3–4/4)–19",
                             "selectable": false,
                             "sectionPartition": 2,

--- a/src/assets/data/edition/series/2/section/2a/m37/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m37/folio-convolute.json
@@ -888,7 +888,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 1–3",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -902,7 +902,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 4–7",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -916,7 +916,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 8–12 → T. 8, {9–12}",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -930,7 +930,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 13–16 → T. {13–14}, 13–14",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -944,7 +944,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 17–19 → T. 15–17",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -973,7 +973,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 16–17(1–2/4)",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -988,7 +988,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 17(3–4/4)–19",
                             "selectable": false,
                             "sectionPartition": 2,

--- a/src/assets/data/edition/series/2/section/2a/m38/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m38/folio-convolute.json
@@ -888,7 +888,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 1–3",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -902,7 +902,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 4–7",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -916,7 +916,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 8–12 → T. 8, {9–12}",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -930,7 +930,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 13–16 → T. {13–14}, 13–14",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -944,7 +944,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 17–19 → T. 15–17",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -973,7 +973,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 16–17(1–2/4)",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -988,7 +988,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 17(3–4/4)–19",
                             "selectable": false,
                             "sectionPartition": 2,

--- a/src/assets/data/edition/series/2/section/2a/m39/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m39/folio-convolute.json
@@ -888,7 +888,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 1–3",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -902,7 +902,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 4–7",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -916,7 +916,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 8–12 → T. 8, {9–12}",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -930,7 +930,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 13–16 → T. {13–14}, 13–14",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -944,7 +944,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 17–19 → T. 15–17",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -973,7 +973,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 16–17(1–2/4)",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -988,7 +988,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 17(3–4/4)–19",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -1592,7 +1592,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 9–11",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -1606,7 +1606,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 12",
                             "selectable": false,
                             "sectionPartition": 1,

--- a/src/assets/data/edition/series/2/section/2a/m39/svg-sheets.json
+++ b/src/assets/data/edition/series/2/section/2a/m39/svg-sheets.json
@@ -10,13 +10,13 @@
                         "svg": "assets/img/edition/series/2/section/2a/m39/M39_Textfassung1-1von2-final.svg",
                         "image": "",
                         "partial": "a",
-                        "convolute": ""
+                        "convolute": "B"
                     },
                     {
                         "svg": "assets/img/edition/series/2/section/2a/m39/M39_Textfassung1-2von2-final.svg",
                         "image": "",
                         "partial": "b",
-                        "convolute": ""
+                        "convolute": "B"
                     }
                 ]
             },
@@ -28,13 +28,13 @@
                         "svg": "assets/img/edition/series/2/section/2a/m39/M39_Textfassung2-1von2-final.svg",
                         "image": "",
                         "partial": "a",
-                        "convolute": ""
+                        "convolute": "D"
                     },
                     {
                         "svg": "assets/img/edition/series/2/section/2a/m39/M39_Textfassung2-2von2-final.svg",
                         "image": "",
                         "partial": "b",
-                        "convolute": ""
+                        "convolute": "B"
                     }
                 ]
             }

--- a/src/assets/data/edition/series/2/section/2a/m40/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m40/folio-convolute.json
@@ -494,7 +494,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 9–11",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -508,7 +508,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 12",
                             "selectable": false,
                             "sectionPartition": 1,

--- a/src/assets/data/edition/series/2/section/2a/m40/svg-sheets.json
+++ b/src/assets/data/edition/series/2/section/2a/m40/svg-sheets.json
@@ -10,13 +10,13 @@
                         "svg": "assets/img/edition/series/2/section/2a/m40/M40_Textfassung1-1von2-final.svg",
                         "image": "",
                         "partial": "a",
-                        "convolute": ""
+                        "convolute": "B"
                     },
                     {
                         "svg": "assets/img/edition/series/2/section/2a/m40/M40_Textfassung1-2von2-final.svg",
                         "image": "",
                         "partial": "b",
-                        "convolute": ""
+                        "convolute": "B"
                     }
                 ]
             }

--- a/src/assets/data/edition/series/2/section/2a/m41/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m41/folio-convolute.json
@@ -617,7 +617,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 1–3",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -631,7 +631,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 4–7",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -645,7 +645,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 8–12 → T. 8, {9–12}",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -659,7 +659,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 13–16 → T. {13–14}, 13–14",
                             "selectable": false,
                             "sectionPartition": 1,
@@ -673,7 +673,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF1",
-                            "sigle": "M 39 Tintenniederschrift TF 1→2",
+                            "sigle": "M 39 Tintenniederschrift TF1→2",
                             "sigleAddendum": "T. 17–19 → T. 15–17",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -702,7 +702,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 16–17(1–2/4)",
                             "selectable": false,
                             "sectionPartition": 2,
@@ -717,7 +717,7 @@
                         {
                             "complexId": "m39",
                             "sheetId": "M_39_TF2",
-                            "sigle": "M 39 Tintenniederschrift TF 2",
+                            "sigle": "M 39 Tintenniederschrift TF2",
                             "sigleAddendum": "T. 17(3–4/4)–19",
                             "selectable": false,
                             "sectionPartition": 2,

--- a/src/assets/data/edition/series/2/section/2a/m41/svg-sheets.json
+++ b/src/assets/data/edition/series/2/section/2a/m41/svg-sheets.json
@@ -10,13 +10,13 @@
                         "svg": "assets/img/edition/series/2/section/2a/m41/M41_Textfassung1-1von2-final.svg",
                         "image": "",
                         "partial": "a",
-                        "convolute": ""
+                        "convolute": "B"
                     },
                     {
                         "svg": "assets/img/edition/series/2/section/2a/m41/M41_Textfassung1-2von2-final.svg",
                         "image": "",
                         "partial": "b",
-                        "convolute": ""
+                        "convolute": "B"
                     }
                 ]
             }


### PR DESCRIPTION
This PR fixes a small whitespace issue in m34-41 and adds the convolutes in the textcritics file if missing.