### PR TITLE
fix(assets): rename mstar -> mx

### DIFF
--- a/src/assets/data/edition/series/1/section/5/op12/folio-convolute.json
+++ b/src/assets/data/edition/series/1/section/5/op12/folio-convolute.json
@@ -638,8 +638,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "Mstar_unknown",
-                            "sheetId": "Mstar_unknown_Sk1",
+                            "complexId": "Mx_unknown",
+                            "sheetId": "Mx_unknown_Sk1",
                             "sigle": "unidentifizierte Skizze",
                             "sigleAddendum": "T. 1–4",
                             "selectable": false,
@@ -653,8 +653,8 @@
                             ]
                         },
                         {
-                            "complexId": "Mstar_unknown",
-                            "sheetId": "Mstar_unknown_Sk1",
+                            "complexId": "Mx_unknown",
+                            "sheetId": "Mx_unknown_Sk1",
                             "sigle": "unidentifizierte Skizze",
                             "sigleAddendum": "T. 5–6",
                             "selectable": false,

--- a/src/assets/data/edition/series/1/section/5/op12/folio-convolute.json
+++ b/src/assets/data/edition/series/1/section/5/op12/folio-convolute.json
@@ -638,7 +638,7 @@
                     },
                     "content": [
                         {
-                            "complexId": "Mx_unknown",
+                            "complexId": "mx_unknown",
                             "sheetId": "Mx_unknown_Sk1",
                             "sigle": "unidentifizierte Skizze",
                             "sigleAddendum": "T. 1–4",
@@ -653,7 +653,7 @@
                             ]
                         },
                         {
-                            "complexId": "Mx_unknown",
+                            "complexId": "mx_unknown",
                             "sheetId": "Mx_unknown_Sk1",
                             "sigle": "unidentifizierte Skizze",
                             "sigleAddendum": "T. 5–6",

--- a/src/assets/data/edition/series/2/section/2a/m112/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m112/folio-convolute.json
@@ -823,8 +823,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar496",
-                            "sheetId": "Mstar_496_Sk1",
+                            "complexId": "mx496",
+                            "sheetId": "Mx_496_Sk1",
                             "sigle": "M* 496 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m113/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m113/folio-convolute.json
@@ -74,8 +74,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar452",
-                            "sheetId": "Mstar_452_SkXXa",
+                            "complexId": "mx452",
+                            "sheetId": "Mx_452_SkXXa",
                             "sigle": "M* 452 Sk##",
                             "sigleAddendum": "T. ###",
                             "selectable": false,
@@ -89,8 +89,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar452",
-                            "sheetId": "Mstar_452_SkXXb",
+                            "complexId": "mx452",
+                            "sheetId": "Mx_452_SkXXb",
                             "sigle": "M* 452 Sk##",
                             "sigleAddendum": "T. ###",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m22/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m22/folio-convolute.json
@@ -913,8 +913,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar400",
-                            "sheetId": "Mstar_400_Sk1",
+                            "complexId": "mx400",
+                            "sheetId": "Mx_400_Sk1",
                             "sigle": "M* 400 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1083,8 +1083,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1a",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1a",
                             "sigle": "M* 401 Sk1",
                             "sigleAddendum": "T. 1–11",
                             "selectable": false,
@@ -1098,8 +1098,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1b",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1b",
                             "sigle": "M* 401 Sk1",
                             "sigleAddendum": "T. 12–16",
                             "selectable": false,
@@ -1113,8 +1113,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1_1",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1_1",
                             "sigle": "M* 401 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1128,8 +1128,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1_2",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1_2",
                             "sigle": "M* 401 Sk1.2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1342,8 +1342,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar417",
-                            "sheetId": "Mstar_417_Sk1",
+                            "complexId": "mx417",
+                            "sheetId": "Mx_417_Sk1",
                             "sigle": "M* 417 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1357,8 +1357,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar418",
-                            "sheetId": "Mstar_418_Sk1",
+                            "complexId": "mx418",
+                            "sheetId": "Mx_418_Sk1",
                             "sigle": "M* 418 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1372,8 +1372,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar419",
-                            "sheetId": "Mstar_419_Sk1",
+                            "complexId": "mx419",
+                            "sheetId": "Mx_419_Sk1",
                             "sigle": "M* 419 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1429,8 +1429,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar420",
-                            "sheetId": "Mstar_420_Sk1",
+                            "complexId": "mx420",
+                            "sheetId": "Mx_420_Sk1",
                             "sigle": "M* 420 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1444,8 +1444,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_Sk1a",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_Sk1a",
                             "sigle": "M* 421 Sk1",
                             "sigleAddendum": "T. {1A}–{1D}",
                             "selectable": false,
@@ -1459,8 +1459,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_Sk1b",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_Sk1b",
                             "sigle": "M* 421 Sk1",
                             "sigleAddendum": "T. 1E–4",
                             "selectable": false,
@@ -1474,8 +1474,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar422",
-                            "sheetId": "Mstar_422_Sk1",
+                            "complexId": "mx422",
+                            "sheetId": "Mx_422_Sk1",
                             "sigle": "M* 422 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1514,8 +1514,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar433",
-                            "sheetId": "Mstar_433_Sk1",
+                            "complexId": "mx433",
+                            "sheetId": "Mx_433_Sk1",
                             "sigle": "M* 433 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1529,8 +1529,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar434",
-                            "sheetId": "Mstar_434_Sk1",
+                            "complexId": "mx434",
+                            "sheetId": "Mx_434_Sk1",
                             "sigle": "M* 434 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1544,8 +1544,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar434",
-                            "sheetId": "Mstar_434_Sk1_1",
+                            "complexId": "mx434",
+                            "sheetId": "Mx_434_Sk1_1",
                             "sigle": "M* 434 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1559,8 +1559,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar435",
-                            "sheetId": "Mstar_435_Sk1",
+                            "complexId": "mx435",
+                            "sheetId": "Mx_435_Sk1",
                             "sigle": "M* 435 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1574,8 +1574,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar436",
-                            "sheetId": "Mstar_436_Sk1",
+                            "complexId": "mx436",
+                            "sheetId": "Mx_436_Sk1",
                             "sigle": "M* 436 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1589,8 +1589,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar437",
-                            "sheetId": "Mstar_437_Sk1",
+                            "complexId": "mx437",
+                            "sheetId": "Mx_437_Sk1",
                             "sigle": "M* 437 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1783,8 +1783,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar438",
-                            "sheetId": "Mstar_438_Sk1",
+                            "complexId": "mx438",
+                            "sheetId": "Mx_438_Sk1",
                             "sigle": "M* 438 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1798,8 +1798,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar439",
-                            "sheetId": "Mstar_439_Sk1a",
+                            "complexId": "mx439",
+                            "sheetId": "Mx_439_Sk1a",
                             "sigle": "M* 439 Sk1",
                             "sigleAddendum": "T. 1–6",
                             "selectable": false,
@@ -1813,8 +1813,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar439",
-                            "sheetId": "Mstar_439_Sk1b",
+                            "complexId": "mx439",
+                            "sheetId": "Mx_439_Sk1b",
                             "sigle": "M* 439 Sk1",
                             "sigleAddendum": "T. 7–8",
                             "selectable": false,
@@ -1828,8 +1828,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar440",
-                            "sheetId": "Mstar_440_Sk1a",
+                            "complexId": "mx440",
+                            "sheetId": "Mx_440_Sk1a",
                             "sigle": "M* 440 Sk1",
                             "sigleAddendum": "T. 1–6",
                             "selectable": false,
@@ -1843,8 +1843,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar440",
-                            "sheetId": "Mstar_440_Sk1b",
+                            "complexId": "mx440",
+                            "sheetId": "Mx_440_Sk1b",
                             "sigle": "M* 440 Sk1",
                             "sigleAddendum": "T. 7–8",
                             "selectable": false,
@@ -1858,8 +1858,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk1",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk1",
                             "sigle": "M* 441 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1873,8 +1873,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk2",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk2",
                             "sigle": "M* 441 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1888,8 +1888,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk3a",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk3a",
                             "sigle": "M* 441 Sk3",
                             "sigleAddendum": "T. {1A}",
                             "selectable": false,
@@ -1903,8 +1903,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk3b",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk3b",
                             "sigle": "M* 441 Sk3",
                             "sigleAddendum": "T. {1B–4}",
                             "selectable": false,
@@ -1918,8 +1918,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk4",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk4",
                             "sigle": "M* 441 Sk4",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1989,8 +1989,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk4_1",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk4_1",
                             "sigle": "M* 441 Sk4.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2004,8 +2004,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar442",
-                            "sheetId": "Mstar_442_Sk1a",
+                            "complexId": "mx442",
+                            "sheetId": "Mx_442_Sk1a",
                             "sigle": "M* 442 Sk1",
                             "sigleAddendum": "T. 1–6",
                             "selectable": false,
@@ -2019,8 +2019,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar442",
-                            "sheetId": "Mstar_442_Sk1b",
+                            "complexId": "mx442",
+                            "sheetId": "Mx_442_Sk1b",
                             "sigle": "M* 442 Sk1",
                             "sigleAddendum": "T. 7A–8C",
                             "selectable": false,
@@ -2034,8 +2034,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar443",
-                            "sheetId": "Mstar_443_Sk1",
+                            "complexId": "mx443",
+                            "sheetId": "Mx_443_Sk1",
                             "sigle": "M* 443 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2124,8 +2124,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar444",
-                            "sheetId": "Mstar_444_Sk1",
+                            "complexId": "mx444",
+                            "sheetId": "Mx_444_Sk1",
                             "sigle": "M* 444 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2154,8 +2154,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar445",
-                            "sheetId": "Mstar_445_Sk1",
+                            "complexId": "mx445",
+                            "sheetId": "Mx_445_Sk1",
                             "sigle": "M* 445 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2184,8 +2184,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar446",
-                            "sheetId": "Mstar_446_Sk1a",
+                            "complexId": "mx446",
+                            "sheetId": "Mx_446_Sk1a",
                             "sigle": "M* 446 Sk1",
                             "sigleAddendum": "T. 1–7",
                             "selectable": false,
@@ -2199,8 +2199,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar446",
-                            "sheetId": "Mstar_446_Sk1b",
+                            "complexId": "mx446",
+                            "sheetId": "Mx_446_Sk1b",
                             "sigle": "M* 446 Sk1",
                             "sigleAddendum": "T. 8–10",
                             "selectable": false,
@@ -2259,8 +2259,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar447",
-                            "sheetId": "Mstar_447_Sk1",
+                            "complexId": "mx447",
+                            "sheetId": "Mx_447_Sk1",
                             "sigle": "M* 447 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2284,8 +2284,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar448",
-                            "sheetId": "Mstar_448_Sk1a",
+                            "complexId": "mx448",
+                            "sheetId": "Mx_448_Sk1a",
                             "sigle": "M* 448 Sk1",
                             "sigleAddendum": "T. 1–7C",
                             "selectable": false,
@@ -2299,8 +2299,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar448",
-                            "sheetId": "Mstar_448_Sk1b",
+                            "complexId": "mx448",
+                            "sheetId": "Mx_448_Sk1b",
                             "sigle": "M* 448 Sk1",
                             "sigleAddendum": "T. 8C–10B",
                             "selectable": false,
@@ -2329,8 +2329,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar449",
-                            "sheetId": "Mstar_449_Sk1",
+                            "complexId": "mx449",
+                            "sheetId": "Mx_449_Sk1",
                             "sigle": "M* 449 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2374,8 +2374,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar450",
-                            "sheetId": "Mstar_450_Sk2_1",
+                            "complexId": "mx450",
+                            "sheetId": "Mx_450_Sk2_1",
                             "sigle": "M* 450 Sk2.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2389,8 +2389,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar450",
-                            "sheetId": "Mstar_450_Sk1",
+                            "complexId": "mx450",
+                            "sheetId": "Mx_450_Sk1",
                             "sigle": "M* 450 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2404,8 +2404,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar450",
-                            "sheetId": "Mstar_450_Sk2",
+                            "complexId": "mx450",
+                            "sheetId": "Mx_450_Sk2",
                             "sigle": "M* 450 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2434,8 +2434,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar450",
-                            "sheetId": "Mstar_450_Sk2_2",
+                            "complexId": "mx450",
+                            "sheetId": "Mx_450_Sk2_2",
                             "sigle": "M* 450 Sk2.2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2449,8 +2449,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar451",
-                            "sheetId": "Mstar_451_Sk1",
+                            "complexId": "mx451",
+                            "sheetId": "Mx_451_Sk1",
                             "sigle": "M* 451 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2464,8 +2464,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar451",
-                            "sheetId": "Mstar_451_Sk3a",
+                            "complexId": "mx451",
+                            "sheetId": "Mx_451_Sk3a",
                             "sigle": "M* 451 Sk3",
                             "sigleAddendum": "T. 1–5A",
                             "selectable": false,
@@ -2479,8 +2479,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar451",
-                            "sheetId": "Mstar_451_Sk3b",
+                            "complexId": "mx451",
+                            "sheetId": "Mx_451_Sk3b",
                             "sigle": "M* 451 Sk3",
                             "sigleAddendum": "T. 5B–12",
                             "selectable": false,
@@ -2494,8 +2494,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar451",
-                            "sheetId": "Mstar_451_Sk2",
+                            "complexId": "mx451",
+                            "sheetId": "Mx_451_Sk2",
                             "sigle": "M* 451 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3363,8 +3363,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar420",
-                            "sheetId": "Mstar_420_TF1",
+                            "complexId": "mx420",
+                            "sheetId": "Mx_420_TF1",
                             "sigle": "M* 420 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3378,8 +3378,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_TF1",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_TF1",
                             "sigle": "M* 421 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3393,8 +3393,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar423",
-                            "sheetId": "Mstar_423_TF1",
+                            "complexId": "mx423",
+                            "sheetId": "Mx_423_TF1",
                             "sigle": "M* 423 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3408,8 +3408,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar422",
-                            "sheetId": "Mstar_422_TF1",
+                            "complexId": "mx422",
+                            "sheetId": "Mx_422_TF1",
                             "sigle": "M* 422 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3433,8 +3433,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar424",
-                            "sheetId": "Mstar_424_Sk1",
+                            "complexId": "mx424",
+                            "sheetId": "Mx_424_Sk1",
                             "sigle": "M* 424 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3448,8 +3448,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar425",
-                            "sheetId": "Mstar_425_Sk1",
+                            "complexId": "mx425",
+                            "sheetId": "Mx_425_Sk1",
                             "sigle": "M* 425 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3463,8 +3463,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1a",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1a",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3478,8 +3478,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar427",
-                            "sheetId": "Mstar_427_Sk1",
+                            "complexId": "mx427",
+                            "sheetId": "Mx_427_Sk1",
                             "sigle": "M* 427 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3493,8 +3493,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1b",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1b",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3508,8 +3508,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar428",
-                            "sheetId": "Mstar_428_Sk1",
+                            "complexId": "mx428",
+                            "sheetId": "Mx_428_Sk1",
                             "sigle": "M* 428 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3607,8 +3607,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar429",
-                            "sheetId": "Mstar_429_Sk1",
+                            "complexId": "mx429",
+                            "sheetId": "Mx_429_Sk1",
                             "sigle": "M* 429 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3664,8 +3664,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar430",
-                            "sheetId": "Mstar_430_Sk1",
+                            "complexId": "mx430",
+                            "sheetId": "Mx_430_Sk1",
                             "sigle": "M* 430 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3693,8 +3693,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk2",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk2",
                             "sigle": "M* 431 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3708,8 +3708,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk1",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk1",
                             "sigle": "M* 431 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -3723,8 +3723,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1a",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1a",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. {1A}–2C",
                             "selectable": false,
@@ -3738,8 +3738,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1b",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1b",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. 3–6",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m23/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m23/folio-convolute.json
@@ -140,8 +140,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar417",
-                            "sheetId": "Mstar_417_Sk1",
+                            "complexId": "mx417",
+                            "sheetId": "Mx_417_Sk1",
                             "sigle": "M* 417 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -155,8 +155,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar418",
-                            "sheetId": "Mstar_418_Sk1",
+                            "complexId": "mx418",
+                            "sheetId": "Mx_418_Sk1",
                             "sigle": "M* 418 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -170,8 +170,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar419",
-                            "sheetId": "Mstar_419_Sk1",
+                            "complexId": "mx419",
+                            "sheetId": "Mx_419_Sk1",
                             "sigle": "M* 419 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -227,8 +227,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar420",
-                            "sheetId": "Mstar_420_Sk1",
+                            "complexId": "mx420",
+                            "sheetId": "Mx_420_Sk1",
                             "sigle": "M* 420 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -242,8 +242,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_Sk1a",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_Sk1a",
                             "sigle": "M* 421 Sk1",
                             "sigleAddendum": "T. {1A}–{1D}",
                             "selectable": false,
@@ -257,8 +257,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_Sk1b",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_Sk1b",
                             "sigle": "M* 421 Sk1",
                             "sigleAddendum": "T. 1E–4",
                             "selectable": false,
@@ -272,8 +272,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar422",
-                            "sheetId": "Mstar_422_Sk1",
+                            "complexId": "mx422",
+                            "sheetId": "Mx_422_Sk1",
                             "sigle": "M* 422 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -312,8 +312,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar433",
-                            "sheetId": "Mstar_433_Sk1",
+                            "complexId": "mx433",
+                            "sheetId": "Mx_433_Sk1",
                             "sigle": "M* 433 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -327,8 +327,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar434",
-                            "sheetId": "Mstar_434_Sk1",
+                            "complexId": "mx434",
+                            "sheetId": "Mx_434_Sk1",
                             "sigle": "M* 434 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -342,8 +342,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar434",
-                            "sheetId": "Mstar_434_Sk1_1",
+                            "complexId": "mx434",
+                            "sheetId": "Mx_434_Sk1_1",
                             "sigle": "M* 434 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -357,8 +357,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar435",
-                            "sheetId": "Mstar_435_Sk1",
+                            "complexId": "mx435",
+                            "sheetId": "Mx_435_Sk1",
                             "sigle": "M* 435 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -372,8 +372,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar436",
-                            "sheetId": "Mstar_436_Sk1",
+                            "complexId": "mx436",
+                            "sheetId": "Mx_436_Sk1",
                             "sigle": "M* 436 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -387,8 +387,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar437",
-                            "sheetId": "Mstar_437_Sk1",
+                            "complexId": "mx437",
+                            "sheetId": "Mx_437_Sk1",
                             "sigle": "M* 437 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -581,8 +581,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar438",
-                            "sheetId": "Mstar_438_Sk1",
+                            "complexId": "mx438",
+                            "sheetId": "Mx_438_Sk1",
                             "sigle": "M* 438 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -596,8 +596,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar439",
-                            "sheetId": "Mstar_439_Sk1a",
+                            "complexId": "mx439",
+                            "sheetId": "Mx_439_Sk1a",
                             "sigle": "M* 439 Sk1",
                             "sigleAddendum": "T. 1–6",
                             "selectable": false,
@@ -611,8 +611,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar439",
-                            "sheetId": "Mstar_439_Sk1b",
+                            "complexId": "mx439",
+                            "sheetId": "Mx_439_Sk1b",
                             "sigle": "M* 439 Sk1",
                             "sigleAddendum": "T. 7–8",
                             "selectable": false,
@@ -626,8 +626,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar440",
-                            "sheetId": "Mstar_440_Sk1a",
+                            "complexId": "mx440",
+                            "sheetId": "Mx_440_Sk1a",
                             "sigle": "M* 440 Sk1",
                             "sigleAddendum": "T. 1–6",
                             "selectable": false,
@@ -641,8 +641,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar440",
-                            "sheetId": "Mstar_440_Sk1b",
+                            "complexId": "mx440",
+                            "sheetId": "Mx_440_Sk1b",
                             "sigle": "M* 440 Sk1",
                             "sigleAddendum": "T. 7–8",
                             "selectable": false,
@@ -656,8 +656,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk1",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk1",
                             "sigle": "M* 441 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -671,8 +671,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk2",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk2",
                             "sigle": "M* 441 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -686,8 +686,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk3a",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk3a",
                             "sigle": "M* 441 Sk3",
                             "sigleAddendum": "T. {1A}",
                             "selectable": false,
@@ -701,8 +701,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk3b",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk3b",
                             "sigle": "M* 441 Sk3",
                             "sigleAddendum": "T. {1B–4}",
                             "selectable": false,
@@ -716,8 +716,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk4",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk4",
                             "sigle": "M* 441 Sk4",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -787,8 +787,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar441",
-                            "sheetId": "Mstar_441_Sk4_1",
+                            "complexId": "mx441",
+                            "sheetId": "Mx_441_Sk4_1",
                             "sigle": "M* 441 Sk4.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -802,8 +802,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar442",
-                            "sheetId": "Mstar_442_Sk1a",
+                            "complexId": "mx442",
+                            "sheetId": "Mx_442_Sk1a",
                             "sigle": "M* 442 Sk1",
                             "sigleAddendum": "T. 1–6",
                             "selectable": false,
@@ -817,8 +817,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar442",
-                            "sheetId": "Mstar_442_Sk1b",
+                            "complexId": "mx442",
+                            "sheetId": "Mx_442_Sk1b",
                             "sigle": "M* 442 Sk1",
                             "sigleAddendum": "T. 7A–8C",
                             "selectable": false,
@@ -832,8 +832,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar443",
-                            "sheetId": "Mstar_443_Sk1",
+                            "complexId": "mx443",
+                            "sheetId": "Mx_443_Sk1",
                             "sigle": "M* 443 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -922,8 +922,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar444",
-                            "sheetId": "Mstar_444_Sk1",
+                            "complexId": "mx444",
+                            "sheetId": "Mx_444_Sk1",
                             "sigle": "M* 444 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -952,8 +952,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar445",
-                            "sheetId": "Mstar_445_Sk1",
+                            "complexId": "mx445",
+                            "sheetId": "Mx_445_Sk1",
                             "sigle": "M* 445 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -982,8 +982,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar446",
-                            "sheetId": "Mstar_446_Sk1a",
+                            "complexId": "mx446",
+                            "sheetId": "Mx_446_Sk1a",
                             "sigle": "M* 446 Sk1",
                             "sigleAddendum": "T. 1–7",
                             "selectable": false,
@@ -997,8 +997,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar446",
-                            "sheetId": "Mstar_446_Sk1b",
+                            "complexId": "mx446",
+                            "sheetId": "Mx_446_Sk1b",
                             "sigle": "M* 446 Sk1",
                             "sigleAddendum": "T. 8–10",
                             "selectable": false,
@@ -1057,8 +1057,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar447",
-                            "sheetId": "Mstar_447_Sk1",
+                            "complexId": "mx447",
+                            "sheetId": "Mx_447_Sk1",
                             "sigle": "M* 447 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1082,8 +1082,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar448",
-                            "sheetId": "Mstar_448_Sk1a",
+                            "complexId": "mx448",
+                            "sheetId": "Mx_448_Sk1a",
                             "sigle": "M* 448 Sk1",
                             "sigleAddendum": "T. 1–7C",
                             "selectable": false,
@@ -1097,8 +1097,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar448",
-                            "sheetId": "Mstar_448_Sk1b",
+                            "complexId": "mx448",
+                            "sheetId": "Mx_448_Sk1b",
                             "sigle": "M* 448 Sk1",
                             "sigleAddendum": "T. 8C–10B",
                             "selectable": false,
@@ -1127,8 +1127,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar449",
-                            "sheetId": "Mstar_449_Sk1",
+                            "complexId": "mx449",
+                            "sheetId": "Mx_449_Sk1",
                             "sigle": "M* 449 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1172,8 +1172,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar450",
-                            "sheetId": "Mstar_450_Sk2_1",
+                            "complexId": "mx450",
+                            "sheetId": "Mx_450_Sk2_1",
                             "sigle": "M* 450 Sk2.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1187,8 +1187,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar450",
-                            "sheetId": "Mstar_450_Sk1",
+                            "complexId": "mx450",
+                            "sheetId": "Mx_450_Sk1",
                             "sigle": "M* 450 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1202,8 +1202,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar450",
-                            "sheetId": "Mstar_450_Sk2",
+                            "complexId": "mx450",
+                            "sheetId": "Mx_450_Sk2",
                             "sigle": "M* 450 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1232,8 +1232,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar450",
-                            "sheetId": "Mstar_450_Sk2_2",
+                            "complexId": "mx450",
+                            "sheetId": "Mx_450_Sk2_2",
                             "sigle": "M* 450 Sk2.2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1247,8 +1247,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar451",
-                            "sheetId": "Mstar_451_Sk1",
+                            "complexId": "mx451",
+                            "sheetId": "Mx_451_Sk1",
                             "sigle": "M* 451 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1262,8 +1262,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar451",
-                            "sheetId": "Mstar_451_Sk3a",
+                            "complexId": "mx451",
+                            "sheetId": "Mx_451_Sk3a",
                             "sigle": "M* 451 Sk3",
                             "sigleAddendum": "T. 1–5A",
                             "selectable": false,
@@ -1277,8 +1277,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar451",
-                            "sheetId": "Mstar_451_Sk3b",
+                            "complexId": "mx451",
+                            "sheetId": "Mx_451_Sk3b",
                             "sigle": "M* 451 Sk3",
                             "sigleAddendum": "T. 5B–12",
                             "selectable": false,
@@ -1292,8 +1292,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar451",
-                            "sheetId": "Mstar_451_Sk2",
+                            "complexId": "mx451",
+                            "sheetId": "Mx_451_Sk2",
                             "sigle": "M* 451 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2161,8 +2161,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar420",
-                            "sheetId": "Mstar_420_TF1",
+                            "complexId": "mx420",
+                            "sheetId": "Mx_420_TF1",
                             "sigle": "M* 420 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2176,8 +2176,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_TF1",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_TF1",
                             "sigle": "M* 421 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2191,8 +2191,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar423",
-                            "sheetId": "Mstar_423_TF1",
+                            "complexId": "mx423",
+                            "sheetId": "Mx_423_TF1",
                             "sigle": "M* 423 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2206,8 +2206,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar422",
-                            "sheetId": "Mstar_422_TF1",
+                            "complexId": "mx422",
+                            "sheetId": "Mx_422_TF1",
                             "sigle": "M* 422 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2231,8 +2231,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar424",
-                            "sheetId": "Mstar_424_Sk1",
+                            "complexId": "mx424",
+                            "sheetId": "Mx_424_Sk1",
                             "sigle": "M* 424 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2246,8 +2246,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar425",
-                            "sheetId": "Mstar_425_Sk1",
+                            "complexId": "mx425",
+                            "sheetId": "Mx_425_Sk1",
                             "sigle": "M* 425 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2261,8 +2261,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1a",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1a",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2276,8 +2276,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar427",
-                            "sheetId": "Mstar_427_Sk1",
+                            "complexId": "mx427",
+                            "sheetId": "Mx_427_Sk1",
                             "sigle": "M* 427 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2291,8 +2291,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1b",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1b",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2306,8 +2306,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar428",
-                            "sheetId": "Mstar_428_Sk1",
+                            "complexId": "mx428",
+                            "sheetId": "Mx_428_Sk1",
                             "sigle": "M* 428 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2405,8 +2405,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar429",
-                            "sheetId": "Mstar_429_Sk1",
+                            "complexId": "mx429",
+                            "sheetId": "Mx_429_Sk1",
                             "sigle": "M* 429 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2462,8 +2462,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar430",
-                            "sheetId": "Mstar_430_Sk1",
+                            "complexId": "mx430",
+                            "sheetId": "Mx_430_Sk1",
                             "sigle": "M* 430 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2491,8 +2491,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk2",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk2",
                             "sigle": "M* 431 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2506,8 +2506,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk1",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk1",
                             "sigle": "M* 431 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -2521,8 +2521,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1a",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1a",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. {1A}–2C",
                             "selectable": false,
@@ -2536,8 +2536,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1b",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1b",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. 3–6",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m29/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m29/folio-convolute.json
@@ -27,8 +27,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar400",
-                            "sheetId": "Mstar_400_Sk1",
+                            "complexId": "mx400",
+                            "sheetId": "Mx_400_Sk1",
                             "sigle": "M* 400 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -197,8 +197,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1a",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1a",
                             "sigle": "M* 401 Sk1",
                             "sigleAddendum": "T. 1–11",
                             "selectable": false,
@@ -212,8 +212,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1b",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1b",
                             "sigle": "M* 401 Sk1",
                             "sigleAddendum": "T. 12–16",
                             "selectable": false,
@@ -227,8 +227,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1_1",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1_1",
                             "sigle": "M* 401 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -242,8 +242,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1_2",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1_2",
                             "sigle": "M* 401 Sk1.2",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m30/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m30/folio-convolute.json
@@ -111,8 +111,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk1a",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk1a",
                             "sigle": "M* 403 Sk1",
                             "sigleAddendum": "T. 1–10",
                             "selectable": false,
@@ -127,8 +127,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk1b",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk1b",
                             "sigle": "M* 403 Sk1",
                             "sigleAddendum": "T. 11–15",
                             "selectable": false,
@@ -304,8 +304,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk2a",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk2a",
                             "sigle": "M* 403 Sk2",
                             "sigleAddendum": "T. 1–8",
                             "selectable": false,
@@ -320,8 +320,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk2b",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk2b",
                             "sigle": "M* 403 Sk2",
                             "sigleAddendum": "T. 9–12",
                             "selectable": false,
@@ -336,8 +336,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk2c",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk2c",
                             "sigle": "M* 403 Sk2",
                             "sigleAddendum": "T. 13–15",
                             "selectable": false,
@@ -352,8 +352,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk2d",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk2d",
                             "sigle": "M* 403 Sk2",
                             "sigleAddendum": "T. x+16 bis x+23",
                             "selectable": false,
@@ -697,8 +697,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar402",
-                            "sheetId": "Mstar_402_Sk1a",
+                            "complexId": "mx402",
+                            "sheetId": "Mx_402_Sk1a",
                             "sigle": "M* 402 Sk1",
                             "sigleAddendum": "T. 1–5",
                             "selectable": false,
@@ -712,8 +712,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar402",
-                            "sheetId": "Mstar_402_Sk1b",
+                            "complexId": "mx402",
+                            "sheetId": "Mx_402_Sk1b",
                             "sigle": "M* 402 Sk1 T. 6–9",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m31/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m31/folio-convolute.json
@@ -111,8 +111,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk1a",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk1a",
                             "sigle": "M* 403 Sk1",
                             "sigleAddendum": "T. 1–10",
                             "selectable": false,
@@ -127,8 +127,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk1b",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk1b",
                             "sigle": "M* 403 Sk1",
                             "sigleAddendum": "T. 11–15",
                             "selectable": false,
@@ -304,8 +304,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk2a",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk2a",
                             "sigle": "M* 403 Sk2",
                             "sigleAddendum": "T. 1–8",
                             "selectable": false,
@@ -320,8 +320,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk2b",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk2b",
                             "sigle": "M* 403 Sk2",
                             "sigleAddendum": "T. 9–12",
                             "selectable": false,
@@ -336,8 +336,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk2c",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk2c",
                             "sigle": "M* 403 Sk2",
                             "sigleAddendum": "T. 13–15",
                             "selectable": false,
@@ -352,8 +352,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar403",
-                            "sheetId": "Mstar_403_Sk2d",
+                            "complexId": "mx403",
+                            "sheetId": "Mx_403_Sk2d",
                             "sigle": "M* 403 Sk2",
                             "sigleAddendum": "T. x+16 bis x+23",
                             "selectable": false,
@@ -697,8 +697,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar402",
-                            "sheetId": "Mstar_402_Sk1a",
+                            "complexId": "mx402",
+                            "sheetId": "Mx_402_Sk1a",
                             "sigle": "M* 402 Sk1",
                             "sigleAddendum": "T. 1–5",
                             "selectable": false,
@@ -712,8 +712,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar402",
-                            "sheetId": "Mstar_402_Sk1b",
+                            "complexId": "mx402",
+                            "sheetId": "Mx_402_Sk1b",
                             "sigle": "M* 402 Sk1 T. 6–9",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m32/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m32/folio-convolute.json
@@ -856,8 +856,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar454",
-                            "sheetId": "Mstar_454_Sk1",
+                            "complexId": "mx454",
+                            "sheetId": "Mx_454_Sk1",
                             "sigle": "M* 454 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m33/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m33/folio-convolute.json
@@ -230,8 +230,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar454",
-                            "sheetId": "Mstar_454_Sk1",
+                            "complexId": "mx454",
+                            "sheetId": "Mx_454_Sk1",
                             "sigle": "M* 454 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m34/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m34/folio-convolute.json
@@ -178,8 +178,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1a",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1a",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 1–{5A}",
                             "selectable": false,
@@ -193,8 +193,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1b",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1b",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 5B–7B",
                             "selectable": false,
@@ -208,8 +208,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1c",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1c",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 8A–11",
                             "selectable": false,
@@ -223,8 +223,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1d",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1d",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 12–15",
                             "selectable": false,
@@ -238,8 +238,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1e",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1e",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 16",
                             "selectable": false,
@@ -253,8 +253,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_1",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_1",
                             "sigle": "M* 404 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -268,8 +268,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_2",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_2",
                             "sigle": "M* 404 Sk1.2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -283,8 +283,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_3",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_3",
                             "sigle": "M* 404 Sk1.3",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -298,8 +298,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_4",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_4",
                             "sigle": "M* 404 Sk1.4",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m35_42/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m35_42/folio-convolute.json
@@ -178,8 +178,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1a",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1a",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 1–{5A}",
                             "selectable": false,
@@ -193,8 +193,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1b",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1b",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 5B–7B",
                             "selectable": false,
@@ -208,8 +208,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1c",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1c",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 8A–11",
                             "selectable": false,
@@ -223,8 +223,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1d",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1d",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 12–15",
                             "selectable": false,
@@ -238,8 +238,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1e",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1e",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 16",
                             "selectable": false,
@@ -253,8 +253,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_1",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_1",
                             "sigle": "M* 404 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -268,8 +268,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_2",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_2",
                             "sigle": "M* 404 Sk1.2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -283,8 +283,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_3",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_3",
                             "sigle": "M* 404 Sk1.3",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -298,8 +298,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_4",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_4",
                             "sigle": "M* 404 Sk1.4",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1441,8 +1441,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1a",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1a",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 1–6",
                             "selectable": false,
@@ -1456,8 +1456,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1b",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1b",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 7–{11A}",
                             "selectable": false,
@@ -1471,8 +1471,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1c",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1c",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 11B–14",
                             "selectable": false,
@@ -1486,8 +1486,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1d",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1d",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 15A–16B",
                             "selectable": false,
@@ -1501,8 +1501,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1e",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1e",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 17–18",
                             "selectable": false,
@@ -1526,8 +1526,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar406",
-                            "sheetId": "Mstar_406_Sk1",
+                            "complexId": "mx406",
+                            "sheetId": "Mx_406_Sk1",
                             "sigle": "M* 406 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m36/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m36/folio-convolute.json
@@ -178,8 +178,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1a",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1a",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 1–{5A}",
                             "selectable": false,
@@ -193,8 +193,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1b",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1b",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 5B–7B",
                             "selectable": false,
@@ -208,8 +208,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1c",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1c",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 8A–11",
                             "selectable": false,
@@ -223,8 +223,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1d",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1d",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 12–15",
                             "selectable": false,
@@ -238,8 +238,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1e",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1e",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 16",
                             "selectable": false,
@@ -253,8 +253,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_1",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_1",
                             "sigle": "M* 404 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -268,8 +268,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_2",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_2",
                             "sigle": "M* 404 Sk1.2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -283,8 +283,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_3",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_3",
                             "sigle": "M* 404 Sk1.3",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -298,8 +298,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_4",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_4",
                             "sigle": "M* 404 Sk1.4",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m37/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m37/folio-convolute.json
@@ -178,8 +178,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1a",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1a",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 1–{5A}",
                             "selectable": false,
@@ -193,8 +193,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1b",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1b",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 5B–7B",
                             "selectable": false,
@@ -208,8 +208,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1c",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1c",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 8A–11",
                             "selectable": false,
@@ -223,8 +223,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1d",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1d",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 12–15",
                             "selectable": false,
@@ -238,8 +238,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1e",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1e",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 16",
                             "selectable": false,
@@ -253,8 +253,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_1",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_1",
                             "sigle": "M* 404 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -268,8 +268,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_2",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_2",
                             "sigle": "M* 404 Sk1.2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -283,8 +283,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_3",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_3",
                             "sigle": "M* 404 Sk1.3",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -298,8 +298,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_4",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_4",
                             "sigle": "M* 404 Sk1.4",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m38/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m38/folio-convolute.json
@@ -178,8 +178,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1a",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1a",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 1–{5A}",
                             "selectable": false,
@@ -193,8 +193,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1b",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1b",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 5B–7B",
                             "selectable": false,
@@ -208,8 +208,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1c",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1c",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 8A–11",
                             "selectable": false,
@@ -223,8 +223,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1d",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1d",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 12–15",
                             "selectable": false,
@@ -238,8 +238,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1e",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1e",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 16",
                             "selectable": false,
@@ -253,8 +253,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_1",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_1",
                             "sigle": "M* 404 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -268,8 +268,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_2",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_2",
                             "sigle": "M* 404 Sk1.2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -283,8 +283,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_3",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_3",
                             "sigle": "M* 404 Sk1.3",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -298,8 +298,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_4",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_4",
                             "sigle": "M* 404 Sk1.4",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m39/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m39/folio-convolute.json
@@ -178,8 +178,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1a",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1a",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 1–{5A}",
                             "selectable": false,
@@ -193,8 +193,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1b",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1b",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 5B–7B",
                             "selectable": false,
@@ -208,8 +208,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1c",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1c",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 8A–11",
                             "selectable": false,
@@ -223,8 +223,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1d",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1d",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 12–15",
                             "selectable": false,
@@ -238,8 +238,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1e",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1e",
                             "sigle": "M* 404 Sk1",
                             "sigleAddendum": "T. 16",
                             "selectable": false,
@@ -253,8 +253,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_1",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_1",
                             "sigle": "M* 404 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -268,8 +268,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_2",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_2",
                             "sigle": "M* 404 Sk1.2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -283,8 +283,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_3",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_3",
                             "sigle": "M* 404 Sk1.3",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -298,8 +298,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar404",
-                            "sheetId": "Mstar_404_Sk1_4",
+                            "complexId": "mx404",
+                            "sheetId": "Mx_404_Sk1_4",
                             "sigle": "M* 404 Sk1.4",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1441,8 +1441,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1a",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1a",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 1–6",
                             "selectable": false,
@@ -1456,8 +1456,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1b",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1b",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 7–{11A}",
                             "selectable": false,
@@ -1471,8 +1471,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1c",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1c",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 11B–14",
                             "selectable": false,
@@ -1486,8 +1486,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1d",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1d",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 15A–16B",
                             "selectable": false,
@@ -1501,8 +1501,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1e",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1e",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 17–18",
                             "selectable": false,
@@ -1526,8 +1526,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar406",
-                            "sheetId": "Mstar_406_Sk1",
+                            "complexId": "mx406",
+                            "sheetId": "Mx_406_Sk1",
                             "sigle": "M* 406 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m40/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m40/folio-convolute.json
@@ -301,8 +301,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1a",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1a",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 1–6",
                             "selectable": false,
@@ -316,8 +316,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1b",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1b",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 7–{11A}",
                             "selectable": false,
@@ -331,8 +331,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1c",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1c",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 11B–14",
                             "selectable": false,
@@ -346,8 +346,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1d",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1d",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 15A–16B",
                             "selectable": false,
@@ -361,8 +361,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1e",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1e",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 17–18",
                             "selectable": false,
@@ -386,8 +386,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar406",
-                            "sheetId": "Mstar_406_Sk1",
+                            "complexId": "mx406",
+                            "sheetId": "Mx_406_Sk1",
                             "sigle": "M* 406 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m41/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m41/folio-convolute.json
@@ -301,8 +301,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1a",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1a",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 1–6",
                             "selectable": false,
@@ -316,8 +316,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1b",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1b",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 7–{11A}",
                             "selectable": false,
@@ -331,8 +331,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1c",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1c",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 11B–14",
                             "selectable": false,
@@ -346,8 +346,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1d",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1d",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 15A–16B",
                             "selectable": false,
@@ -361,8 +361,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar405",
-                            "sheetId": "Mstar_405_Sk1e",
+                            "complexId": "mx405",
+                            "sheetId": "Mx_405_Sk1e",
                             "sigle": "M* 405 Sk1",
                             "sigleAddendum": "T. 17–18",
                             "selectable": false,
@@ -386,8 +386,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar406",
-                            "sheetId": "Mstar_406_Sk1",
+                            "complexId": "mx406",
+                            "sheetId": "Mx_406_Sk1",
                             "sigle": "M* 406 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/m46/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/m46/folio-convolute.json
@@ -101,8 +101,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar407",
-                            "sheetId": "Mstar_407_Sk1_1",
+                            "complexId": "mx407",
+                            "sheetId": "Mx_407_Sk1_1",
                             "sigle": "M* 407 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -116,8 +116,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar407",
-                            "sheetId": "Mstar_407_Sk1",
+                            "complexId": "mx407",
+                            "sheetId": "Mx_407_Sk1",
                             "sigle": "M* 407 Sk1",
                             "sigleAddendum": "T. 1–7",
                             "selectable": false,
@@ -131,8 +131,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar407",
-                            "sheetId": "Mstar_407_Sk1",
+                            "complexId": "mx407",
+                            "sheetId": "Mx_407_Sk1",
                             "sigle": "M* 407 Sk1",
                             "sigleAddendum": "T. 8–13",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/mx409/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/mx409/folio-convolute.json
@@ -791,8 +791,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar420",
-                            "sheetId": "Mstar_420_TF1",
+                            "complexId": "mx420",
+                            "sheetId": "Mx_420_TF1",
                             "sigle": "M* 420 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -806,8 +806,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_TF1",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_TF1",
                             "sigle": "M* 421 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -821,8 +821,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar423",
-                            "sheetId": "Mstar_423_TF1",
+                            "complexId": "mx423",
+                            "sheetId": "Mx_423_TF1",
                             "sigle": "M* 423 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -836,8 +836,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar422",
-                            "sheetId": "Mstar_422_TF1",
+                            "complexId": "mx422",
+                            "sheetId": "Mx_422_TF1",
                             "sigle": "M* 422 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -861,8 +861,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar424",
-                            "sheetId": "Mstar_424_Sk1",
+                            "complexId": "mx424",
+                            "sheetId": "Mx_424_Sk1",
                             "sigle": "M* 424 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -876,8 +876,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar425",
-                            "sheetId": "Mstar_425_Sk1",
+                            "complexId": "mx425",
+                            "sheetId": "Mx_425_Sk1",
                             "sigle": "M* 425 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -891,8 +891,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1a",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1a",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -906,8 +906,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar427",
-                            "sheetId": "Mstar_427_Sk1",
+                            "complexId": "mx427",
+                            "sheetId": "Mx_427_Sk1",
                             "sigle": "M* 427 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -921,8 +921,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1b",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1b",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -936,8 +936,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar428",
-                            "sheetId": "Mstar_428_Sk1",
+                            "complexId": "mx428",
+                            "sheetId": "Mx_428_Sk1",
                             "sigle": "M* 428 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1035,8 +1035,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar429",
-                            "sheetId": "Mstar_429_Sk1",
+                            "complexId": "mx429",
+                            "sheetId": "Mx_429_Sk1",
                             "sigle": "M* 429 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1092,8 +1092,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar430",
-                            "sheetId": "Mstar_430_Sk1",
+                            "complexId": "mx430",
+                            "sheetId": "Mx_430_Sk1",
                             "sigle": "M* 430 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1121,8 +1121,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk2",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk2",
                             "sigle": "M* 431 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1136,8 +1136,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk1",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk1",
                             "sigle": "M* 431 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1151,8 +1151,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1a",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1a",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. {1A}–2C",
                             "selectable": false,
@@ -1166,8 +1166,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1b",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1b",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. 3–6",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/mx410/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/mx410/folio-convolute.json
@@ -791,8 +791,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar420",
-                            "sheetId": "Mstar_420_TF1",
+                            "complexId": "mx420",
+                            "sheetId": "Mx_420_TF1",
                             "sigle": "M* 420 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -806,8 +806,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_TF1",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_TF1",
                             "sigle": "M* 421 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -821,8 +821,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar423",
-                            "sheetId": "Mstar_423_TF1",
+                            "complexId": "mx423",
+                            "sheetId": "Mx_423_TF1",
                             "sigle": "M* 423 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -836,8 +836,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar422",
-                            "sheetId": "Mstar_422_TF1",
+                            "complexId": "mx422",
+                            "sheetId": "Mx_422_TF1",
                             "sigle": "M* 422 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -861,8 +861,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar424",
-                            "sheetId": "Mstar_424_Sk1",
+                            "complexId": "mx424",
+                            "sheetId": "Mx_424_Sk1",
                             "sigle": "M* 424 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -876,8 +876,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar425",
-                            "sheetId": "Mstar_425_Sk1",
+                            "complexId": "mx425",
+                            "sheetId": "Mx_425_Sk1",
                             "sigle": "M* 425 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -891,8 +891,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1a",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1a",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -906,8 +906,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar427",
-                            "sheetId": "Mstar_427_Sk1",
+                            "complexId": "mx427",
+                            "sheetId": "Mx_427_Sk1",
                             "sigle": "M* 427 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -921,8 +921,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1b",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1b",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -936,8 +936,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar428",
-                            "sheetId": "Mstar_428_Sk1",
+                            "complexId": "mx428",
+                            "sheetId": "Mx_428_Sk1",
                             "sigle": "M* 428 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1035,8 +1035,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar429",
-                            "sheetId": "Mstar_429_Sk1",
+                            "complexId": "mx429",
+                            "sheetId": "Mx_429_Sk1",
                             "sigle": "M* 429 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1092,8 +1092,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar430",
-                            "sheetId": "Mstar_430_Sk1",
+                            "complexId": "mx430",
+                            "sheetId": "Mx_430_Sk1",
                             "sigle": "M* 430 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1121,8 +1121,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk2",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk2",
                             "sigle": "M* 431 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1136,8 +1136,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk1",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk1",
                             "sigle": "M* 431 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1151,8 +1151,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1a",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1a",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. {1A}–2C",
                             "selectable": false,
@@ -1166,8 +1166,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1b",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1b",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. 3–6",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/mx412/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/mx412/folio-convolute.json
@@ -1234,8 +1234,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar420",
-                            "sheetId": "Mstar_420_TF1",
+                            "complexId": "mx420",
+                            "sheetId": "Mx_420_TF1",
                             "sigle": "M* 420 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1249,8 +1249,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_TF1",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_TF1",
                             "sigle": "M* 421 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1264,8 +1264,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar423",
-                            "sheetId": "Mstar_423_TF1",
+                            "complexId": "mx423",
+                            "sheetId": "Mx_423_TF1",
                             "sigle": "M* 423 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1279,8 +1279,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar422",
-                            "sheetId": "Mstar_422_TF1",
+                            "complexId": "mx422",
+                            "sheetId": "Mx_422_TF1",
                             "sigle": "M* 422 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1304,8 +1304,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar424",
-                            "sheetId": "Mstar_424_Sk1",
+                            "complexId": "mx424",
+                            "sheetId": "Mx_424_Sk1",
                             "sigle": "M* 424 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1319,8 +1319,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar425",
-                            "sheetId": "Mstar_425_Sk1",
+                            "complexId": "mx425",
+                            "sheetId": "Mx_425_Sk1",
                             "sigle": "M* 425 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1334,8 +1334,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1a",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1a",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1349,8 +1349,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar427",
-                            "sheetId": "Mstar_427_Sk1",
+                            "complexId": "mx427",
+                            "sheetId": "Mx_427_Sk1",
                             "sigle": "M* 427 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1364,8 +1364,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1b",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1b",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1379,8 +1379,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar428",
-                            "sheetId": "Mstar_428_Sk1",
+                            "complexId": "mx428",
+                            "sheetId": "Mx_428_Sk1",
                             "sigle": "M* 428 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1478,8 +1478,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar429",
-                            "sheetId": "Mstar_429_Sk1",
+                            "complexId": "mx429",
+                            "sheetId": "Mx_429_Sk1",
                             "sigle": "M* 429 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1535,8 +1535,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar430",
-                            "sheetId": "Mstar_430_Sk1",
+                            "complexId": "mx430",
+                            "sheetId": "Mx_430_Sk1",
                             "sigle": "M* 430 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1564,8 +1564,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk2",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk2",
                             "sigle": "M* 431 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1579,8 +1579,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk1",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk1",
                             "sigle": "M* 431 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1594,8 +1594,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1a",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1a",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. {1A}–2C",
                             "selectable": false,
@@ -1609,8 +1609,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1b",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1b",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. 3–6",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/mx413/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/mx413/folio-convolute.json
@@ -1234,8 +1234,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar420",
-                            "sheetId": "Mstar_420_TF1",
+                            "complexId": "mx420",
+                            "sheetId": "Mx_420_TF1",
                             "sigle": "M* 420 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1249,8 +1249,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_TF1",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_TF1",
                             "sigle": "M* 421 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1264,8 +1264,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar423",
-                            "sheetId": "Mstar_423_TF1",
+                            "complexId": "mx423",
+                            "sheetId": "Mx_423_TF1",
                             "sigle": "M* 423 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1279,8 +1279,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar422",
-                            "sheetId": "Mstar_422_TF1",
+                            "complexId": "mx422",
+                            "sheetId": "Mx_422_TF1",
                             "sigle": "M* 422 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1304,8 +1304,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar424",
-                            "sheetId": "Mstar_424_Sk1",
+                            "complexId": "mx424",
+                            "sheetId": "Mx_424_Sk1",
                             "sigle": "M* 424 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1319,8 +1319,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar425",
-                            "sheetId": "Mstar_425_Sk1",
+                            "complexId": "mx425",
+                            "sheetId": "Mx_425_Sk1",
                             "sigle": "M* 425 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1334,8 +1334,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1a",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1a",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1349,8 +1349,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar427",
-                            "sheetId": "Mstar_427_Sk1",
+                            "complexId": "mx427",
+                            "sheetId": "Mx_427_Sk1",
                             "sigle": "M* 427 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1364,8 +1364,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1b",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1b",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1379,8 +1379,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar428",
-                            "sheetId": "Mstar_428_Sk1",
+                            "complexId": "mx428",
+                            "sheetId": "Mx_428_Sk1",
                             "sigle": "M* 428 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1478,8 +1478,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar429",
-                            "sheetId": "Mstar_429_Sk1",
+                            "complexId": "mx429",
+                            "sheetId": "Mx_429_Sk1",
                             "sigle": "M* 429 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1535,8 +1535,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar430",
-                            "sheetId": "Mstar_430_Sk1",
+                            "complexId": "mx430",
+                            "sheetId": "Mx_430_Sk1",
                             "sigle": "M* 430 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1564,8 +1564,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk2",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk2",
                             "sigle": "M* 431 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1579,8 +1579,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk1",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk1",
                             "sigle": "M* 431 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1594,8 +1594,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1a",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1a",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. {1A}–2C",
                             "selectable": false,
@@ -1609,8 +1609,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1b",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1b",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. 3–6",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/mx414/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/mx414/folio-convolute.json
@@ -1234,8 +1234,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar420",
-                            "sheetId": "Mstar_420_TF1",
+                            "complexId": "mx420",
+                            "sheetId": "Mx_420_TF1",
                             "sigle": "M* 420 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1249,8 +1249,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_TF1",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_TF1",
                             "sigle": "M* 421 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1264,8 +1264,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar423",
-                            "sheetId": "Mstar_423_TF1",
+                            "complexId": "mx423",
+                            "sheetId": "Mx_423_TF1",
                             "sigle": "M* 423 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1279,8 +1279,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar422",
-                            "sheetId": "Mstar_422_TF1",
+                            "complexId": "mx422",
+                            "sheetId": "Mx_422_TF1",
                             "sigle": "M* 422 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1304,8 +1304,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar424",
-                            "sheetId": "Mstar_424_Sk1",
+                            "complexId": "mx424",
+                            "sheetId": "Mx_424_Sk1",
                             "sigle": "M* 424 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1319,8 +1319,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar425",
-                            "sheetId": "Mstar_425_Sk1",
+                            "complexId": "mx425",
+                            "sheetId": "Mx_425_Sk1",
                             "sigle": "M* 425 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1334,8 +1334,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1a",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1a",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1349,8 +1349,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar427",
-                            "sheetId": "Mstar_427_Sk1",
+                            "complexId": "mx427",
+                            "sheetId": "Mx_427_Sk1",
                             "sigle": "M* 427 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1364,8 +1364,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1b",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1b",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1379,8 +1379,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar428",
-                            "sheetId": "Mstar_428_Sk1",
+                            "complexId": "mx428",
+                            "sheetId": "Mx_428_Sk1",
                             "sigle": "M* 428 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1478,8 +1478,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar429",
-                            "sheetId": "Mstar_429_Sk1",
+                            "complexId": "mx429",
+                            "sheetId": "Mx_429_Sk1",
                             "sigle": "M* 429 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1535,8 +1535,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar430",
-                            "sheetId": "Mstar_430_Sk1",
+                            "complexId": "mx430",
+                            "sheetId": "Mx_430_Sk1",
                             "sigle": "M* 430 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1564,8 +1564,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk2",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk2",
                             "sigle": "M* 431 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1579,8 +1579,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk1",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk1",
                             "sigle": "M* 431 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1594,8 +1594,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1a",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1a",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. {1A}–2C",
                             "selectable": false,
@@ -1609,8 +1609,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1b",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1b",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. 3–6",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/mx415/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/mx415/folio-convolute.json
@@ -27,8 +27,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar400",
-                            "sheetId": "Mstar_400_Sk1",
+                            "complexId": "mx400",
+                            "sheetId": "Mx_400_Sk1",
                             "sigle": "M* 400 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -197,8 +197,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1a",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1a",
                             "sigle": "M* 401 Sk1",
                             "sigleAddendum": "T. 1–11",
                             "selectable": false,
@@ -212,8 +212,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1b",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1b",
                             "sigle": "M* 401 Sk1",
                             "sigleAddendum": "T. 12–16",
                             "selectable": false,
@@ -227,8 +227,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1_1",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1_1",
                             "sigle": "M* 401 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -242,8 +242,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1_2",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1_2",
                             "sigle": "M* 401 Sk1.2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1107,8 +1107,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar420",
-                            "sheetId": "Mstar_420_TF1",
+                            "complexId": "mx420",
+                            "sheetId": "Mx_420_TF1",
                             "sigle": "M* 420 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1122,8 +1122,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_TF1",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_TF1",
                             "sigle": "M* 421 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1137,8 +1137,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar423",
-                            "sheetId": "Mstar_423_TF1",
+                            "complexId": "mx423",
+                            "sheetId": "Mx_423_TF1",
                             "sigle": "M* 423 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1152,8 +1152,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar422",
-                            "sheetId": "Mstar_422_TF1",
+                            "complexId": "mx422",
+                            "sheetId": "Mx_422_TF1",
                             "sigle": "M* 422 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1177,8 +1177,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar424",
-                            "sheetId": "Mstar_424_Sk1",
+                            "complexId": "mx424",
+                            "sheetId": "Mx_424_Sk1",
                             "sigle": "M* 424 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1192,8 +1192,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar425",
-                            "sheetId": "Mstar_425_Sk1",
+                            "complexId": "mx425",
+                            "sheetId": "Mx_425_Sk1",
                             "sigle": "M* 425 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1207,8 +1207,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1a",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1a",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1222,8 +1222,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar427",
-                            "sheetId": "Mstar_427_Sk1",
+                            "complexId": "mx427",
+                            "sheetId": "Mx_427_Sk1",
                             "sigle": "M* 427 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1237,8 +1237,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1b",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1b",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1252,8 +1252,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar428",
-                            "sheetId": "Mstar_428_Sk1",
+                            "complexId": "mx428",
+                            "sheetId": "Mx_428_Sk1",
                             "sigle": "M* 428 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1351,8 +1351,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar429",
-                            "sheetId": "Mstar_429_Sk1",
+                            "complexId": "mx429",
+                            "sheetId": "Mx_429_Sk1",
                             "sigle": "M* 429 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1408,8 +1408,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar430",
-                            "sheetId": "Mstar_430_Sk1",
+                            "complexId": "mx430",
+                            "sheetId": "Mx_430_Sk1",
                             "sigle": "M* 430 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1437,8 +1437,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk2",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk2",
                             "sigle": "M* 431 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1452,8 +1452,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk1",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk1",
                             "sigle": "M* 431 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1467,8 +1467,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1a",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1a",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. {1A}–2C",
                             "selectable": false,
@@ -1482,8 +1482,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1b",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1b",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. 3–6",
                             "selectable": false,

--- a/src/assets/data/edition/series/2/section/2a/mx416/folio-convolute.json
+++ b/src/assets/data/edition/series/2/section/2a/mx416/folio-convolute.json
@@ -27,8 +27,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar400",
-                            "sheetId": "Mstar_400_Sk1",
+                            "complexId": "mx400",
+                            "sheetId": "Mx_400_Sk1",
                             "sigle": "M* 400 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -197,8 +197,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1a",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1a",
                             "sigle": "M* 401 Sk1",
                             "sigleAddendum": "T. 1–11",
                             "selectable": false,
@@ -212,8 +212,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1b",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1b",
                             "sigle": "M* 401 Sk1",
                             "sigleAddendum": "T. 12–16",
                             "selectable": false,
@@ -227,8 +227,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1_1",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1_1",
                             "sigle": "M* 401 Sk1.1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -242,8 +242,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar401",
-                            "sheetId": "Mstar_401_Sk1_2",
+                            "complexId": "mx401",
+                            "sheetId": "Mx_401_Sk1_2",
                             "sigle": "M* 401 Sk1.2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1107,8 +1107,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar420",
-                            "sheetId": "Mstar_420_TF1",
+                            "complexId": "mx420",
+                            "sheetId": "Mx_420_TF1",
                             "sigle": "M* 420 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1122,8 +1122,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar421",
-                            "sheetId": "Mstar_421_TF1",
+                            "complexId": "mx421",
+                            "sheetId": "Mx_421_TF1",
                             "sigle": "M* 421 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1137,8 +1137,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar423",
-                            "sheetId": "Mstar_423_TF1",
+                            "complexId": "mx423",
+                            "sheetId": "Mx_423_TF1",
                             "sigle": "M* 423 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1152,8 +1152,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar422",
-                            "sheetId": "Mstar_422_TF1",
+                            "complexId": "mx422",
+                            "sheetId": "Mx_422_TF1",
                             "sigle": "M* 422 Tintenniederschrift TF1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1177,8 +1177,8 @@
                     },
                     "content": [
                         {
-                            "complexId": "mstar424",
-                            "sheetId": "Mstar_424_Sk1",
+                            "complexId": "mx424",
+                            "sheetId": "Mx_424_Sk1",
                             "sigle": "M* 424 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1192,8 +1192,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar425",
-                            "sheetId": "Mstar_425_Sk1",
+                            "complexId": "mx425",
+                            "sheetId": "Mx_425_Sk1",
                             "sigle": "M* 425 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1207,8 +1207,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1a",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1a",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1222,8 +1222,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar427",
-                            "sheetId": "Mstar_427_Sk1",
+                            "complexId": "mx427",
+                            "sheetId": "Mx_427_Sk1",
                             "sigle": "M* 427 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1237,8 +1237,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar426",
-                            "sheetId": "Mstar_426_Sk1b",
+                            "complexId": "mx426",
+                            "sheetId": "Mx_426_Sk1b",
                             "sigle": "M* 426 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1252,8 +1252,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar428",
-                            "sheetId": "Mstar_428_Sk1",
+                            "complexId": "mx428",
+                            "sheetId": "Mx_428_Sk1",
                             "sigle": "M* 428 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1351,8 +1351,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar429",
-                            "sheetId": "Mstar_429_Sk1",
+                            "complexId": "mx429",
+                            "sheetId": "Mx_429_Sk1",
                             "sigle": "M* 429 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1408,8 +1408,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar430",
-                            "sheetId": "Mstar_430_Sk1",
+                            "complexId": "mx430",
+                            "sheetId": "Mx_430_Sk1",
                             "sigle": "M* 430 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1437,8 +1437,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk2",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk2",
                             "sigle": "M* 431 Sk2",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1452,8 +1452,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar431",
-                            "sheetId": "Mstar_431_Sk1",
+                            "complexId": "mx431",
+                            "sheetId": "Mx_431_Sk1",
                             "sigle": "M* 431 Sk1",
                             "sigleAddendum": "",
                             "selectable": false,
@@ -1467,8 +1467,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1a",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1a",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. {1A}–2C",
                             "selectable": false,
@@ -1482,8 +1482,8 @@
                             ]
                         },
                         {
-                            "complexId": "mstar432",
-                            "sheetId": "Mstar_432_Sk1b",
+                            "complexId": "mx432",
+                            "sheetId": "Mx_432_Sk1b",
                             "sigle": "M* 432 Sk1",
                             "sigleAddendum": "T. 3–6",
                             "selectable": false,


### PR DESCRIPTION
This PR renames the existing deprecated mstar references to the newer mx naming scheme.