### PR TITLE
ci(gh-actions): update sonar analysis job

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -110,7 +110,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
-                  fetch-depth: 2
+                  fetch-depth: 0 # fetch all history, needed for SonarQube analysis
 
             - name: Common Node setup
               uses: ./.github/actions/common-node-setup

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -93,9 +93,10 @@ jobs:
                   yarn run lint
 
     sonar:
-        # perform SonarQube scan only for current node version and not with pull requests or forks (token issue)
+        # perform SonarQube scan only for current node version, and only on non-PR runs in the main repository (token issue)
         name: Sonar scanning (Node v${{ matrix.node-version }}, ${{ matrix.os }})
         runs-on: ${{ matrix.os }}
+        if: github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER
 
         strategy:
             matrix:
@@ -104,25 +105,21 @@ jobs:
 
         steps:
             - name: Harden Runner
-              if: github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER
               uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
               with:
                   egress-policy: audit
 
             - name: Checkout repository
-              if: github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0 # fetch all history, needed for SonarQube analysis
 
             - name: Common Node setup
-              if: github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER
               uses: ./.github/actions/common-node-setup
               with:
                   node-version: ${{ matrix.node-version }}
 
             - name: Perform SonarQube scan
-              if: github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER
               uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -16,9 +16,6 @@ permissions:
 
 # globals
 env:
-    # general settings
-    MAIN_REPO_OWNER: webern-unibas-ch # Main repo owner (default: webern-unibas-ch; should not be changed)
-
     # dev settings
     DEV_GH_PAGES_BRANCH: gh-pages
     DEV_GH_PAGES_DIR: gh-pages-dir
@@ -94,7 +91,7 @@ jobs:
 
     sonar:
         # perform SonarQube scan only for current node version, and only on non-PR runs in the main repository (token issue)
-        if: github.event_name != 'pull_request' && github.repository_owner == 'webern-unibas-ch'
+        if: github.event_name != 'pull_request' && github.repository_owner == vars.MAIN_REPO_OWNER
         name: Sonar scanning (Node v${{ matrix.node-version }}, ${{ matrix.os }})
         runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -94,9 +94,9 @@ jobs:
 
     sonar:
         # perform SonarQube scan only for current node version, and only on non-PR runs in the main repository (token issue)
+        if: github.event_name != 'pull_request' && github.repository_owner == 'webern-unibas-ch'
         name: Sonar scanning (Node v${{ matrix.node-version }}, ${{ matrix.os }})
         runs-on: ${{ matrix.os }}
-        if: github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER
 
         strategy:
             matrix:

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -93,6 +93,7 @@ jobs:
                   yarn run lint
 
     sonar:
+        # perform SonarQube scan only for current node version and not with pull requests or forks (token issue)
         name: Sonar scanning (Node v${{ matrix.node-version }}, ${{ matrix.os }})
         runs-on: ${{ matrix.os }}
 
@@ -103,22 +104,25 @@ jobs:
 
         steps:
             - name: Harden Runner
+              if: github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER
               uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
               with:
                   egress-policy: audit
 
             - name: Checkout repository
+              if: github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0 # fetch all history, needed for SonarQube analysis
 
             - name: Common Node setup
+              if: github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER
               uses: ./.github/actions/common-node-setup
               with:
                   node-version: ${{ matrix.node-version }}
 
             - name: Perform SonarQube scan
-              if: github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER # perform SonarQube scan only for current node version and not with pull requests or forks(token issue)
+              if: github.event_name != 'pull_request' && github.repository_owner == env.MAIN_REPO_OWNER
               uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any


### PR DESCRIPTION
This PR changes the git fetch-depth for the repo checkout to 0, to fetch all history and branches needed for sonar analysis.