### PR TITLE
style(edition): adjust note glyphs

### DIFF
--- a/src/app/views/edition-view/data/edition-glyphs.data.ts
+++ b/src/app/views/edition-view/data/edition-glyphs.data.ts
@@ -195,6 +195,15 @@ export const EDITION_GLYPHS_DATA = {
     },
 
     /**
+     * The glyph of a musical half note with dot symbol.
+     * Cf. https://w3c.github.io/smufl/latest/tables/individual-notes.html
+     */
+    NOTE_HALF_DOTTED: {
+        alt: '[Punktierte Halbe Note]',
+        hex: '\uE1D3 \uE1E7',
+    },
+
+    /**
      * The glyph of a musical quarter note symbol.
      * Cf. https://w3c.github.io/smufl/latest/tables/individual-notes.html
      */

--- a/src/assets/data/edition/series/1/section/5/op12/textcritics.json
+++ b/src/assets/data/edition/series/1/section/5/op12/textcritics.json
@@ -295,7 +295,7 @@
                                 "measure": "35",
                                 "system": "",
                                 "position": "Taktanfang",
-                                "comment": "Zeilenfall bei <em>sehr ruhig | (</em><span class='glyph'>{{ref.getGlyph('[Achtelnote]')}}</span>&ngsp;<em>= ca 100)</em>. aufgelöst gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_F'})\"><strong>F</strong></a>. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Auf Grund des Akkoladenwechsels nach T. 35 nicht ausreichend Raum bis zum Seitenrand für die Tempobezeichnung in einer Zeile."
+                                "comment": "Zeilenfall bei <em>sehr ruhig | (</em><span class='glyph note'>{{ref.getGlyph('[Achtelnote]')}}</span><em> = ca 100)</em>. aufgelöst gemäß <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_F'})\"><strong>F</strong></a>. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_G'})\"><strong>G</strong></a>: Auf Grund des Akkoladenwechsels nach T. 35 nicht ausreichend Raum bis zum Seitenrand für die Tempobezeichnung in einer Zeile."
                             },
                             {
                                 "svgGroupId": "TODO",
@@ -581,7 +581,7 @@
                                 "measure": "1",
                                 "system": "",
                                 "position": "Taktanfang",
-                                "comment": "<em>Sehr fließend und leicht (</em><span class='glyph'>{{ref.getGlyph('[Halbe Note]')}}</span>. <em>= circa 44)</em> umgebrochen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_D'})\"><strong>D</strong></a>: in einer Zeile."
+                                "comment": "<em>Sehr fließend und leicht (</em><span class='glyph note'>{{ref.getGlyph('[Punktierte Halbe Note]')}}</span><em> = circa 44)</em> umgebrochen. <a (click)=\"ref.navigateToReportFragment({complexId: 'op12', fragmentId: 'source_D'})\"><strong>D</strong></a>: in einer Zeile."
                             },
                             {
                                 "svgGroupId": "g435",

--- a/src/assets/data/edition/series/1/section/5/op25/textcritics.json
+++ b/src/assets/data/edition/series/1/section/5/op25/textcritics.json
@@ -253,7 +253,7 @@
                                 "measure": "31",
                                 "system": "",
                                 "position": "2/4",
-                                "comment": "Eckige Klammern um <span class='glyph'>{{ref.getGlyph('[Halbe Note]')}}</span>&ngsp;<em>= ca 96</em> geändert zu runden Klammern."
+                                "comment": "Eckige Klammern um <span class='glyph note'>{{ref.getGlyph('[Halbe Note]')}}</span><em> = ca 96</em> geändert zu runden Klammern."
                             },
                             {
                                 "svgGroupId": "TODO",
@@ -323,7 +323,7 @@
                                 "measure": "76",
                                 "system": "",
                                 "position": "2/4",
-                                "comment": "Punkt nach <em>tempo I</em> weggelassen, eckige Klammern um <span class='glyph'>{{ref.getGlyph('[Halbe Note]')}}</span>&ngsp;<em>= ca 96</em> geändert zu runden Klammern."
+                                "comment": "Punkt nach <em>tempo I</em> weggelassen, eckige Klammern um <span class='glyph note'>{{ref.getGlyph('[Halbe Note]')}}</span><em> = ca 96</em> geändert zu runden Klammern."
                             },
                             {
                                 "svgGroupId": "TODO",

--- a/src/assets/data/edition/series/1/section/5/op3/source-description.json
+++ b/src/assets/data/edition/series/1/section/5/op3/source-description.json
@@ -806,7 +806,7 @@
                                             "measure": "1",
                                             "system": "",
                                             "position": "Taktanfang",
-                                            "comment": "<em>Ganz wenig bewegt (</em><span class='glyph'>{{ref.getGlyph('[Achtelnote]')}}</span><em>)</em> auf Rasur."
+                                            "comment": "<em>Ganz wenig bewegt (</em><span class='glyph note'>{{ref.getGlyph('[Achtelnote]')}}</span><em>)</em> auf Rasur."
                                         },
                                         {
                                             "measure": "1",
@@ -3124,7 +3124,7 @@
                                             "measure": "1",
                                             "system": "",
                                             "position": "Taktanfang",
-                                            "comment": "<em>Ganz wenig bewegt (</em><span class='glyph'>{{ref.getGlyph('[Achtelnote]')}}</span><em>)</em> hinzugefügt."
+                                            "comment": "<em>Ganz wenig bewegt (</em><span class='glyph note'>{{ref.getGlyph('[Achtelnote]')}}</span><em>)</em> hinzugefügt."
                                         },
                                         {
                                             "measure": "1",

--- a/src/assets/data/edition/series/1/section/5/op3/textcritics.json
+++ b/src/assets/data/edition/series/1/section/5/op3/textcritics.json
@@ -1300,7 +1300,7 @@
                                 "measure": "vor 1",
                                 "system": "",
                                 "position": "Anfang",
-                                "comment": "sic: Metronomzahlangabe fehlt bei <em>(</em><span class='glyph'>{{ref.getGlyph('[Viertelnote]')}}</span>&ngsp;<em>=  )</em>."
+                                "comment": "sic: Metronomzahlangabe fehlt bei <em>(</em><span class='glyph note'>{{ref.getGlyph('[Viertelnote]')}}</span><em> =  )</em>."
                             },
                             {
                                 "svgGroupId": "g514",
@@ -1356,7 +1356,7 @@
                                 "measure": "13",
                                 "system": "",
                                 "position": "Taktanfang",
-                                "comment": "sic: Metronomzahlangabe fehlt bei <em>(</em><span class='glyph'>{{ref.getGlyph('[Achtelnote]')}}</span>&ngsp;<em>=  )</em>."
+                                "comment": "sic: Metronomzahlangabe fehlt bei <em>(</em><span class='glyph note'>{{ref.getGlyph('[Achtelnote]')}}</span><em> =  )</em>."
                             },
                             {
                                 "svgGroupId": "g490",

--- a/src/assets/data/edition/series/1/section/5/op4/source-description.json
+++ b/src/assets/data/edition/series/1/section/5/op4/source-description.json
@@ -2571,7 +2571,7 @@
                                             "measure": "vor 1",
                                             "system": "",
                                             "position": "Taktanfang",
-                                            "comment": "<em>Sehr</em> hinzugefügt vor <em>Langsam (</em><span class='glyph'>{{ref.getGlyph('[Viertelnote]')}}</span><em>)</em> mit schwarzer Tinte."
+                                            "comment": "<em>Sehr</em> hinzugefügt vor <em>Langsam (</em><span class='glyph note'>{{ref.getGlyph('[Viertelnote]')}}</span><em>)</em> mit schwarzer Tinte."
                                         },
                                         {
                                             "measure": "vor 1",
@@ -3975,7 +3975,7 @@
                                             "measure": "13",
                                             "system": "",
                                             "position": "Taktanfang",
-                                            "comment": "<em>ruhig (</em><span class='glyph'>{{ref.getGlyph('[Achtelnote]')}}</span>&ngsp;<em>= ca 72)</em> auf Rasur."
+                                            "comment": "<em>ruhig (</em><span class='glyph note'>{{ref.getGlyph('[Achtelnote]')}}</span<em> = ca 72)</em> auf Rasur."
                                         },
                                         {
                                             "measure": "12 <br /> und 14",
@@ -4004,7 +4004,7 @@
                                             "measure": "vor 1",
                                             "system": "",
                                             "position": "",
-                                            "comment": "<em>Langsam (</em><span class='glyph'>{{ref.getGlyph('[Viertelnote]')}}</span>&ngsp;<em>= ca 48)</em> teilweise auf Rasur und geändert. Ante correcturam: vermutlich <em>Sehr langsam (</em><span class='glyph'>{{ref.getGlyph('[Viertelnote]')}}</span><em>)</em> (siehe <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_142_TF2'})\">Textfassung 2</a>)."
+                                            "comment": "<em>Langsam (</em><span class='glyph note'>{{ref.getGlyph('[Viertelnote]')}}</span><em> = ca 48)</em> teilweise auf Rasur und geändert. Ante correcturam: vermutlich <em>Sehr langsam (</em><span class='glyph note'>{{ref.getGlyph('[Viertelnote]')}}</span><em>)</em> (siehe <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_142_TF2'})\">Textfassung 2</a>)."
                                         },
                                         {
                                             "measure": "2",
@@ -4106,7 +4106,7 @@
                                             "measure": "10",
                                             "system": "",
                                             "position": "Taktanfang",
-                                            "comment": "<em>poco rit.</em> | <span class='glyph'>{{ref.getGlyph('[Viertelnote]')}}</span><em> = ca 66</em> auf Rasur. Ante correcturam: vermutlich <em>rit.</em> (siehe <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_142_TF2'})\">Textfassung 2</a>)."
+                                            "comment": "<em>poco rit.</em> | <span class='glyph note'>{{ref.getGlyph('[Viertelnote]')}}</span><em> = ca 66</em> auf Rasur. Ante correcturam: vermutlich <em>rit.</em> (siehe <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_142_TF2'})\">Textfassung 2</a>)."
                                         },
                                         {
                                             "measure": "10",
@@ -4160,7 +4160,7 @@
                                             "measure": "13",
                                             "system": "",
                                             "position": "Taktanfang",
-                                            "comment": "<em>tempo I. (</em><span class='glyph'>{{ref.getGlyph('[Viertelnote]')}}</span><em> = ca 48)</em> auf Rasur. Ante correcturam: vermutlich <em>sehr ruhig</em> (siehe <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_142_TF2'})\">Textfassung 2</a>)."
+                                            "comment": "<em>tempo I. (</em><span class='glyph note'>{{ref.getGlyph('[Viertelnote]')}}</span><em> = ca 48)</em> auf Rasur. Ante correcturam: vermutlich <em>sehr ruhig</em> (siehe <a (click)=\"ref.selectSvgSheet({complexId: 'op4', sheetId: 'M_142_TF2'})\">Textfassung 2</a>)."
                                         },
                                         {
                                             "measure": "13",
@@ -4642,7 +4642,7 @@
                                             "measure": "1",
                                             "system": "",
                                             "position": "Taktanfang",
-                                            "comment": "<em>Ruhevoll (</em><span class='glyph'>{{ref.getGlyph('[Achtelnote]')}}</span>&ngsp;<em>= ca <s>58</s></em> &lt;<em>58</em>&gt;<em>)</em>, <em><s>58</s></em> gestrichen mit Bleistift, &lt;<em>58</em>&gt; hinzugefügt mit schwarzer Tinte (Hs. Webern?)."
+                                            "comment": "<em>Ruhevoll (</em><span class='glyph note'>{{ref.getGlyph('[Achtelnote]')}}</span><em> = ca <s>58</s></em> &lt;<em>58</em>&gt;<em>)</em>, <em><s>58</s></em> gestrichen mit Bleistift, &lt;<em>58</em>&gt; hinzugefügt mit schwarzer Tinte (Hs. Webern?)."
                                         },
                                         {
                                             "measure": "1–13",

--- a/src/assets/data/edition/series/1/section/5/op4/textcritics.json
+++ b/src/assets/data/edition/series/1/section/5/op4/textcritics.json
@@ -942,7 +942,7 @@
                                 "measure": "15",
                                 "system": "",
                                 "position": "Taktanfang",
-                                "comment": "Klammern zu <span class='glyph'>{{ref.getGlyph('[Viertelnote]')}}</span>&ngsp;<em>= 80</em> ergänzt analog T. 1, 10 und 13."
+                                "comment": "Klammern zu <span class='glyph note'>{{ref.getGlyph('[Viertelnote]')}}</span><em> = 80</em> ergänzt analog T. 1, 10 und 13."
                             },
                             {
                                 "svgGroupId": "TODO",

--- a/src/assets/themes/scss/main.scss
+++ b/src/assets/themes/scss/main.scss
@@ -446,3 +446,6 @@ span.facet-badge {
 .glyph.accid {
     vertical-align: middle;
 }
+.glyph.note {
+    font-size: 16px;
+}


### PR DESCRIPTION
This PR fixes the size of note glyphs, adds a new glyph entry for dotted half notes and fixes some whitespace with note glyphs.