### PR TITLE
New Functions for Graph

### DIFF
--- a/src/app/shared/toast/toast.component.scss
+++ b/src/app/shared/toast/toast.component.scss
@@ -1,6 +1,38 @@
 :host {
     position: fixed;
     bottom: 0;
-    margin: auto;
+    left: 1rem;
+    right: auto;
+    margin: 0;
     z-index: 1200;
+    width: min(500px, calc(100vw - 2rem));
+    max-width: 500px;
+
+    ::ng-deep {
+        ngb-toast {
+            display: block;
+            width: 100%;
+        }
+
+        .toast {
+            padding: 0.35rem 0.5rem;
+            font-size: 0.75rem;
+            width: 100%;
+            max-width: 100%;
+        }
+
+        .toast-header {
+            padding: 0.3rem 0.5rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+        }
+
+        .toast-body {
+            padding: 0.35rem 0.5rem;
+            font-size: 0.7rem;
+            line-height: 0.9;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+    }
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/force-graph/force-graph.component.scss
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/force-graph/force-graph.component.scss
@@ -168,14 +168,18 @@ input[type='range'].awg-force-graph-zoom-slider {
 
 :host ::ng-deep .node-text {
     font:
-        15px 'Roboto',
+        13px 'Roboto',
         sans-serif;
     fill: black;
 }
 
 :host ::ng-deep .link-text {
     font:
-        13px 'Roboto',
+        10px 'Roboto',
         sans-serif;
-    fill: grey;
+    fill: #333;
+    stroke: white;
+    stroke-width: 3px;
+    paint-order: stroke;
+    pointer-events: none;
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/force-graph/force-graph.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/force-graph/force-graph.component.spec.ts
@@ -5,12 +5,14 @@ import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testi
 
 import { PrefixPipe } from '../prefix-pipe/prefix.pipe';
 import { GraphVisualizerService } from '../services/graph-visualizer.service';
+import { Triple } from '../models';
 
 import { ForceGraphComponent } from './force-graph.component';
 
 describe('ForceGraphComponent', () => {
     let component: ForceGraphComponent;
     let fixture: ComponentFixture<ForceGraphComponent>;
+    let graphVisualizerService: GraphVisualizerService;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
@@ -23,10 +25,84 @@ describe('ForceGraphComponent', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ForceGraphComponent);
         component = fixture.componentInstance;
+        graphVisualizerService = TestBed.inject(GraphVisualizerService);
         fixture.detectChanges();
     });
 
     it('... should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    it('... should render node labels instead of raw qnames if rdfs:label is available', () => {
+        const forceGraphFixture = TestBed.createComponent(ForceGraphComponent);
+        const forceGraphComponent = forceGraphFixture.componentInstance;
+
+        forceGraphComponent.currentQueryResultTriples = [
+            {
+                subject: 'https://edition.anton-webern.ch/webern-onto#M312_Sk1',
+                predicate: 'http://www.w3.org/2000/01/rdf-schema#label',
+                object: 'M 312 Sk1 [A]',
+            },
+            {
+                subject: 'https://edition.anton-webern.ch/webern-onto#M312_Sk1',
+                predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                object: 'https://edition.anton-webern.ch/webern-onto#SketchEdition',
+            },
+        ] as Triple[];
+
+        forceGraphFixture.detectChanges();
+
+        const nodeTexts = Array.from(forceGraphFixture.nativeElement.querySelectorAll('text.node-text')).map(
+            (text: SVGTextElement) => text.textContent?.trim()
+        );
+
+        expect(nodeTexts).toContain('M 312 Sk1 [A]');
+        expect(nodeTexts).not.toContain('awg:M312_Sk1');
+    });
+
+    it('... should attach source type and location to clicked sheet and source nodes without rendering metadata triples', () => {
+        const triples = [
+            {
+                subject: 'https://edition.anton-webern.ch/webern-onto#M312_Sk1',
+                predicate: 'http://www.w3.org/2000/01/rdf-schema#label',
+                object: 'M 312 Sk1 [A]',
+            },
+            {
+                subject: 'https://edition.anton-webern.ch/webern-onto#M312_Sk1',
+                predicate: 'https://edition.anton-webern.ch/webern-onto#hasSource',
+                object: 'https://edition.anton-webern.ch/webern-onto#source_A',
+            },
+            {
+                subject: 'https://edition.anton-webern.ch/webern-onto#source_A',
+                predicate: 'http://www.w3.org/2000/01/rdf-schema#label',
+                object: 'A',
+            },
+            {
+                subject: 'https://edition.anton-webern.ch/webern-onto#source_A',
+                predicate: 'https://edition.anton-webern.ch/webern-onto#sourceType',
+                object: 'Skizzen (in: Skizzenbuch 3).',
+            },
+            {
+                subject: 'https://edition.anton-webern.ch/webern-onto#source_A',
+                predicate: 'https://edition.anton-webern.ch/webern-onto#sourceLocation',
+                object: 'CH-Bps, Sammlung Anton Webern.',
+            },
+        ] as Triple[];
+
+        const labelMap = graphVisualizerService.extractLabelsFromTriples(triples);
+        const graphData = (component as any)._triplesToD3GraphData(triples, labelMap);
+        const expectedSourceDetails = [
+            {
+                id: 'awg:source_A',
+                label: 'A',
+                type: 'Skizzen (in: Skizzenbuch 3).',
+                location: 'CH-Bps, Sammlung Anton Webern.',
+            },
+        ];
+
+        expect(graphData.nodes.find(node => node.id === 'awg:M312_Sk1')?.sourceDetails).toEqual(expectedSourceDetails);
+        expect(graphData.nodes.find(node => node.id === 'awg:source_A')?.sourceDetails).toEqual(expectedSourceDetails);
+        expect(graphData.nodeTriples.some(nodeTriple => nodeTriple.nodePredicate.id === 'awg:sourceType')).toBeFalse();
+        expect(graphData.nodeTriples.some(nodeTriple => nodeTriple.nodePredicate.id === 'awg:sourceLocation')).toBeFalse();
     });
 });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/force-graph/force-graph.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/force-graph/force-graph.component.ts
@@ -1145,6 +1145,8 @@ export class ForceGraphComponent implements OnInit, OnChanges, OnDestroy {
      *
      * It updates the positions of the link texts
      * on a force simulation's tick.
+     * Positions text labels ON the edges (between subject and object nodes),
+     * rotated parallel to the edge direction.
      *
      * @param {D3Selection} linkTexts The given linkTexts selection.
      *
@@ -1152,18 +1154,21 @@ export class ForceGraphComponent implements OnInit, OnChanges, OnDestroy {
      */
     private _updateLinkTextPositions(linkTexts: D3Selection): void {
         linkTexts
-            .attr('x', (d: D3SimulationNodeTriple) => {
-                if (d.nodeSubject.x === d.nodeObject.x && d.nodeSubject.y === d.nodeObject.y) {
-                    return 20 + (d.nodeSubject.x + d.nodePredicate.x + d.nodeObject.x) / 3;
-                }
+            .attr('text-anchor', 'middle')
+            .attr('dy', '-0.5em')
+            .attr('transform', (d: D3SimulationNodeTriple) => {
+                // Calculate angle between subject and object nodes
+                const dx = d.nodeObject.x - d.nodeSubject.x;
+                const dy = d.nodeObject.y - d.nodeSubject.y;
+                const angle = (Math.atan2(dy, dx) * 180) / Math.PI;
 
-                return 10 + (d.nodeSubject.x + d.nodePredicate.x + d.nodeObject.x) / 3;
-            })
-            .attr('y', (d: D3SimulationNodeTriple) => {
-                if (d.nodeSubject.x === d.nodeObject.x && d.nodeSubject.y === d.nodeObject.y) {
-                    return -40 + (d.nodeSubject.y + d.nodePredicate.y + d.nodeObject.y) / 3;
-                }
-                return 4 + (d.nodeSubject.y + d.nodePredicate.y + d.nodeObject.y) / 3;
+                // Rotate text to be parallel with edge, avoid upside-down text
+                const rotation = angle > 90 || angle < -90 ? angle + 180 : angle;
+
+                const x = (d.nodeSubject.x + d.nodeObject.x) / 2;
+                const y = (d.nodeSubject.y + d.nodeObject.y) / 2;
+
+                return `translate(${x},${y}) rotate(${rotation})`;
             });
     }
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/force-graph/force-graph.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/force-graph/force-graph.component.ts
@@ -31,6 +31,7 @@ import {
     D3SimulationData,
     D3SimulationLink,
     D3SimulationNode,
+    D3SimulationNodeSourceDetails,
     D3SimulationNodeTriple,
     D3SimulationNodeType,
     PrefixForm,
@@ -550,7 +551,7 @@ export class ForceGraphComponent implements OnInit, OnChanges, OnDestroy {
             .enter()
             .append('text')
             .attr('class', 'node-text')
-            .text((d: D3SimulationNode) => d.id);
+            .text((d: D3SimulationNode) => d.label);
 
         // ==================== Add Nodes =====================
         const nodes: D3Selection = this._zoomGroup
@@ -850,9 +851,11 @@ export class ForceGraphComponent implements OnInit, OnChanges, OnDestroy {
         const graphData: D3SimulationData = new D3SimulationData();
 
         const nodeMap = new Map<string, D3SimulationNode>();
+        const nodeSourceDetailsMap = this._extractNodeSourceDetails(triples, labelMap);
+        const visibleTriples = triples.filter(triple => !this._isNodeMetadataTriple(triple));
 
         // Initial Graph from triples
-        triples.forEach((triple: Triple) => {
+        visibleTriples.forEach((triple: Triple) => {
             const subjId = this._prefixPipe.transform(triple.subject, PrefixForm.SHORT);
             const predId = this._prefixPipe.transform(triple.predicate, PrefixForm.SHORT);
             let objId = this._prefixPipe.transform(triple.object, PrefixForm.SHORT);
@@ -869,8 +872,8 @@ export class ForceGraphComponent implements OnInit, OnChanges, OnDestroy {
             graphData.nodes.push(predNode);
 
             // Get or create subject and object nodes (deduplicated)
-            const subjNode = this._getOrCreateNode(subjId, nodeMap, labelMap, graphData);
-            const objNode = this._getOrCreateNode(objId, nodeMap, labelMap, graphData);
+            const subjNode = this._getOrCreateNode(subjId, nodeMap, labelMap, graphData, nodeSourceDetailsMap);
+            const objNode = this._getOrCreateNode(objId, nodeMap, labelMap, graphData, nodeSourceDetailsMap);
 
             // Check if predicate is "rdf:type"
             // Then subjNode is an instance and objNode is a Class
@@ -891,6 +894,99 @@ export class ForceGraphComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     /**
+     * Private method: _extractNodeSourceDetails.
+     *
+     * It collects source metadata for source nodes and nodes that reference sources.
+     *
+     * @param {Triple[]} triples The given triple array.
+     * @param {Map<string, string>} labelMap The label map extracted from the triple set.
+     *
+     * @returns {Map<string, D3SimulationNodeSourceDetails[]>} A map of node ids to source details.
+     */
+    private _extractNodeSourceDetails(
+        triples: Triple[],
+        labelMap: Map<string, string>
+    ): Map<string, D3SimulationNodeSourceDetails[]> {
+        const sourceTypeMap = new Map<string, string>();
+        const sourceLocationMap = new Map<string, string>();
+        const nodeSourceIdsMap = new Map<string, Set<string>>();
+        const sourceIds = new Set<string>();
+
+        triples.forEach(triple => {
+            const subjectId = this._prefixPipe.transform(triple.subject, PrefixForm.SHORT);
+            const predicateId = this._prefixPipe.transform(triple.predicate, PrefixForm.SHORT);
+
+            if (predicateId === 'awg:sourceType') {
+                sourceTypeMap.set(subjectId, triple.object);
+                sourceIds.add(subjectId);
+                return;
+            }
+
+            if (predicateId === 'awg:sourceLocation') {
+                sourceLocationMap.set(subjectId, triple.object);
+                sourceIds.add(subjectId);
+                return;
+            }
+
+            if (predicateId === 'awg:hasSource') {
+                const sourceId = this._prefixPipe.transform(triple.object, PrefixForm.SHORT);
+
+                sourceIds.add(sourceId);
+
+                if (!nodeSourceIdsMap.has(subjectId)) {
+                    nodeSourceIdsMap.set(subjectId, new Set<string>());
+                }
+
+                nodeSourceIdsMap.get(subjectId).add(sourceId);
+            }
+        });
+
+        const sourceDetailsMap = new Map<string, D3SimulationNodeSourceDetails>();
+
+        sourceIds.forEach(sourceId => {
+            sourceDetailsMap.set(sourceId, {
+                id: sourceId,
+                label: labelMap.get(sourceId) || sourceId,
+                type: sourceTypeMap.get(sourceId),
+                location: sourceLocationMap.get(sourceId),
+            });
+        });
+
+        const nodeSourceDetailsMap = new Map<string, D3SimulationNodeSourceDetails[]>();
+
+        sourceDetailsMap.forEach((sourceDetails, sourceId) => {
+            nodeSourceDetailsMap.set(sourceId, [sourceDetails]);
+        });
+
+        nodeSourceIdsMap.forEach((linkedSourceIds, nodeId) => {
+            const sourceDetails = Array.from(linkedSourceIds)
+                .map(sourceId => sourceDetailsMap.get(sourceId) || { id: sourceId, label: labelMap.get(sourceId) || sourceId })
+                .sort((firstSource, secondSource) => firstSource.label.localeCompare(secondSource.label));
+
+            if (sourceDetails.length) {
+                nodeSourceDetailsMap.set(nodeId, sourceDetails);
+            }
+        });
+
+        return nodeSourceDetailsMap;
+    }
+
+    /**
+     * Private method: _isNodeMetadataTriple.
+     *
+     * It checks if a triple only adds click metadata and should be hidden from the visible graph.
+     *
+     * @param {Triple} triple The given triple.
+     *
+     * @returns {boolean} True if the triple should not be rendered as graph edge.
+     */
+    private _isNodeMetadataTriple(triple: Triple): boolean {
+        const predicateId = this._prefixPipe.transform(triple.predicate, PrefixForm.SHORT);
+
+        return predicateId === 'awg:sourceType' || predicateId === 'awg:sourceLocation';
+    }
+
+    /**
      * Private method: _getOrCreateNode.
      *
      * It gets an existing node from the nodeMap or creates a new one if it doesn't exist.
@@ -906,7 +1002,8 @@ export class ForceGraphComponent implements OnInit, OnChanges, OnDestroy {
         nodeId: string,
         nodeMap: Map<string, D3SimulationNode>,
         labelMap: Map<string, string>,
-        graphData: D3SimulationData
+        graphData: D3SimulationData,
+        nodeSourceDetailsMap: Map<string, D3SimulationNodeSourceDetails[]>
     ): D3SimulationNode {
         let node = nodeMap.get(nodeId);
         if (node == null) {
@@ -914,6 +1011,11 @@ export class ForceGraphComponent implements OnInit, OnChanges, OnDestroy {
 
             // Set label from labelMap if available, otherwise use nodeId
             node.label = labelMap.get(nodeId) || nodeId;
+
+            const sourceDetails = nodeSourceDetailsMap.get(nodeId);
+            if (sourceDetails?.length) {
+                node.sourceDetails = sourceDetails;
+            }
 
             // Store node in map for future reference
             nodeMap.set(nodeId, node);

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.html
@@ -56,7 +56,7 @@
                                         <div class="card-body">
                                             <div class="awg-node-details__header mb-3">
                                                 <div>
-                                                    <p class="awg-node-details__eyebrow mb-2">Ausgewählter Knoten</p>
+                                                    <p class="awg-node-details__eyebrow mb-2">selected node</p>
                                                     <h3 class="h5 mb-0">{{ nodePanel.node.label }}</h3>
                                                 </div>
 
@@ -66,7 +66,7 @@
                                                         class="btn btn-sm awg-node-details__pin-button"
                                                         [ngClass]="nodePanel.isPinned ? 'btn-secondary' : 'btn-outline-secondary'"
                                                         (click)="toggleNodeDetailsPinned(nodePanel.id)">
-                                                        {{ nodePanel.isPinned ? 'Lösen' : 'Anheften' }}
+                                                        {{ nodePanel.isPinned ? 'unpin' : 'pin' }}
                                                     </button>
                                                     <button
                                                         type="button"
@@ -80,7 +80,7 @@
                                                 <dt class="col-sm-3">ID</dt>
                                                 <dd class="col-sm-9">{{ nodePanel.node.id }}</dd>
 
-                                                <dt class="col-12 mt-3">Quellen</dt>
+                                                <dt class="col-12 mt-2">Quellen</dt>
                                                 @if (nodePanel.node.sourceDetails?.length) {
                                                     <dd class="col-12 mb-0">
                                                         <div class="awg-node-details__sources">

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.html
@@ -33,7 +33,7 @@
             <!-- awg-graph-construct-result -->
             @if (query.queryType === 'construct') {
                 <div class="row g-3 awg-graph-results">
-                    <div [ngClass]="nodeDetailsPanels.length ? 'col-12 col-xl-8' : 'col-12'">
+                    <div [ngClass]="nodeDetailsPanels.length ? 'col-12 col-xl-9' : 'col-12'">
                         <awg-construct-results
                             #queryConstructResultAcc
                             [queryResult$]="queryResult$"
@@ -49,7 +49,7 @@
                     </div>
 
                     @if (nodeDetailsPanels.length) {
-                        <div class="col-12 col-xl-4">
+                        <div class="col-12 col-xl-3">
                             <div class="awg-node-details-list">
                                 @for (nodePanel of nodeDetailsPanels; track nodePanel.id) {
                                     <aside class="card awg-node-details" [class.awg-node-details--pinned]="nodePanel.isPinned">

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.html
@@ -100,7 +100,7 @@
                                                         </div>
                                                     </dd>
                                                 } @else {
-                                                    <dd class="col-12 mb-0 text-body-secondary">Keine Quelldetails verfuegbar.</dd>
+                                                    <dd class="col-12 mb-0 text-body-secondary">Keine Quelldetails verfügbar.</dd>
                                                 }
                                             </dl>
                                         </div>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.html
@@ -26,17 +26,90 @@
                 </div>
             </div>
         </div>
+
         <!-- Results -->
         <div [ngClass]="isFullscreen ? 'col-8 col-lg-9 px-0 awg-fullscreen' : 'col-12'">
             <!-- CONSTRUCT -->
             <!-- awg-graph-construct-result -->
             @if (query.queryType === 'construct') {
-                <awg-construct-results
-                    #queryConstructResultAcc
-                    [queryResult$]="queryResult$"
-                    [defaultForceGraphHeight]="isFullscreen ? 1000 : defaultForceGraphHeight"
-                    [isFullscreen]="isFullscreen"
-                    (clickedNodeRequest)="onGraphNodeClick($event)"></awg-construct-results>
+                <div class="row g-3 awg-graph-results">
+                    <div [ngClass]="nodeDetailsPanels.length ? 'col-12 col-xl-8' : 'col-12'">
+                        <awg-construct-results
+                            #queryConstructResultAcc
+                            [queryResult$]="queryResult$"
+                            [defaultForceGraphHeight]="isFullscreen ? 1000 : defaultForceGraphHeight"
+                            [isFullscreen]="isFullscreen"
+                            (clickedNodeRequest)="onGraphNodeClick($event)"></awg-construct-results>
+
+                        @if (!nodeDetailsPanels.length) {
+                            <p class="awg-node-details__hint mb-0 mt-3">
+                                Klicken Sie im Graphen auf einen Knoten, um das Detailpanel zu öffnen.
+                            </p>
+                        }
+                    </div>
+
+                    @if (nodeDetailsPanels.length) {
+                        <div class="col-12 col-xl-4">
+                            <div class="awg-node-details-list">
+                                @for (nodePanel of nodeDetailsPanels; track nodePanel.id) {
+                                    <aside class="card awg-node-details" [class.awg-node-details--pinned]="nodePanel.isPinned">
+                                        <div class="card-body">
+                                            <div class="awg-node-details__header mb-3">
+                                                <div>
+                                                    <p class="awg-node-details__eyebrow mb-2">Ausgewählter Knoten</p>
+                                                    <h3 class="h5 mb-0">{{ nodePanel.node.label }}</h3>
+                                                </div>
+
+                                                <div class="awg-node-details__actions">
+                                                    <button
+                                                        type="button"
+                                                        class="btn btn-sm awg-node-details__pin-button"
+                                                        [ngClass]="nodePanel.isPinned ? 'btn-secondary' : 'btn-outline-secondary'"
+                                                        (click)="toggleNodeDetailsPinned(nodePanel.id)">
+                                                        {{ nodePanel.isPinned ? 'Lösen' : 'Anheften' }}
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        class="btn-close awg-node-details__close-button"
+                                                        aria-label="Details schliessen"
+                                                        (click)="closeNodeDetailsPanel(nodePanel.id)"></button>
+                                                </div>
+                                            </div>
+
+                                            <dl class="row mb-0 awg-node-details__meta">
+                                                <dt class="col-sm-3">ID</dt>
+                                                <dd class="col-sm-9">{{ nodePanel.node.id }}</dd>
+
+                                                <dt class="col-12 mt-3">Quellen</dt>
+                                                @if (nodePanel.node.sourceDetails?.length) {
+                                                    <dd class="col-12 mb-0">
+                                                        <div class="awg-node-details__sources">
+                                                            @for (sourceDetail of nodePanel.node.sourceDetails; track sourceDetail.id) {
+                                                                <section class="awg-node-details__source">
+                                                                    <h4 class="h6 mb-2">{{ sourceDetail.label }}</h4>
+
+                                                                    @if (sourceDetail.type) {
+                                                                        <p class="mb-1"><span class="fw-semibold">Typ:</span> {{ sourceDetail.type }}</p>
+                                                                    }
+
+                                                                    @if (sourceDetail.location) {
+                                                                        <p class="mb-0"><span class="fw-semibold">Standort:</span> {{ sourceDetail.location }}</p>
+                                                                    }
+                                                                </section>
+                                                            }
+                                                        </div>
+                                                    </dd>
+                                                } @else {
+                                                    <dd class="col-12 mb-0 text-body-secondary">Keine Quelldetails verfuegbar.</dd>
+                                                }
+                                            </dl>
+                                        </div>
+                                    </aside>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
             } @else {
                 @if (query.queryType === 'select') {
                     <awg-select-results

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.html
@@ -33,8 +33,9 @@
             <!-- awg-graph-construct-result -->
             @if (query.queryType === 'construct') {
                 <div class="row g-3 awg-graph-results">
-                    <div [ngClass]="nodeDetailsPanels.length ? 'col-12 col-xl-9' : 'col-12'">
+                    <div class="col-12">
                         <awg-construct-results
+                            [class.awg-panel-open]="nodeDetailsPanels.length"
                             #queryConstructResultAcc
                             [queryResult$]="queryResult$"
                             [defaultForceGraphHeight]="isFullscreen ? 1000 : defaultForceGraphHeight"
@@ -46,10 +47,8 @@
                                 Klicken Sie im Graphen auf einen Knoten, um das Detailpanel zu öffnen.
                             </p>
                         }
-                    </div>
-
-                    @if (nodeDetailsPanels.length) {
-                        <div class="col-12 col-xl-3">
+                        @if (nodeDetailsPanels.length) {
+                            <div class="awg-node-details-overlay">
                             <div class="awg-node-details-list">
                                 @for (nodePanel of nodeDetailsPanels; track nodePanel.id) {
                                     <aside class="card awg-node-details" [class.awg-node-details--pinned]="nodePanel.isPinned">
@@ -108,7 +107,8 @@
                                 }
                             </div>
                         </div>
-                    }
+                        }
+                    </div>
                 </div>
             } @else {
                 @if (query.queryType === 'select') {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.scss
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.scss
@@ -25,7 +25,7 @@
         justify-content: space-between;
 
         h3 {
-            font-size: 0.95rem;
+            font-size: 0.875rem;
         }
     }
 
@@ -38,6 +38,13 @@
 
     .awg-node-details__pin-button {
         white-space: nowrap;
+        font-size: 0.65rem;
+        padding: 0.15rem 0.35rem;
+    }
+
+    .awg-node-details__close-button {
+        width: 0.65em;
+        height: 0.65em;
     }
 
     .awg-node-details__eyebrow {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.scss
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.scss
@@ -1,12 +1,37 @@
 :host {
+    .awg-graph-results {
+        position: relative;
+    }
+
+    .awg-node-details-overlay {
+        background: transparent;
+        bottom: 0;
+        display: flex;
+        align-items: flex-start;
+        justify-content: flex-end;
+        pointer-events: none;
+        position: absolute;
+        right: 0;
+        top: 0;
+        width: clamp(4rem, 24vw, 16rem);
+        max-width: calc(100vw - 1rem);
+        z-index: 2;
+    }
+
     .awg-node-details-list {
         display: grid;
         gap: 0.75rem;
+        pointer-events: none;
+        position: sticky;
+        top: 1.5rem;
+        width: 100%;
     }
 
     .awg-node-details {
+        background: rgba(255, 255, 255, 0.95);
         border: 1px solid var(--bs-border-color, #dee2e6);
         box-shadow: 0 0.5rem 1.5rem rgba(33, 37, 41, 0.08);
+        pointer-events: auto;
     }
 
     .awg-node-details--pinned {
@@ -93,6 +118,22 @@
     }
 
     @media (max-width: 1199.98px) {
+        .awg-node-details-overlay {
+            pointer-events: none;
+            position: absolute;
+            right: 0;
+            top: 0;
+            bottom: 0;
+            width: clamp(3.5rem, 36vw, 14rem);
+            max-width: calc(100vw - 0.5rem);
+        }
+
+        .awg-node-details-list {
+            pointer-events: none;
+            position: sticky;
+            top: 1.5rem;
+        }
+
         .awg-node-details__header {
             flex-direction: column;
         }
@@ -103,6 +144,10 @@
     }
 
     &::ng-deep {
+        .awg-panel-open .awg-force-graph-node-limit-container {
+            margin-right: calc(clamp(4rem, 24vw, 16rem) + 0.35rem);
+        }
+
         .awg-fullscreen {
             .collapse.show {
                 height: 100vh;

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.scss
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.scss
@@ -1,4 +1,81 @@
 :host {
+    .awg-node-details-list {
+        display: grid;
+        gap: 0.75rem;
+    }
+
+    .awg-node-details {
+        border: 1px solid var(--bs-border-color, #dee2e6);
+        box-shadow: 0 0.5rem 1.5rem rgba(33, 37, 41, 0.08);
+    }
+
+    .awg-node-details--pinned {
+        border-color: var(--bs-primary, #0d6efd);
+    }
+
+    .awg-node-details__hint {
+        color: var(--bs-secondary-color, #6c757d);
+        font-size: 0.9rem;
+    }
+
+    .awg-node-details__header {
+        align-items: flex-start;
+        display: flex;
+        gap: 1rem;
+        justify-content: space-between;
+    }
+
+    .awg-node-details__actions {
+        align-items: center;
+        display: flex;
+        flex-shrink: 0;
+        gap: 0.5rem;
+    }
+
+    .awg-node-details__pin-button {
+        white-space: nowrap;
+    }
+
+    .awg-node-details__eyebrow {
+        color: var(--bs-secondary-color, #6c757d);
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .awg-node-details__meta {
+        dt {
+            font-size: 0.8rem;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+        }
+
+        dd {
+            overflow-wrap: anywhere;
+        }
+    }
+
+    .awg-node-details__sources {
+        display: grid;
+        gap: 0.75rem;
+    }
+
+    .awg-node-details__source {
+        background: rgba(248, 249, 250, 0.9);
+        border-radius: 0.5rem;
+        padding: 0.75rem;
+    }
+
+    @media (max-width: 1199.98px) {
+        .awg-node-details__header {
+            flex-direction: column;
+        }
+
+        .awg-node-details__actions {
+            width: 100%;
+        }
+    }
+
     &::ng-deep {
         .awg-fullscreen {
             .collapse.show {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.scss
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.scss
@@ -23,6 +23,10 @@
         display: flex;
         gap: 1rem;
         justify-content: space-between;
+
+        h3 {
+            font-size: 0.95rem;
+        }
     }
 
     .awg-node-details__actions {
@@ -38,19 +42,20 @@
 
     .awg-node-details__eyebrow {
         color: var(--bs-secondary-color, #6c757d);
-        font-size: 0.75rem;
+        font-size: 0.65rem;
         letter-spacing: 0.08em;
         text-transform: uppercase;
     }
 
     .awg-node-details__meta {
         dt {
-            font-size: 0.8rem;
+            font-size: 0.7rem;
             letter-spacing: 0.04em;
             text-transform: uppercase;
         }
 
         dd {
+            font-size: 0.85rem;
             overflow-wrap: anywhere;
         }
     }
@@ -64,6 +69,20 @@
         background: rgba(248, 249, 250, 0.9);
         border-radius: 0.5rem;
         padding: 0.75rem;
+
+        h4 {
+            font-size: 0.85rem;
+            margin-bottom: 0.5rem;
+        }
+
+        p {
+            font-size: 0.8rem;
+            margin-bottom: 0.25rem;
+
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
     }
 
     @media (max-width: 1199.98px) {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
@@ -1098,7 +1098,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
                 resultsCmp.clickedNodeRequest.emit(expectedNode);
 
                 // Check ToastMessage
-                const expectedMessage = `GraphVisualizerComponent# graphClick on node ${expectedNode.id}\n\n Label: ${expectedNode.label}`;
+                const expectedMessage = `GraphVisualizerComponent# graphClick on node ${expectedNode.id}\n\nLabel: ${expectedNode.label}`;
                 const toastMessage = new ToastMessage(expectedNode.id, expectedMessage, 5000);
                 const expectedToast = new Toast(toastMessage.message, {
                     header: toastMessage.name,
@@ -1110,6 +1110,162 @@ describe('GraphVisualizerComponent (DONE)', () => {
                 expectSpyCall(showToastMessageSpy, 1, [toastMessage, 'info']);
                 expectSpyCall(toastServiceAddSpy, 1, expectedToast);
                 expectSpyCall(consoleSpy, 1, ['Test', ':', expectedMessage]);
+            });
+
+            it('... should include source type and location in the ToastMessage if source details are available', () => {
+                const resultsDes = getAndExpectDebugElementByDirective(compDe, ConstructResultsStubComponent, 1, 1);
+                const resultsCmp = resultsDes[0].injector.get(
+                    ConstructResultsStubComponent
+                ) as ConstructResultsStubComponent;
+
+                const expectedNode = new D3SimulationNode('awg:M312_Sk1', D3SimulationNodeType.node);
+                expectedNode.label = 'M 312 Sk1 [A]';
+                expectedNode.sourceDetails = [
+                    {
+                        id: 'awg:source_A',
+                        label: 'A',
+                        type: 'Skizzen (in: Skizzenbuch 3).',
+                        location: 'CH-Bps, Sammlung Anton Webern.',
+                    },
+                ];
+
+                resultsCmp.clickedNodeRequest.emit(expectedNode);
+
+                const expectedMessage =
+                    'GraphVisualizerComponent# graphClick on node awg:M312_Sk1\n\n' +
+                    'Label: M 312 Sk1 [A]\n\n' +
+                    'Source: A\n' +
+                    'Type: Skizzen (in: Skizzenbuch 3).\n' +
+                    'Location: CH-Bps, Sammlung Anton Webern.';
+                const toastMessage = new ToastMessage(expectedNode.id, expectedMessage, 5000);
+                const expectedToast = new Toast(toastMessage.message, {
+                    header: toastMessage.name,
+                    classname: 'bg-info text-light',
+                    delay: toastMessage.duration,
+                });
+
+                expectSpyCall(onGraphNodeClickSpy, 1, expectedNode);
+                expectSpyCall(showToastMessageSpy, 1, [toastMessage, 'info']);
+                expectSpyCall(toastServiceAddSpy, 1, expectedToast);
+                expectSpyCall(consoleSpy, 1, ['awg:M312_Sk1', ':', expectedMessage]);
+            });
+
+            it('... should persist selected node details in a side panel', () => {
+                const resultsDes = getAndExpectDebugElementByDirective(compDe, ConstructResultsStubComponent, 1, 1);
+                const resultsCmp = resultsDes[0].injector.get(
+                    ConstructResultsStubComponent
+                ) as ConstructResultsStubComponent;
+
+                const expectedNode = new D3SimulationNode('awg:M312_Sk1', D3SimulationNodeType.node);
+                expectedNode.label = 'M 312 Sk1 [A]';
+                expectedNode.sourceDetails = [
+                    {
+                        id: 'awg:source_A',
+                        label: 'A',
+                        type: 'Skizzen (in: Skizzenbuch 3).',
+                        location: 'CH-Bps, Sammlung Anton Webern.',
+                    },
+                ];
+
+                resultsCmp.clickedNodeRequest.emit(expectedNode);
+                detectChangesOnPush(fixture);
+
+                const detailsPanel = fixture.nativeElement.querySelector('.awg-node-details') as HTMLElement;
+
+                expect(component.nodeDetailsPanels.length).toBe(1);
+                expect(component.nodeDetailsPanels[0].node.id).toBe('awg:M312_Sk1');
+                expect(detailsPanel).toBeTruthy();
+                expect(detailsPanel.textContent).toContain('Ausgewaehlter Knoten');
+                expect(detailsPanel.textContent).toContain('M 312 Sk1 [A]');
+                expect(detailsPanel.textContent).toContain('A');
+                expect(detailsPanel.textContent).toContain('Typ: Skizzen (in: Skizzenbuch 3).');
+                expect(detailsPanel.textContent).toContain('Standort: CH-Bps, Sammlung Anton Webern.');
+            });
+
+            it('... should show a hint before a node is selected', () => {
+                const detailsHint = fixture.nativeElement.querySelector('.awg-node-details__hint') as HTMLElement;
+
+                expect(detailsHint).toBeTruthy();
+                expect(detailsHint.textContent).toContain(
+                    'Klicken Sie im Graphen auf einen Knoten, um das Detailpanel zu oeffnen.'
+                );
+            });
+
+            it('... should pin and close the selected node details panel', () => {
+                const resultsDes = getAndExpectDebugElementByDirective(compDe, ConstructResultsStubComponent, 1, 1);
+                const resultsCmp = resultsDes[0].injector.get(
+                    ConstructResultsStubComponent
+                ) as ConstructResultsStubComponent;
+
+                const expectedNode = new D3SimulationNode('awg:M312_Sk1', D3SimulationNodeType.node);
+                expectedNode.label = 'M 312 Sk1 [A]';
+                expectedNode.sourceDetails = [
+                    {
+                        id: 'awg:source_A',
+                        label: 'A',
+                        type: 'Skizzen (in: Skizzenbuch 3).',
+                        location: 'CH-Bps, Sammlung Anton Webern.',
+                    },
+                ];
+
+                resultsCmp.clickedNodeRequest.emit(expectedNode);
+                detectChangesOnPush(fixture);
+
+                const pinButton = fixture.nativeElement.querySelector('.awg-node-details__pin-button') as HTMLButtonElement;
+                const closeButton = fixture.nativeElement.querySelector('.awg-node-details__close-button') as HTMLButtonElement;
+
+                expect(pinButton).toBeTruthy();
+                expect(closeButton).toBeTruthy();
+                expect(component.nodeDetailsPanels[0].isPinned).toBeFalse();
+
+                pinButton.click();
+                detectChangesOnPush(fixture);
+
+                const pinnedPanel = fixture.nativeElement.querySelector('.awg-node-details') as HTMLElement;
+                const pinnedButton = fixture.nativeElement.querySelector('.awg-node-details__pin-button') as HTMLButtonElement;
+
+                expect(component.nodeDetailsPanels[0].isPinned).toBeTrue();
+                expect(pinnedPanel.classList.contains('awg-node-details--pinned')).toBeTrue();
+                expect(pinnedButton.textContent).toContain('Lösen');
+
+                closeButton.click();
+                detectChangesOnPush(fixture);
+
+                expect(component.nodeDetailsPanels.length).toBe(0);
+                expect(fixture.nativeElement.querySelector('.awg-node-details')).toBeFalsy();
+            });
+
+            it('... should keep pinned panels and open a new unpinned panel for another node', () => {
+                const resultsDes = getAndExpectDebugElementByDirective(compDe, ConstructResultsStubComponent, 1, 1);
+                const resultsCmp = resultsDes[0].injector.get(
+                    ConstructResultsStubComponent
+                ) as ConstructResultsStubComponent;
+
+                const firstNode = new D3SimulationNode('awg:M312_Sk1', D3SimulationNodeType.node);
+                firstNode.label = 'M 312 Sk1 [A]';
+
+                const secondNode = new D3SimulationNode('awg:M313_Sk2', D3SimulationNodeType.node);
+                secondNode.label = 'M 313 Sk2 [B]';
+
+                resultsCmp.clickedNodeRequest.emit(firstNode);
+                detectChangesOnPush(fixture);
+
+                let pinButtons = fixture.nativeElement.querySelectorAll('.awg-node-details__pin-button') as NodeListOf<HTMLButtonElement>;
+                pinButtons[0].click();
+                detectChangesOnPush(fixture);
+
+                resultsCmp.clickedNodeRequest.emit(secondNode);
+                detectChangesOnPush(fixture);
+
+                const allPanels = fixture.nativeElement.querySelectorAll('.awg-node-details') as NodeListOf<HTMLElement>;
+
+                expect(component.nodeDetailsPanels.length).toBe(2);
+                expect(component.nodeDetailsPanels.filter(panel => panel.isPinned).length).toBe(1);
+                expect(component.nodeDetailsPanels.some(panel => panel.node.id === 'awg:M312_Sk1' && panel.isPinned)).toBeTrue();
+                expect(component.nodeDetailsPanels.some(panel => panel.node.id === 'awg:M313_Sk2' && !panel.isPinned)).toBeTrue();
+                expect(allPanels.length).toBe(2);
+                expect(allPanels[0].textContent).toContain('M 312 Sk1 [A]');
+                expect(allPanels[1].textContent).toContain('M 313 Sk2 [B]');
             });
         });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
@@ -1187,7 +1187,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
                 expect(detailsHint).toBeTruthy();
                 expect(detailsHint.textContent).toContain(
-                    'Klicken Sie im Graphen auf einen Knoten, um das Detailpanel zu oeffnen.'
+                    'Klicken Sie im Graphen auf einen Knoten, um das Detailpanel zu öffnen.'
                 );
             });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
@@ -1175,7 +1175,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
                 expect(component.nodeDetailsPanels.length).toBe(1);
                 expect(component.nodeDetailsPanels[0].node.id).toBe('awg:M312_Sk1');
                 expect(detailsPanel).toBeTruthy();
-                expect(detailsPanel.textContent).toContain('Ausgewaehlter Knoten');
+                expect(detailsPanel.textContent).toContain('Ausgewählter Knoten');
                 expect(detailsPanel.textContent).toContain('M 312 Sk1 [A]');
                 expect(detailsPanel.textContent).toContain('A');
                 expect(detailsPanel.textContent).toContain('Typ: Skizzen (in: Skizzenbuch 3).');

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
@@ -1175,7 +1175,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
                 expect(component.nodeDetailsPanels.length).toBe(1);
                 expect(component.nodeDetailsPanels[0].node.id).toBe('awg:M312_Sk1');
                 expect(detailsPanel).toBeTruthy();
-                expect(detailsPanel.textContent).toContain('Ausgewählter Knoten');
+                expect(detailsPanel.textContent).toContain('selected node');
                 expect(detailsPanel.textContent).toContain('M 312 Sk1 [A]');
                 expect(detailsPanel.textContent).toContain('A');
                 expect(detailsPanel.textContent).toContain('Typ: Skizzen (in: Skizzenbuch 3).');

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.ts
@@ -12,6 +12,12 @@ import { D3SimulationNode, QueryResult, Triple } from './models';
 
 import { GraphVisualizerService } from './services';
 
+interface GraphNodeDetailsPanel {
+    id: string;
+    node: D3SimulationNode;
+    isPinned: boolean;
+}
+
 /**
  * The GraphVisualizer component.
  *
@@ -83,6 +89,13 @@ export class GraphVisualizerComponent implements OnInit {
      * It keeps the duration time of the query.
      */
     queryTime: number;
+
+    /**
+      * Public variable: nodeDetailsPanels.
+     *
+      * It keeps the currently open node details panels.
+     */
+     nodeDetailsPanels: GraphNodeDetailsPanel[] = [];
 
     /**
      * Public variable: triples.
@@ -164,6 +177,8 @@ export class GraphVisualizerComponent implements OnInit {
      * @returns {void} Performs the query.
      */
     performQuery(): void {
+        this.nodeDetailsPanels = [];
+
         // If no namespace is defined in the query, get it from the turtle file
         this.query.queryString = this._graphVisualizerService.checkNamespacesInQuery(
             this.query.queryString,
@@ -195,13 +210,64 @@ export class GraphVisualizerComponent implements OnInit {
             return;
         }
 
+        const clickedNode = this._cloneGraphNode(node);
+        this._upsertNodeDetailsPanel(clickedNode);
+
         this.showToastMessage(
-            new ToastMessage(
-                node.id,
-                `GraphVisualizerComponent# graphClick on node ${node.id}\n\n Label: ${node.label}`,
-                5000
-            ),
+            new ToastMessage(clickedNode.id, this._createGraphNodeClickMessage(clickedNode), 5000),
             'info'
+        );
+    }
+
+    /**
+     * Public method: closeNodeDetailsPanel.
+     *
+     * It closes a node details panel.
+     *
+     * @param {string} panelId The id of the panel.
+     *
+     * @returns {void} Closes the node details panel.
+     */
+    closeNodeDetailsPanel(panelId: string): void {
+        this.nodeDetailsPanels = this.nodeDetailsPanels.filter(panel => panel.id !== panelId);
+    }
+
+    /**
+     * Public method: toggleNodeDetailsPinned.
+     *
+     * It toggles the pin state of a node details panel.
+     *
+     * @param {string} panelId The id of the panel.
+     *
+     * @returns {void} Toggles the pin state.
+     */
+    toggleNodeDetailsPinned(panelId: string): void {
+        const panel = this.nodeDetailsPanels.find(nodeDetailsPanel => nodeDetailsPanel.id === panelId);
+
+        if (!panel) {
+            return;
+        }
+
+        const updatedPanels = this.nodeDetailsPanels.map(nodeDetailsPanel => {
+            if (nodeDetailsPanel.id !== panelId) {
+                return nodeDetailsPanel;
+            }
+
+            return {
+                ...nodeDetailsPanel,
+                isPinned: !nodeDetailsPanel.isPinned,
+            };
+        });
+
+        const toggledPanel = updatedPanels.find(nodeDetailsPanel => nodeDetailsPanel.id === panelId);
+
+        if (toggledPanel?.isPinned) {
+            this.nodeDetailsPanels = updatedPanels;
+            return;
+        }
+
+        this.nodeDetailsPanels = updatedPanels.filter(
+            nodeDetailsPanel => nodeDetailsPanel.isPinned || nodeDetailsPanel.id === panelId
         );
     }
 
@@ -254,6 +320,126 @@ export class GraphVisualizerComponent implements OnInit {
         } else {
             console.info(toastMessage.name, ':', toastMessage.message);
         }
+    }
+
+    /**
+     * Private method: _createGraphNodeClickMessage.
+     *
+     * It formats the message shown when clicking on a graph node.
+     *
+     * @param {D3SimulationNode} node The clicked node.
+     *
+     * @returns {string} The formatted toast message.
+     */
+    private _createGraphNodeClickMessage(node: D3SimulationNode): string {
+        const messageLines = [`GraphVisualizerComponent# graphClick on node ${node.id}`, '', `Label: ${node.label}`];
+        const sourceDetails = this._getUniqueSourceDetails(node);
+
+        sourceDetails.forEach((sourceDetail, index) => {
+            messageLines.push('');
+            messageLines.push(sourceDetails.length === 1 ? `Source: ${sourceDetail.label}` : `Source ${index + 1}: ${sourceDetail.label}`);
+
+            if (sourceDetail.type) {
+                messageLines.push(`Type: ${sourceDetail.type}`);
+            }
+
+            if (sourceDetail.location) {
+                messageLines.push(`Location: ${sourceDetail.location}`);
+            }
+        });
+
+        return messageLines.join('\n');
+    }
+
+    /**
+     * Private method: _getUniqueSourceDetails.
+     *
+     * It removes duplicate source details before formatting the toast message.
+     *
+     * @param {D3SimulationNode} node The clicked node.
+     *
+     * @returns {D3SimulationNode['sourceDetails']} The unique source details.
+     */
+    private _getUniqueSourceDetails(node: D3SimulationNode): D3SimulationNode['sourceDetails'] {
+        const seenSourceIds = new Set<string>();
+
+        return (node.sourceDetails || []).filter(sourceDetail => {
+            const sourceKey = sourceDetail.id || sourceDetail.label;
+
+            if (seenSourceIds.has(sourceKey)) {
+                return false;
+            }
+
+            seenSourceIds.add(sourceKey);
+            return true;
+        });
+    }
+
+    /**
+     * Private method: _cloneGraphNode.
+     *
+     * It creates a detached copy of the clicked graph node for the side panel.
+     *
+     * @param {D3SimulationNode} node The clicked node.
+     *
+     * @returns {D3SimulationNode} The cloned node.
+     */
+    private _cloneGraphNode(node: D3SimulationNode): D3SimulationNode {
+        return {
+            ...node,
+            sourceDetails: node.sourceDetails?.map(sourceDetail => ({ ...sourceDetail })),
+        } as D3SimulationNode;
+    }
+
+    /**
+     * Private method: _upsertNodeDetailsPanel.
+     *
+     * It keeps pinned panels and opens one additional unpinned panel for the clicked node.
+     *
+     * @param {D3SimulationNode} node The clicked node.
+     *
+     * @returns {void} Updates the node details panel list.
+     */
+    private _upsertNodeDetailsPanel(node: D3SimulationNode): void {
+        const panelId = this._createNodeDetailsPanelId(node);
+        const pinnedPanel = this.nodeDetailsPanels.find(panel => panel.id === panelId && panel.isPinned);
+
+        if (pinnedPanel) {
+            this.nodeDetailsPanels = this.nodeDetailsPanels.map(panel => {
+                if (panel.id !== panelId || !panel.isPinned) {
+                    return panel;
+                }
+
+                return {
+                    ...panel,
+                    node,
+                };
+            });
+            return;
+        }
+
+        const pinnedPanels = this.nodeDetailsPanels.filter(panel => panel.isPinned && panel.id !== panelId);
+        this.nodeDetailsPanels = [
+            ...pinnedPanels,
+            {
+                id: panelId,
+                node,
+                isPinned: false,
+            },
+        ];
+    }
+
+    /**
+     * Private method: _createNodeDetailsPanelId.
+     *
+     * It creates a stable id for a node details panel.
+     *
+     * @param {D3SimulationNode} node The clicked node.
+     *
+     * @returns {string} The panel id.
+     */
+    private _createNodeDetailsPanelId(node: D3SimulationNode): string {
+        return node.id;
     }
 
     /**

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.ts
@@ -91,11 +91,33 @@ export class GraphVisualizerComponent implements OnInit {
     queryTime: number;
 
     /**
-      * Public variable: nodeDetailsPanels.
+     * Public variable: nodeDetailsPanels.
      *
-      * It keeps the currently open node details panels.
+     * It keeps the currently open node details panels.
      */
-     nodeDetailsPanels: GraphNodeDetailsPanel[] = [];
+    nodeDetailsPanels: GraphNodeDetailsPanel[] = [];
+
+    /**
+     * Private variable: _lastClickedNodeId.
+     *
+     * It keeps track of the last clicked node to prevent duplicate clicks.
+     */
+    private _lastClickedNodeId: string | null = null;
+
+    /**
+     * Private variable: _lastClickTime.
+     *
+     * It keeps track of the timestamp of the last node click.
+     */
+    private _lastClickTime: number = 0;
+
+    /**
+     * Private variable: _lastQueryPerformedTime.
+     *
+     * It keeps track of when performQuery was last called.
+     * Used to suppress auto-emitted clicks during D3 render from showing toasts.
+     */
+    private _lastQueryPerformedTime: number = 0;
 
     /**
      * Public variable: triples.
@@ -177,7 +199,15 @@ export class GraphVisualizerComponent implements OnInit {
      * @returns {void} Performs the query.
      */
     performQuery(): void {
+        // Clear any pending toasts from the previous graph to prevent stacking
+        // Create a copy of the toasts array since remove() mutates it
+        const pendingToasts = [...this._toastService.toasts];
+        pendingToasts.forEach(toast => this._toastService.remove(toast));
+
         this.nodeDetailsPanels = [];
+        this._lastClickedNodeId = null;
+        this._lastClickTime = 0;
+        this._lastQueryPerformedTime = Date.now();
 
         // If no namespace is defined in the query, get it from the turtle file
         this.query.queryString = this._graphVisualizerService.checkNamespacesInQuery(
@@ -210,6 +240,23 @@ export class GraphVisualizerComponent implements OnInit {
             return;
         }
 
+        const now = Date.now();
+
+        // Prevent duplicate clicks on the same node within 300ms
+        if (node.id === this._lastClickedNodeId && now - this._lastClickTime < 300) {
+            return;
+        }
+
+        // Suppress toasts only during D3 initial render (1 second)
+        // After that, nodes are fully clickable and functional
+        if (now - this._lastQueryPerformedTime < 1000) {
+            this._lastClickedNodeId = node.id;
+            this._lastClickTime = now;
+            return;
+        }
+
+        this._lastClickedNodeId = node.id;
+        this._lastClickTime = now;
         const clickedNode = this._cloneGraphNode(node);
         this._upsertNodeDetailsPanel(clickedNode);
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/models/d3-simulation-node.model.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/models/d3-simulation-node.model.ts
@@ -1,6 +1,33 @@
 import * as D3_FORCE from 'd3-force';
 
 /**
+ * The D3SimulationNodeSourceDetails interface.
+ *
+ * It stores source metadata attached to a graph node.
+ */
+export interface D3SimulationNodeSourceDetails {
+    /**
+     * The id of the source node.
+     */
+    id: string;
+
+    /**
+     * The label of the source node.
+     */
+    label: string;
+
+    /**
+     * The type description of the source.
+     */
+    type?: string;
+
+    /**
+     * The physical location of the source.
+     */
+    location?: string;
+}
+
+/**
  * The D3SimulationNodeType enumeration.
  *
  * It stores the possible node types.
@@ -26,6 +53,11 @@ export class D3SimulationNode implements D3_FORCE.SimulationNodeDatum {
      * The label of the simulation node.
      */
     label: string;
+
+    /**
+     * Related source details for the simulation node.
+     */
+    sourceDetails?: D3SimulationNodeSourceDetails[];
 
     /**
      * The weigth of the simulation node.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/models/index.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/models/index.ts
@@ -12,7 +12,7 @@ import { D3ForceSimulation, D3ForceSimulationOptions, D3Simulation } from './d3-
 import { D3SimulationData } from './d3-simulation-data';
 import { D3SimulationLink } from './d3-simulation-link.model';
 import { D3SimulationNodeTriple } from './d3-simulation-node-triple.model';
-import { D3SimulationNode, D3SimulationNodeType } from './d3-simulation-node.model';
+import { D3SimulationNode, D3SimulationNodeSourceDetails, D3SimulationNodeType } from './d3-simulation-node.model';
 import { Namespace, NamespaceType } from './namespace.model';
 import { Prefix, PrefixForm } from './prefix.model';
 import { QueryResult, QueryResultBindings } from './query-result.model';
@@ -33,6 +33,7 @@ export {
     D3SimulationData,
     D3SimulationLink,
     D3SimulationNode,
+    D3SimulationNodeSourceDetails,
     D3SimulationNodeTriple,
     D3SimulationNodeType,
     Namespace,

--- a/src/app/views/edition-view/services/edition-rdf-generator.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-rdf-generator.service.spec.ts
@@ -1,16 +1,133 @@
-import { TestBed } from '@angular/core/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
+
+import { EditionComplex, EditionSvgSheetList, GraphList, SourceList } from '../models';
 
 import { EditionRdfGeneratorService } from './edition-rdf-generator.service';
 
 describe('EditionRdfGeneratorService', () => {
     let service: EditionRdfGeneratorService;
+    let httpTestingController: HttpTestingController;
+
+    const expectedAssetPath = 'assets/data/edition/series/1/section/5/op23';
+    const expectedEditionComplex = {
+        pubStatement: {
+            series: { route: '1' },
+            section: { route: '5' },
+        },
+        complexId: { route: 'op23' },
+    } as EditionComplex;
+
+    const expectedGraphData = {
+        graph: [
+            {
+                id: 'op23',
+                title: 'Skizzengraph Opus 23',
+                description: [],
+                rdfData: {
+                    queryList: [],
+                    triples: '',
+                },
+            },
+        ],
+    } as GraphList;
+
+    const expectedSheetsData = {
+        sheets: {
+            workEditions: [],
+            textEditions: [],
+            sketchEditions: [
+                {
+                    id: 'M312_Sk1',
+                    label: 'M 312 Sk1',
+                    content: [
+                        {
+                            svg: 'assets/img/edition/series/1/section/5/op23/M312_Sk1-1von1-final.svg',
+                            image: '',
+                            partial: '',
+                            convolute: 'A',
+                        },
+                    ],
+                },
+            ],
+        },
+    } as EditionSvgSheetList;
+
+    const expectedSourceListData = {
+        sources: [
+            {
+                siglum: 'A',
+                siglumAddendum: '',
+                type: 'Skizzen (in: Skizzenbuch 3).',
+                location: 'CH-Bps, Sammlung Anton Webern.',
+                hasDescription: true,
+                linkTo: 'source_A',
+            },
+        ],
+    } as SourceList;
 
     beforeEach(() => {
-        TestBed.configureTestingModule({});
+        TestBed.configureTestingModule({
+            providers: [EditionRdfGeneratorService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
+        });
+
         service = TestBed.inject(EditionRdfGeneratorService);
+        httpTestingController = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => {
+        httpTestingController.verify();
     });
 
     it('should be created', () => {
         expect(service).toBeTruthy();
     });
+
+    it('... should generate source-aware RDF triples from svg sheets and source list', waitForAsync(() => {
+        let generatedGraphData: GraphList;
+
+        service.generateRdfTriples(expectedEditionComplex).subscribe({
+            next: graphData => {
+                generatedGraphData = graphData;
+            },
+        });
+
+        httpTestingController.expectOne(`${expectedAssetPath}/svg-sheets.json`).flush(expectedSheetsData);
+        httpTestingController.expectOne(`${expectedAssetPath}/source-list.json`).flush(expectedSourceListData);
+        httpTestingController.expectOne(`${expectedAssetPath}/graph.json`).flush(expectedGraphData);
+
+        const triples = generatedGraphData.graph[0].rdfData.triples;
+        const queryList = generatedGraphData.graph[0].rdfData.queryList;
+
+        expect(triples).toContain('rdfs:label "M 312 Sk1 [A]"');
+        expect(triples).toContain('awg:hasSource awg:source_A');
+        expect(triples).toContain('awg:source_A rdfs:label "A"');
+        expect(triples).toContain('awg:sourceType "Skizzen (in: Skizzenbuch 3)."');
+        expect(triples).toContain('awg:sourceLocation "CH-Bps, Sammlung Anton Webern."');
+        expect(queryList.some(query => query.queryLabel === 'Finde alle Quellenbezuege')).toBeTrue();
+        expect(queryList.some(query => query.queryString.includes('awg:hasSource'))).toBeTrue();
+    }));
+
+    it('... should fall back to plain sheet labels if source list loading fails', waitForAsync(() => {
+        let generatedGraphData: GraphList;
+
+        service.generateRdfTriples(expectedEditionComplex).subscribe({
+            next: graphData => {
+                generatedGraphData = graphData;
+            },
+        });
+
+        httpTestingController.expectOne(`${expectedAssetPath}/svg-sheets.json`).flush(expectedSheetsData);
+        httpTestingController.expectOne(`${expectedAssetPath}/source-list.json`).flush(null, {
+            status: 404,
+            statusText: 'NOT FOUND',
+        });
+        httpTestingController.expectOne(`${expectedAssetPath}/graph.json`).flush(expectedGraphData);
+
+        const triples = generatedGraphData.graph[0].rdfData.triples;
+
+        expect(triples).toContain('rdfs:label "M 312 Sk1" .');
+        expect(triples).not.toContain('awg:hasSource');
+    }));
 });

--- a/src/app/views/edition-view/services/edition-rdf-generator.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-rdf-generator.service.spec.ts
@@ -16,7 +16,7 @@ describe('EditionRdfGeneratorService', () => {
             series: { route: '1' },
             section: { route: '5' },
         },
-        complexId: { route: 'op23' },
+        complexId: { route: '/op23' },
     } as EditionComplex;
 
     const expectedGraphData = {

--- a/src/app/views/edition-view/services/edition-rdf-generator.service.ts
+++ b/src/app/views/edition-view/services/edition-rdf-generator.service.ts
@@ -1,17 +1,18 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
-import { Observable, forkJoin } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, forkJoin, of as observableOf } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 
-import { EditionComplex, EditionSvgSheet, EditionSvgSheetList, GraphList } from '../models';
+import { EDITION_ASSETS_DATA } from '../data';
+import { EditionComplex, EditionSvgSheet, EditionSvgSheetList, GraphList, Source, SourceList } from '../models';
 import { EditionDataService } from './edition-data.service';
 
 @Injectable({
     providedIn: 'root',
 })
 export class EditionRdfGeneratorService extends EditionDataService {
-    private _assetsPath = 'assets/data/edition/series/1/section/5/op23/';
+    private _assetsPath = 'assets/data/edition/series/1/section/5/op23';
 
     constructor(private http: HttpClient) {
         super();
@@ -20,14 +21,18 @@ export class EditionRdfGeneratorService extends EditionDataService {
     generateRdfTriples(editionComplex: EditionComplex): Observable<GraphList> {
         this._assetsPath = this._setAssetPathForEditionComplex(editionComplex);
 
-        const sheetsUrl = this._assetsPath + '/svg-sheets.json';
+        const sheetsUrl = `${this._assetsPath}/${EDITION_ASSETS_DATA.FILES.svgSheetsFile}`;
+        const sourceListUrl = `${this._assetsPath}/${EDITION_ASSETS_DATA.FILES.sourceListFile}`;
 
         return forkJoin({
             sheetsData: this.http.get<EditionSvgSheetList>(sheetsUrl),
+            sourceListData: this.http
+                .get<SourceList>(sourceListUrl)
+                .pipe(catchError(() => observableOf(new SourceList()))),
             graphData: this.getEditionGraphData(editionComplex),
         }).pipe(
-            map(({ sheetsData, graphData }) => {
-                const rdfTriples = this._createRdfTriples(sheetsData);
+            map(({ sheetsData, sourceListData, graphData }) => {
+                const rdfTriples = this._createRdfTriples(sheetsData, sourceListData);
                 const queryList = this._createQueryList();
 
                 graphData.graph[0].rdfData.triples = rdfTriples;
@@ -38,7 +43,7 @@ export class EditionRdfGeneratorService extends EditionDataService {
         );
     }
 
-    private _createRdfTriples(sheetsData: EditionSvgSheetList): string {
+    private _createRdfTriples(sheetsData: EditionSvgSheetList, sourceListData: SourceList): string {
         let rdfTriples = `
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -48,24 +53,140 @@ export class EditionRdfGeneratorService extends EditionDataService {
 
 `;
 
-        const generateTriplesForSheet = (sheet: EditionSvgSheet, editionType: string) => {
-            const triples = [];
-            const sheetId = sheet.id;
-            const sheetLabel = sheet.label;
-            triples.push(`awg:${sheetId} a awg:${editionType} ;`);
-            triples.push(`\trdfs:label "${sheetLabel}" .`);
-            return triples.join('\n');
+        const sourceLookup = this._createSourceLookup(sourceListData);
+        const referencedSources = new Map<string, Source>();
+
+        const appendTriplesForSheets = (sheets: EditionSvgSheet[], editionType: string) => {
+            sheets?.forEach((sheet: EditionSvgSheet) => {
+                rdfTriples += this._createSheetTriples(sheet, editionType, sourceLookup, referencedSources) + '\n\n';
+            });
         };
 
-        sheetsData.sheets.textEditions?.forEach((sheet: EditionSvgSheet) => {
-            rdfTriples += generateTriplesForSheet(sheet, 'TextEdition') + '\n\n';
-        });
+        appendTriplesForSheets(sheetsData.sheets.workEditions, 'WorkEdition');
+        appendTriplesForSheets(sheetsData.sheets.textEditions, 'TextEdition');
+        appendTriplesForSheets(sheetsData.sheets.sketchEditions, 'SketchEdition');
 
-        sheetsData.sheets.sketchEditions?.forEach((sheet: EditionSvgSheet) => {
-            rdfTriples += generateTriplesForSheet(sheet, 'SketchEdition') + '\n\n';
+        referencedSources.forEach(source => {
+            rdfTriples += this._createSourceTriples(source) + '\n\n';
         });
 
         return rdfTriples.trim();
+    }
+
+    private _createSheetTriples(
+        sheet: EditionSvgSheet,
+        editionType: string,
+        sourceLookup: Map<string, Source>,
+        referencedSources: Map<string, Source>
+    ): string {
+        const sources = this._collectSourcesForSheet(sheet, sourceLookup);
+        const displayLabel = this._createSheetDisplayLabel(sheet.label, sources);
+        const triples = [`awg:${sheet.id} a awg:${editionType} ;`, `\trdfs:label "${this._escapeLiteral(displayLabel)}"`];
+
+        sources.forEach(source => {
+            const sourceNodeId = this._getSourceNodeId(source);
+
+            referencedSources.set(sourceNodeId, source);
+            triples.push(`\tawg:hasSource awg:${sourceNodeId}`);
+        });
+
+        return triples
+            .map((line, index) => {
+                if (index === 0) {
+                    return line;
+                }
+
+                const terminator = index === triples.length - 1 ? ' .' : ' ;';
+                return `${line}${terminator}`;
+            })
+            .join('\n');
+    }
+
+    private _createSourceLookup(sourceListData: SourceList): Map<string, Source> {
+        const lookup = new Map<string, Source>();
+
+        sourceListData?.sources?.forEach(source => {
+            const combinedKey = this._normalizeSourceKey(this._formatSourceSiglum(source));
+            const plainKey = this._normalizeSourceKey(source.siglum);
+
+            if (combinedKey) {
+                lookup.set(combinedKey, source);
+            }
+            if (plainKey && !lookup.has(plainKey)) {
+                lookup.set(plainKey, source);
+            }
+        });
+
+        return lookup;
+    }
+
+    private _collectSourcesForSheet(sheet: EditionSvgSheet, sourceLookup: Map<string, Source>): Source[] {
+        const sources = new Map<string, Source>();
+
+        sheet.content?.forEach(content => {
+            const sourceKey = this._normalizeSourceKey(content.convolute);
+
+            if (!sourceKey) {
+                return;
+            }
+
+            const source = sourceLookup.get(sourceKey);
+
+            if (source) {
+                sources.set(this._getSourceNodeId(source), source);
+            }
+        });
+
+        return Array.from(sources.values());
+    }
+
+    private _createSheetDisplayLabel(sheetLabel: string, sources: Source[]): string {
+        if (!sources.length) {
+            return sheetLabel;
+        }
+
+        const sourceSigla = sources.map(source => this._formatSourceSiglum(source)).join(', ');
+        return `${sheetLabel} [${sourceSigla}]`;
+    }
+
+    private _createSourceTriples(source: Source): string {
+        const sourceNodeId = this._getSourceNodeId(source);
+        const sourceLabel = this._formatSourceSiglum(source);
+        const triples = [`awg:${sourceNodeId} rdfs:label "${this._escapeLiteral(sourceLabel)}"`];
+
+        if (source?.type?.trim()) {
+            triples.push(`\tawg:sourceType "${this._escapeLiteral(source.type.trim())}"`);
+        }
+
+        if (source?.location?.trim()) {
+            triples.push(`\tawg:sourceLocation "${this._escapeLiteral(source.location.trim())}"`);
+        }
+
+        return triples.map((line, index) => `${line}${index === triples.length - 1 ? ' .' : ' ;'}`).join('\n');
+    }
+
+    private _formatSourceSiglum(source: Source): string {
+        return `${source?.siglum ?? ''}${source?.siglumAddendum ?? ''}`.trim();
+    }
+
+    private _getSourceNodeId(source: Source): string {
+        if (source?.linkTo?.trim()) {
+            return this._sanitizeNodeId(source.linkTo);
+        }
+
+        return this._sanitizeNodeId(`source_${this._formatSourceSiglum(source)}`);
+    }
+
+    private _normalizeSourceKey(sourceKey?: string): string {
+        return sourceKey?.replace(/\s+/g, '').trim() ?? '';
+    }
+
+    private _sanitizeNodeId(value: string): string {
+        return value.replace(/[^A-Za-z0-9_]+/g, '_').replace(/_+/g, '_').replace(/^_+|_+$/g, '');
+    }
+
+    private _escapeLiteral(value: string): string {
+        return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\r?\n/g, ' ');
     }
 
     private _createQueryList() {
@@ -81,6 +202,12 @@ export class EditionRdfGeneratorService extends EditionDataService {
                 queryLabel: 'Finde alle Editionskomplexe',
                 queryString:
                     'PREFIX dc: <http://purl.org/dc/elements/1.1/> \nPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \nPREFIX owl: <http://www.w3.org/2002/07/owl#> \nPREFIX awg: <https://edition.anton-webern.ch/webern-onto#> \n\n CONSTRUCT \n WHERE { \n\t ?complex a awg:EditionComplex; rdfs:label ?label .  \n }',
+            },
+            {
+                queryType: 'construct',
+                queryLabel: 'Finde alle Quellenbezuege',
+                queryString:
+                    'PREFIX dc: <http://purl.org/dc/elements/1.1/> \nPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \nPREFIX owl: <http://www.w3.org/2002/07/owl#> \nPREFIX awg: <https://edition.anton-webern.ch/webern-onto#> \n\n CONSTRUCT { \n\t ?sheet awg:hasSource ?source .\n\t ?sheet rdfs:label ?sheetLabel .\n\t ?source rdfs:label ?sourceLabel .\n\t ?source awg:sourceType ?sourceType .\n\t ?source awg:sourceLocation ?sourceLocation .\n }\n WHERE { \n\t ?sheet awg:hasSource ?source ; rdfs:label ?sheetLabel .\n\t ?source rdfs:label ?sourceLabel .\n\t OPTIONAL { ?source awg:sourceType ?sourceType . }\n\t OPTIONAL { ?source awg:sourceLocation ?sourceLocation . }\n }',
             },
         ];
     }


### PR DESCRIPTION
High-Level Outcome
1. The dynamic graph is now automatically enriched with source information from source-list data.
2. Node rendering now prefers human-readable labels instead of raw ids.
3. Source type and source location are available on clicked nodes and shown in UI details.
4. The graph got a sidepanel details UI that supports multiple panels when they are pinned.
5. A new source-focused SPARQL preset was added.
6. Test coverage was extended for all of the above.

Functional Changes in the App
1. Automatic source linking in graph generation: [edition-rdf-generator.service.ts:21](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) It now loads svg sheets and source list together, maps sheet convolute values to sources, and generates source-aware triples.
2. Sheet labels can include source sigla: [edition-rdf-generator.service.ts:152](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) The generator emits source metadata triples, including sourceType and sourceLocation.
3. New source query preset: [edition-rdf-generator.service.ts:208](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) Finde alle Quellenbezuege was added to query presets.
4. Graph nodes display labels, not raw qnames: [force-graph.component.ts:554](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
5. Metadata-only triples are hidden from visual edges: [force-graph.component.ts:855](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) sourceType and sourceLocation are used for details, but do not clutter the graph layout.
6. Clicked node details now include source type and location: [graph-visualizer.component.ts:334](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
8. Sidepanel UI was added for node details: [graph-visualizer.component.html:36](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
9. Multiple sidepanels are supported when pinned: [graph-visualizer.component.ts:403](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) Pinned panels persist; a new click opens one active unpinned panel.
10. Pin button text now uses umlaut: [graph-visualizer.component.html:69](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) The label is now Lösen instead of Loesen.
11. Panel styling supports multi-panel stack and pinned visual state: [graph-visualizer.component.scss:2](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Core Code Change Map
1. Runtime RDF generation: [edition-rdf-generator.service.ts:21](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
2. Source metadata triple emission: [edition-rdf-generator.service.ts:152](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
3. Source preset query: [edition-rdf-generator.service.ts:208](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
4. Force graph conversion and metadata handling: [force-graph.component.ts:845](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
5. Node model extension with source details: [d3-simulation-node.model.ts:8](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
6. Export of new model type: [index.ts:15](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
7. Multi-panel state + pin/close behavior: [graph-visualizer.component.ts:98](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
8. Multi-panel template rendering and controls: [graph-visualizer.component.html:51](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Tests Added/Updated
1. RDF generator behavior, source metadata, and fallback: [edition-rdf-generator.service.spec.ts:87](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
2. Force graph label rendering and metadata attachment: [force-graph.component.spec.ts:36](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
3. Graph visualizer toast details, sidepanel persistence, pin text Lösen, and multi-panel behavior: [graph-visualizer.component.spec.ts:1115](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Validation Status
1. TypeScript/template diagnostics are clean for edited files.
2. Targeted ng test bundle compiles successfully.
3. Browser execution still stops at environment level because ChromeHeadless cannot launch without a Chrome binary or CHROME_BIN.

Suggested Reading Order for Another Developer
1. Start with data generation: [edition-rdf-generator.service.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
2. Then graph conversion: [force-graph.component.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
3. Then UI state + template: [graph-visualizer.component.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [graph-visualizer.component.html](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
5. Finally read tests for intent and edge cases: [edition-rdf-generator.service.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [force-graph.component.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [graph-visualizer.component.spec.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)