### PR TITLE
fix(app): fix sonar analysis issues (II)

### DIFF
--- a/src/app/shared/order-by-pipe/order-by.pipe.spec.ts
+++ b/src/app/shared/order-by-pipe/order-by.pipe.spec.ts
@@ -388,7 +388,7 @@ describe('OrderByPipe (DONE)', () => {
             const arr = ['$10,0', '$2,0', '$100,0'];
             const res = ['$2,0', '$10,0', '$100,0'];
 
-            const parse = value => parseInt(value.replace(/[^0-9]/g, ''), 10);
+            const parse = value => Number.parseInt(value.replace(/[^0-9]/g, ''), 10);
 
             expectToEqual(
                 pipe.transform(arr, null, false, true, (a, b) => {

--- a/src/app/shared/table/table-pagination/table-pagination.component.ts
+++ b/src/app/shared/table/table-pagination/table-pagination.component.ts
@@ -93,7 +93,7 @@ export class TablePaginationComponent {
      * @returns {void} Selects the page.
      */
     selectPage(page: string): void {
-        this.page = parseInt(page, 10) || 1;
+        this.page = Number.parseInt(page, 10) || 1;
         this.onPageChange(this.page);
     }
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.spec.ts
@@ -1809,6 +1809,7 @@ describe('FolioService (DONE)', () => {
                     )
                 );
                 const reversedContentSegment = folioSvgData.contentSegments[0];
+                const expectedTransform = `rotate(${expectedReversedRotationAngle}, ${reversedContentSegment.centeredXPosition}, ${reversedContentSegment.centeredYPosition})`;
 
                 (folioService as any)._appendContentSegmentLinkLabel(
                     contentSegmentLinkReversed,
@@ -1817,10 +1818,7 @@ describe('FolioService (DONE)', () => {
 
                 const contentSegmentLinkLabel = contentSegmentLinkReversed.select('text');
 
-                expectToBe(
-                    contentSegmentLinkLabel.attr('transform'),
-                    `rotate(${expectedReversedRotationAngle}, ${reversedContentSegment.centeredXPosition}, ${reversedContentSegment.centeredYPosition})`
-                );
+                expectToBe(contentSegmentLinkLabel.attr('transform'), expectedTransform);
             });
         });
     });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.ts
@@ -627,12 +627,17 @@ export class FolioService {
 
         const symbolPath = `M 10 39 Q 12 36 14 39 T 18 39 Q 20 36 22 39 T 26 39 Q 28 36 30 39 T 34 39 M 10 43 T 34 43 M 14 31 L 15 30 L 17 30 L 15 26 L 17 23 L 22 23 L 18 31 L 14 31 M 20 31 L 21 30 L 23 30 L 21 26 L 22 23 L 27 23 L 24 31 L 20 31 M 14 17 L 18 15 L 21 14 L 22 15 L 21 17 L 18 17 L 14 19 M 13 15 L 14 17 L 14 19 L 13 19 L 13 19 L 12 19 L 13 18 L 12 18 L 13 17 L 12 17 L 13 15 M 17 23 L 20 20 L 21 17 L 22 15 L 25 15 L 27 23 M 26 24 L 30 20 L 30 17 L 29 18 L 28 18 L 28 17 L 30 15 L 31 17 L 31 21 L 26 25 M 25 15 L 27 14 L 26 13 L 27 12 L 26 11 L 27 10 L 26 9 L 27 8 L 26 7 L 25 8 L 24 7 L 23 8 L 22 7 L 21 8 L 20 7 L 19 8 L 18 9 L 19 9 L 21 10 L 18 11 L 20 12 L 18 13 L 21 14 L 22 15`;
 
+        let transform = `translate(${centerX - 10}, ${centerY - 10}) scale(0.5)`;
+        if (systemsReversed) {
+            transform += ` rotate(${this._reversedRotationAngle}, 20, 20)`;
+        }
+
         const symbolAttributes = {
             class: 'trademark-symbol',
             d: symbolPath,
             fill: this._disabledColor,
             stroke: this._disabledColor,
-            transform: `translate(${centerX - 10}, ${centerY - 10}) scale(0.5)${systemsReversed ? ` rotate(${this._reversedRotationAngle}, 20, 20)` : ''}`,
+            transform: transform,
         };
         symbolAttributes['stroke-width'] = this._contentSegmentStrokeWidth;
 

--- a/src/app/views/edition-view/models/folio-calculation.model.ts
+++ b/src/app/views/edition-view/models/folio-calculation.model.ts
@@ -974,11 +974,11 @@ export class FolioCalculationSystems {
      * from the calculated folio sheet, the systems string and the zoom factor.
      *
      * @param {FolioCalculationSheet} sheet The given calculated folio sheet.
+     * @param {number} factor The given zoom factor.
      * @param {string} systems The given systems string.
      * @param {boolean} systemsReversed The given reversed flag.
-     * @param {number} factor The given zoom factor.
      */
-    constructor(sheet: FolioCalculationSheet, systems: string, systemsReversed: boolean = false, factor: number) {
+    constructor(sheet: FolioCalculationSheet, factor: number, systems: string, systemsReversed: boolean = false) {
         this.NUMBER_OF_SYSTEMS = systems ? Number.parseInt(systems, 10) : 0;
         this.SYSTEMS_REVERSED = systemsReversed;
         this.ZOOM_FACTOR = factor;
@@ -1063,9 +1063,9 @@ export class FolioCalculation {
         this.SHEET = new FolioCalculationSheet(folioSettings, folioData.folioId, folioData.trademarkPosition);
         this.SYSTEMS = new FolioCalculationSystems(
             this.SHEET,
+            folioSettings.factor,
             folioData.systems,
-            folioData.reversed,
-            folioSettings.factor
+            folioData.reversed
         );
         this.CONTENT_SEGMENTS = folioData.content.map(
             (content: FolioContent) =>

--- a/src/app/views/edition-view/models/folio-calculation.model.ts
+++ b/src/app/views/edition-view/models/folio-calculation.model.ts
@@ -979,7 +979,7 @@ export class FolioCalculationSystems {
      * @param {number} factor The given zoom factor.
      */
     constructor(sheet: FolioCalculationSheet, systems: string, systemsReversed: boolean = false, factor: number) {
-        this.NUMBER_OF_SYSTEMS = systems ? parseInt(systems, 10) : 0;
+        this.NUMBER_OF_SYSTEMS = systems ? Number.parseInt(systems, 10) : 0;
         this.SYSTEMS_REVERSED = systemsReversed;
         this.ZOOM_FACTOR = factor;
 


### PR DESCRIPTION
As a follow up to #2950, this PR fixes some more of the issues raised by Sonar analysis. This includes nested template literals, default values and `parseInt`.