### PR TITLE
ci(gh-actions): fix fetch depth for build job

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -146,7 +146,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
-                  fetch-depth: 2
+                  fetch-depth: 0 # fetch all history, needed for git sha
 
             - name: Common Node setup
               uses: ./.github/actions/common-node-setup


### PR DESCRIPTION
This PR fixes the fetch depth for the commit history in thhe CI build job.