### PR TITLE
build(deps): bump actions/setup-node from 4.4.0 to 6.4.0

### DIFF
--- a/.github/actions/common-node-setup/action.yml
+++ b/.github/actions/common-node-setup/action.yml
@@ -8,7 +8,7 @@ runs:
           shell: bash
 
         - name: Set up node and yarn cache
-          uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+          uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
           with:
               node-version: ${{ inputs.node-version }}
               cache: 'yarn'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,9 @@ version: 2
 updates:
     # Maintain dependencies for GitHub Actions
     - package-ecosystem: 'github-actions'
-      directory: '/'
+      directories:
+          - '/'
+          - '/.github/actions/common-node-setup'
       schedule:
           interval: 'daily'
       target-branch: 'develop'


### PR DESCRIPTION
This PR updates the common node setup deps and includes them in the dependabot updates.