### PR TITLE
build(app): adjust dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,12 +22,14 @@ updates:
           angular-cli/devkit:
               patterns:
                   - '@angular/cli'
+                  - '@angular/build'
                   - '@angular-devkit/*'
           angular:
               patterns:
                   - '@angular/*'
               exclude-patterns:
                   - '@angular/cli'
+                  - '@angular/build'
           angular-eslint:
               patterns:
                   - '@angular-eslint/*'


### PR DESCRIPTION
This PR adjusts the dependabot groups to move angular build to the correct group.