### PR TITLE
style(edition): make detail toggles small and muted

### DIFF
--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.html
@@ -1,7 +1,7 @@
 <div class="awg-source-description-contents">
     <p class="awg-source-description-contents-label no-para-margin">
         <span class="smallcaps">Inhalt:</span>
-        <span class="awg-source-description-contents-toggle">
+        <span class="awg-source-description-contents-toggle text-muted small">
             [
             <span
                 class="awg-source-description-contents-toggle-text"

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.scss
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.scss
@@ -5,15 +5,17 @@
 .awg-source-description-contents-toggle {
     margin-left: 1em;
     cursor: pointer;
-}
-.awg-source-description-contents-toggle.text-muted {
-    transition: color 0.2s;
+
+    &.text-muted {
+        transition: color 0.2s;
+    }
+
+    &:hover,
+    &:focus {
+        color: inherit !important;
+    }
 }
 
-.awg-source-description-contents-toggle:hover,
-.awg-source-description-contents-toggle:focus {
-    color: inherit !important;
-}
 .awg-source-description-contents-toggle-text {
     text-decoration: underline;
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.scss
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.scss
@@ -6,6 +6,14 @@
     margin-left: 1em;
     cursor: pointer;
 }
+.awg-source-description-contents-toggle.text-muted {
+    transition: color 0.2s;
+}
+
+.awg-source-description-contents-toggle:hover,
+.awg-source-description-contents-toggle:focus {
+    color: inherit !important;
+}
 .awg-source-description-contents-toggle-text {
     text-decoration: underline;
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.spec.ts
@@ -114,7 +114,7 @@ describe('SourceDescriptionContentsComponent', () => {
                 expectToBe(spanEl.textContent.trim(), expectedLabel);
             });
 
-            it('... should contain a toggle span in the label paragraph', () => {
+            it('... should contain a small muted toggle span in the label paragraph', () => {
                 const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-source-description-contents-label', 1, 1);
                 const toggleSpanDes = getAndExpectDebugElementByCss(
                     pDes[0],
@@ -122,12 +122,10 @@ describe('SourceDescriptionContentsComponent', () => {
                     1,
                     1
                 );
-                getAndExpectDebugElementByCss(
-                    toggleSpanDes[0],
-                    'span.awg-source-description-contents-toggle-text',
-                    1,
-                    1
-                );
+                const toggleSpanEl: HTMLSpanElement = toggleSpanDes[0].nativeElement;
+
+                expect(toggleSpanEl).toHaveClass('small');
+                expect(toggleSpanEl).toHaveClass('text-muted');
             });
 
             it('... should not display a text in the toggle span yet', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.html
@@ -1,7 +1,7 @@
 <div class="awg-source-description-corrections">
     <p class="awg-source-description-corrections-label no-para-margin">
         <span class="smallcaps">Korrekturen:</span>
-        <span class="awg-source-description-corrections-toggle"
+        <span class="awg-source-description-corrections-toggle text-muted small"
             >[
             <span
                 class="awg-source-description-corrections-toggle-text"

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.scss
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.scss
@@ -1,15 +1,17 @@
 .awg-source-description-corrections-toggle {
     margin-left: 1em;
     cursor: pointer;
-}
-.awg-source-description-corrections-toggle.text-muted {
-    transition: color 0.2s;
+
+    &.text-muted {
+        transition: color 0.2s;
+    }
+
+    &:hover,
+    &:focus {
+        color: inherit !important;
+    }
 }
 
-.awg-source-description-corrections-toggle:hover,
-.awg-source-description-corrections-toggle:focus {
-    color: inherit !important;
-}
 .awg-source-description-corrections-toggle-text {
     text-decoration: underline;
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.scss
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.scss
@@ -2,6 +2,14 @@
     margin-left: 1em;
     cursor: pointer;
 }
+.awg-source-description-corrections-toggle.text-muted {
+    transition: color 0.2s;
+}
+
+.awg-source-description-corrections-toggle:hover,
+.awg-source-description-corrections-toggle:focus {
+    color: inherit !important;
+}
 .awg-source-description-corrections-toggle-text {
     text-decoration: underline;
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.spec.ts
@@ -138,7 +138,7 @@ describe('SourceDescriptionCorrectionsComponent (DONE)', () => {
                 expectToBe(spanEl.textContent.trim(), expectedLabel);
             });
 
-            it('... should contain a toggle span in the label paragraph', () => {
+            it('... should contain a small muted toggle span in the label paragraph', () => {
                 const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-source-description-corrections-label', 1, 1);
                 const toggleSpanDes = getAndExpectDebugElementByCss(
                     pDes[0],
@@ -146,12 +146,10 @@ describe('SourceDescriptionCorrectionsComponent (DONE)', () => {
                     1,
                     1
                 );
-                getAndExpectDebugElementByCss(
-                    toggleSpanDes[0],
-                    'span.awg-source-description-corrections-toggle-text',
-                    1,
-                    1
-                );
+                const toggleSpanEl: HTMLSpanElement = toggleSpanDes[0].nativeElement;
+
+                expect(toggleSpanEl).toHaveClass('small');
+                expect(toggleSpanEl).toHaveClass('text-muted');
             });
 
             it('... should not display a text in the toggle span yet', () => {


### PR DESCRIPTION
This PR improves the styling of the details toggles.