### PR TITLE
refactor(edition): adjust segment stroke width based on systems number

### DIFF
--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.spec.ts
@@ -69,8 +69,9 @@ describe('FolioService (DONE)', () => {
     let expectedContentSegmentFontFamily: string;
     let expectedContentSegmentFontSize: string;
     let expectedContentSegmentOffsetCorrection: number;
-    let expectedReversedRotationAngle: number;
     let expectedContentSegmentStrokeWidth: number;
+    let expectedDefaultNumberOfSystems: number;
+    let expectedReversedRotationAngle: number;
     let expectedSheetStrokeWidth: number;
     let expectedSystemsLineStrokeWidth: number;
 
@@ -106,12 +107,13 @@ describe('FolioService (DONE)', () => {
         expectedContentSegmentFillColor = '#eeeeee';
         expectedSheetFillColor = 'white';
 
-        expectedContentSegmentOffsetCorrection = 4;
         expectedContentSegmentFontFamily = 'Source Sans Pro, source-sans-pro, sans-serif';
         expectedContentSegmentFontSize = '11px';
-
-        expectedReversedRotationAngle = 180;
+        expectedContentSegmentOffsetCorrection = 4;
         expectedContentSegmentStrokeWidth = 2;
+
+        expectedDefaultNumberOfSystems = 18;
+        expectedReversedRotationAngle = 180;
         expectedSheetStrokeWidth = 1;
         expectedSystemsLineStrokeWidth = 0.7;
 
@@ -255,12 +257,16 @@ describe('FolioService (DONE)', () => {
             expectToBe((folioService as any)._contentSegmentOffsetCorrection, expectedContentSegmentOffsetCorrection);
         });
 
-        it('... should have `_reversedRotationAngle`', () => {
-            expectToBe((folioService as any)._reversedRotationAngle, expectedReversedRotationAngle);
-        });
-
         it('... should have `_contentSegmentStrokeWidth`', () => {
             expectToBe((folioService as any)._contentSegmentStrokeWidth, expectedContentSegmentStrokeWidth);
+        });
+
+        it('... should have `_defaultNumberOfSystems`', () => {
+            expectToBe((folioService as any)._defaultNumberOfSystems, expectedDefaultNumberOfSystems);
+        });
+
+        it('... should have `_reversedRotationAngle`', () => {
+            expectToBe((folioService as any)._reversedRotationAngle, expectedReversedRotationAngle);
         });
 
         it('... should have `_sheetStrokeWidth`', () => {
@@ -1371,6 +1377,7 @@ describe('FolioService (DONE)', () => {
                     expectToEqual(callArgs, [
                         contentSegmentLink,
                         expectedFolioSvgData.contentSegments[i].segmentVertices,
+                        expectedFolioSvgData.systems.systemsLines.length,
                     ]);
                 });
             });
@@ -2071,17 +2078,22 @@ describe('FolioService (DONE)', () => {
         describe('... when called', () => {
             let contentSegmentLink: D3_SELECTION.Selection<SVGAElement, unknown, null, undefined>;
             let expectedContentSegment: FolioSvgContentSegment;
+            let expectedAdjustedStrokeWidth: number;
 
             beforeEach(() => {
                 // Create a new SVG group for testing
                 const contentSegmentGroup = D3_SELECTION.create('g');
                 contentSegmentLink = contentSegmentGroup.append('svg:a');
 
+                const systemsLength = expectedFolioSvgData.systems.systemsLines.length;
                 expectedContentSegment = expectedFolioSvgData.contentSegments[0];
+                expectedAdjustedStrokeWidth =
+                    expectedContentSegmentStrokeWidth * (expectedDefaultNumberOfSystems / systemsLength);
 
                 (folioService as any)._appendContentSegmentLinkPolygon(
                     contentSegmentLink,
-                    expectedContentSegment.segmentVertices
+                    expectedContentSegment.segmentVertices,
+                    systemsLength
                 );
             });
 
@@ -2095,7 +2107,7 @@ describe('FolioService (DONE)', () => {
                     points: expectedContentSegment.segmentVertices,
                     fill: expectedContentSegmentFillColor,
                 };
-                attributes['stroke-width'] = expectedContentSegmentStrokeWidth;
+                attributes['stroke-width'] = expectedAdjustedStrokeWidth;
 
                 expectSpyCall(appendSvgElementWithAttrsSpy, 1, [contentSegmentLink, 'polygon', attributes]);
             });
@@ -2117,7 +2129,8 @@ describe('FolioService (DONE)', () => {
 
                 (folioService as any)._appendContentSegmentLinkPolygon(
                     altSegmentLink,
-                    altFolioSvgData.contentSegments[0].segmentVertices
+                    altFolioSvgData.contentSegments[0].segmentVertices,
+                    altFolioSvgData.systems.systemsLines.length
                 );
 
                 const polygonElement = altSegmentLink.select('polygon');
@@ -2137,7 +2150,8 @@ describe('FolioService (DONE)', () => {
 
                 (folioService as any)._appendContentSegmentLinkPolygon(
                     altSegmentLink,
-                    altFolioSvgData.contentSegments[0].segmentVertices
+                    altFolioSvgData.contentSegments[0].segmentVertices,
+                    altFolioSvgData.systems.systemsLines.length
                 );
 
                 const polygonElement = altSegmentLink.select('polygon');
@@ -2164,10 +2178,27 @@ describe('FolioService (DONE)', () => {
                 expectToBe(polygonElement.attr('fill'), expectedContentSegmentFillColor);
             });
 
-            it('... should set the `stroke-width` attribute of the polygon element', () => {
-                const polygonElement = contentSegmentLink.select('polygon');
+            it('... should set the `stroke-width` attribute of the polygon element to default value if no number of systems is given', () => {
+                const altSegmentLink = D3_SELECTION.create('svg:a');
+
+                const altFolioSvgData = new FolioSvgData(
+                    new FolioCalculation(expectedFolioSettings, expectedReversedFolio, 0)
+                );
+
+                (folioService as any)._appendContentSegmentLinkPolygon(
+                    altSegmentLink,
+                    altFolioSvgData.contentSegments[0].segmentVertices
+                );
+
+                const polygonElement = altSegmentLink.select('polygon');
 
                 expectToBe(polygonElement.attr('stroke-width'), String(expectedContentSegmentStrokeWidth));
+            });
+
+            it('... should adjust the `stroke-width` attribute of the polygon element based on the number of systems if given', () => {
+                const polygonElement = contentSegmentLink.select('polygon');
+
+                expectToBe(polygonElement.attr('stroke-width'), String(expectedAdjustedStrokeWidth));
             });
 
             it('... should only have specified attributes', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.ts
@@ -90,6 +90,13 @@ export class FolioService {
     private readonly _contentSegmentStrokeWidth = 2;
 
     /**
+     * Private readonly variable: _defaultNumberOfSystems.
+     *
+     * It keeps the default number of systems.
+     */
+    private readonly _defaultNumberOfSystems = 18;
+
+    /**
      * Private readonly variable: _reversedRotationAngle.
      *
      * It keeps the rotation angle for a reversed item.
@@ -264,7 +271,11 @@ export class FolioService {
             const svgContentSegmentLink = this._appendContentSegmentLink(svgContentSegmentGroup);
 
             // Draw content segment polygon.
-            this._appendContentSegmentLinkPolygon(svgContentSegmentLink, contentSegment.segmentVertices);
+            this._appendContentSegmentLinkPolygon(
+                svgContentSegmentLink,
+                contentSegment.segmentVertices,
+                folioSvgData.systems.systemsLines.length
+            );
 
             // Draw content segment link label.
             this._appendContentSegmentLinkLabel(svgContentSegmentLink, contentSegment);
@@ -465,13 +476,20 @@ export class FolioService {
      * @param {string} segmentVertices The given segment vertices.
      * @returns {D3Selection} Appends a polygon shape to the content segment link selection.
      */
-    private _appendContentSegmentLinkPolygon(svgContentSegmentLink: D3Selection, segmentVertices: string): D3Selection {
+    private _appendContentSegmentLinkPolygon(
+        svgContentSegmentLink: D3Selection,
+        segmentVertices: string,
+        numberOfSystems: number = this._defaultNumberOfSystems
+    ): D3Selection {
+        // Dynamically adjust the strokeWidth based on the number of systems (reference: 18 systems)
+        const adjustedStrokeWidth = this._contentSegmentStrokeWidth * (this._defaultNumberOfSystems / numberOfSystems);
+
         const attributes = {
             class: 'content-segment-shape',
             points: segmentVertices,
             fill: this._contentSegmentFillColor,
         };
-        attributes['stroke-width'] = this._contentSegmentStrokeWidth;
+        attributes['stroke-width'] = adjustedStrokeWidth;
 
         return this._appendSvgElementWithAttrs(svgContentSegmentLink, 'polygon', attributes);
     }

--- a/src/app/views/edition-view/models/folio-calculation.model.ts
+++ b/src/app/views/edition-view/models/folio-calculation.model.ts
@@ -493,11 +493,16 @@ export class FolioCalculationContentSegment {
 
         const label = new FolioCalculationContentSegmentLabel(sigle, sigleAddendum);
 
+        // Dynamically adjust the segmentOffsetCorrection based on the number of systems (reference: 18 systems)
+        const defaultNumberOfSystems = 18;
+        const adjustedOffsetCorrection =
+            this._segmentOffsetCorrection * (defaultNumberOfSystems / this._systems.NUMBER_OF_SYSTEMS);
+
         this.vertices = new FolioCalculationContentSegmentVertices(
             segment,
             this._systems,
             this.segmentSplit,
-            this._segmentOffsetCorrection
+            adjustedOffsetCorrection
         );
 
         const centeredPositions = new FolioCalculationContentSegmentCenteredPositions(

--- a/src/testing/mock-data/mockEditionData.ts
+++ b/src/testing/mock-data/mockEditionData.ts
@@ -112,7 +112,7 @@ export const mockEditionData = {
                 folios: [
                     {
                         folioId: '1',
-                        systems: '12',
+                        systems: '18',
                         dimensions: {
                             height: 180,
                             width: 267,
@@ -185,7 +185,7 @@ export const mockEditionData = {
      */
     mockReversedFolio: {
         folioId: '1',
-        systems: '12',
+        systems: '18',
         reversed: true,
         dimensions: {
             height: 180,


### PR DESCRIPTION
This PR adjusts the stroke width of the content segments in the folio overview based on the systems number.