### PR TITLE
fix(assets): add line break between kv snippets in m144

### DIFF
--- a/src/assets/data/edition/series/1/section/5/m144/source-description.json
+++ b/src/assets/data/edition/series/1/section/5/m144/source-description.json
@@ -238,7 +238,7 @@
                                             "measure": "6 <br />bis 8",
                                             "system": "Ges.",
                                             "position": "",
-                                            "comment": "Korrekturskizze über dem System: <br />##Abbildung## ##Abbildung##"
+                                            "comment": "Korrekturskizze über dem System: <br />##Abbildung## <br />##Abbildung##"
                                         },
                                         {
                                             "svgGroupId": "awg-kv-m144_tf1_A_corr_2-002",

--- a/src/assets/themes/scss/main.scss
+++ b/src/assets/themes/scss/main.scss
@@ -472,3 +472,6 @@ details[open] summary::before {
     width: auto;
     cursor: pointer;
 }
+.awg-edition-tkk-snippet + br + .awg-edition-tkk-snippet {
+    margin-top: 0.25em; /* add margin between multiple consecutive snippets */
+}

--- a/src/assets/themes/scss/main.scss
+++ b/src/assets/themes/scss/main.scss
@@ -473,5 +473,5 @@ details[open] summary::before {
     cursor: pointer;
 }
 .awg-edition-tkk-snippet + br + .awg-edition-tkk-snippet {
-    margin-top: 0.25em; /* add margin between multiple consecutive snippets */
+    margin-top: 0.25em; /* add margin between consecutive snippets */
 }

--- a/src/assets/themes/scss/main.scss
+++ b/src/assets/themes/scss/main.scss
@@ -471,6 +471,7 @@ details[open] summary::before {
     max-height: 4em;
     width: auto;
     cursor: pointer;
+    display: inline-block;
 }
 .awg-edition-tkk-snippet + br + .awg-edition-tkk-snippet {
     margin-top: 0.25em; /* add margin between consecutive snippets */


### PR DESCRIPTION
This PR adds a line break between the consecutive KV snippets in m144 and adjusts the styling.