### PR TITLE
ci(gh-actions): fix sha output

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -194,7 +194,7 @@ jobs:
             contents: write
 
         env:
-            SHA: ${{ needs.test.outputs.sha }}
+            SHA: ${{ needs.build.outputs.sha }}
 
         strategy:
             matrix:


### PR DESCRIPTION
This PR fixes the reference to the sha output variable in the deploy job.