### PR TITLE
test(app): improve type checks in tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,6 +77,7 @@ export default defineConfig(
             '@angular-eslint/no-output-on-prefix': 'error',
             '@angular-eslint/no-output-rename': 'error',
             '@angular-eslint/no-outputs-metadata-property': 'error',
+            '@angular-eslint/no-uncalled-signals': 'error',
             '@angular-eslint/prefer-standalone': 'off',
             '@angular-eslint/use-lifecycle-interface': 'error',
             '@angular-eslint/use-pipe-transform-interface': 'error',

--- a/src/app/core/services/analytics-sercvice/analytics.service.spec.ts
+++ b/src/app/core/services/analytics-sercvice/analytics.service.spec.ts
@@ -7,7 +7,7 @@ type Spy = ReturnType<typeof vi.spyOn>;
 import { expectSpyCall, expectToBe, expectToEqual } from '@testing/expect-helper';
 import { mockAnalytics, mockConsole } from '@testing/mock-helper';
 
-import { AnalyticsService } from './analytics.service';
+import { AnalyticsConfigEvent, AnalyticsService } from './analytics.service';
 
 // Helper functions for  Analytics setup
 function setupAnalytics(service: AnalyticsService, endpoint: string, id: string, pageView?: boolean) {
@@ -218,7 +218,7 @@ describe('AnalyticsService (DONE)', () => {
         });
 
         it('... should track the given page', () => {
-            const expectedAnalyticsEvent = [
+            const expectedAnalyticsEvent: AnalyticsConfigEvent = [
                 'config',
                 expectedAnalyticsId,
                 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -235,13 +235,13 @@ describe('AnalyticsService (DONE)', () => {
         });
 
         it('... should track page changes', () => {
-            const expectedAnalyticsEvent = [
+            const expectedAnalyticsEvent: AnalyticsConfigEvent = [
                 'config',
                 expectedAnalyticsId,
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 { page_path: expectedPage, send_page_view: expectedSendPageView },
             ];
-            const otherAnalyticsEvent = [
+            const otherAnalyticsEvent: AnalyticsConfigEvent = [
                 'config',
                 expectedAnalyticsId,
                 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/app/core/services/analytics-sercvice/analytics.service.ts
+++ b/src/app/core/services/analytics-sercvice/analytics.service.ts
@@ -10,6 +10,14 @@ import { environment } from 'environments/environment';
 declare let gtag: Function;
 
 /**
+ * The AnalyticsConfigEvent type.
+ *
+ * It defines the type for the Analytics event configuration.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type AnalyticsConfigEvent = [string, string, { page_path: string; send_page_view: boolean }];
+
+/**
  * The Analytics service.
  *
  * It handles the configuration for the GoogleAnalytics setup.
@@ -93,12 +101,18 @@ export class AnalyticsService {
             return;
         }
 
-        gtag('config', this._analyticsId, {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            page_path: page,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            send_page_view: this._sendPageView,
-        });
+        const configEvent: AnalyticsConfigEvent = [
+            'config',
+            this._analyticsId,
+            {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                page_path: page,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                send_page_view: this._sendPageView,
+            },
+        ];
+
+        gtag(...configEvent);
     }
 
     /**

--- a/src/app/core/services/fullscreen-service/fullscreen.service.spec.ts
+++ b/src/app/core/services/fullscreen-service/fullscreen.service.spec.ts
@@ -87,14 +87,16 @@ describe('FullscreenService (DONE)', () => {
         });
 
         it('... should catch an error if `exitFullscreen` fails', async () => {
-            exitFullscreenSpy.mockReturnValue(Promise.reject(new Error('Test error')));
+            const err = new Error('Test error');
+            exitFullscreenSpy.mockReturnValue(Promise.reject(err));
 
             fullscreenService.closeFullscreen();
             await Promise.resolve();
 
+            const loggedError = mockConsole.get(0) as unknown as Error;
             expectSpyCall(exitFullscreenSpy, 1);
-            expectSpyCall(consoleSpy, 1, new Error('Test error'));
-            expectToEqual(mockConsole.get(0), new Error('Test error'));
+            expectSpyCall(consoleSpy, 1, err);
+            expectToBe(loggedError, err);
         });
     });
 
@@ -156,6 +158,7 @@ describe('FullscreenService (DONE)', () => {
         });
 
         it('... should catch an error if `requestFullscreen` fails', async () => {
+            const err = new Error('Test error');
             const element = mockDocument.createElement('div');
             // Redefine as configurable/writable for spy
             Object.defineProperty(element, 'requestFullscreen', {
@@ -163,16 +166,15 @@ describe('FullscreenService (DONE)', () => {
                 configurable: true,
                 writable: true,
             });
-            const requestFullscreenSpy = vi
-                .spyOn(element, 'requestFullscreen')
-                .mockReturnValue(Promise.reject(new Error('Test error')));
+            const requestFullscreenSpy = vi.spyOn(element, 'requestFullscreen').mockReturnValue(Promise.reject(err));
 
             fullscreenService.openFullscreen(element);
             await Promise.resolve();
 
+            const loggedError = mockConsole.get(0) as unknown as Error;
             expectSpyCall(requestFullscreenSpy, 1);
-            expectSpyCall(consoleSpy, 1, new Error('Test error'));
-            expectToEqual(mockConsole.get(0), new Error('Test error'));
+            expectSpyCall(consoleSpy, 1, err);
+            expectToEqual(loggedError, err);
         });
     });
 });

--- a/src/app/shared/toast/toast.component.spec.ts
+++ b/src/app/shared/toast/toast.component.spec.ts
@@ -31,7 +31,7 @@ class NgbToastStubComponent {
     @Input()
     class: string;
     @Input()
-    autohide: string;
+    autohide: boolean;
     @Input()
     delay: number;
     @Output()

--- a/src/app/views/contact-view/contact-address/contact-address.component.spec.ts
+++ b/src/app/views/contact-view/contact-address/contact-address.component.spec.ts
@@ -40,11 +40,11 @@ describe('ContactAddressComponent (DONE)', () => {
 
     describe('BEFORE initial data binding', () => {
         it('... should have default `pageMetaData`', () => {
-            expectToEqual(component.pageMetaData(), {});
+            expectToEqual(component.pageMetaData(), {} as MetaPage);
         });
 
         it('... should have default `contactMetaData`', () => {
-            expectToEqual(component.contactMetaData(), {});
+            expectToEqual(component.contactMetaData(), {} as MetaContact);
         });
 
         describe('VIEW', () => {
@@ -116,11 +116,11 @@ describe('ContactAddressComponent (DONE)', () => {
         });
 
         it('... should have default `pageMetaData`', () => {
-            expectToEqual(component.pageMetaData(), {});
+            expectToEqual(component.pageMetaData(), {} as MetaPage);
         });
 
         it('... should have default `contactMetaData`', () => {
-            expectToEqual(component.contactMetaData(), {});
+            expectToEqual(component.contactMetaData(), {} as MetaContact);
         });
     });
 

--- a/src/app/views/contact-view/contact-side-info/contact-side-info.component.spec.ts
+++ b/src/app/views/contact-view/contact-side-info/contact-side-info.component.spec.ts
@@ -148,8 +148,8 @@ describe('ContactSideInfoComponent (DONE)', () => {
                     ContactAddressStubComponent
                 ) as ContactAddressStubComponent;
 
-                expectToEqual(addressCmp.pageMetaData(), {});
-                expectToEqual(addressCmp.contactMetaData(), {});
+                expectToEqual(addressCmp.pageMetaData(), {} as MetaPage);
+                expectToEqual(addressCmp.contactMetaData(), {} as MetaContact);
             });
 
             it('... should contain one map component (stubbed)', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
@@ -72,7 +72,7 @@ class GraphVisualizerStubComponent {
     isFullscreen: boolean;
     // Mock the viewChild fs
     get fs() {
-        return { nativeElement: '<div></div>' };
+        return { nativeElement: document.createElement('div') };
     }
 }
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.spyOn>;
 
-import { EmptyError, lastValueFrom, Observable } from 'rxjs';
+import { EmptyError, lastValueFrom, Observable, take } from 'rxjs';
 
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
@@ -19,7 +19,7 @@ import { mockConsole } from '@testing/mock-helper';
 import { Toast, ToastMessage, ToastService } from '@awg-shared/toast/toast.service';
 
 import { GraphRDFData, GraphSparqlQuery } from '@awg-views/edition-view/models';
-import { D3SimulationNode, D3SimulationNodeType, QuerySelectResult, Triple } from './models';
+import { D3SimulationNode, D3SimulationNodeType, QueryResult, QuerySelectResult, Triple } from './models';
 import { GraphVisualizerService } from './services/graph-visualizer.service';
 
 import { GraphVisualizerComponent } from './graph-visualizer.component';
@@ -143,16 +143,22 @@ describe('GraphVisualizerComponent (DONE)', () => {
     let showToastMessageSpy: Spy;
     let toastServiceAddSpy: Spy;
 
+    let lastQueryString = '';
+
     beforeEach(async () => {
+        lastQueryString = '';
+
         // Mocked dataStreamerService
         mockGraphVisualizerService = {
-            checkNamespacesInQuery: (queryString: string): string => queryString,
-            getQuerytype: (): string => 'construct',
-            doQuery: (): Promise<Triple[]> =>
-                new Promise((resolve, reject) => {
-                    resolve(expectedConstructResult);
-                    reject({ name: 'Error1', message: 'failed' });
-                }),
+            checkNamespacesInQuery: (queryString: string): string => {
+                lastQueryString = queryString;
+                return queryString;
+            },
+            getQuerytype: (): string => (lastQueryString.toLowerCase().includes('select') ? 'select' : 'construct'),
+            doQuery: (queryString: string): Promise<QueryResult> => {
+                const isSelectQuery = queryString.toLowerCase().includes('select');
+                return isSelectQuery ? Promise.resolve(expectedSelectResult) : Promise.resolve(expectedConstructResult);
+            },
         };
 
         await TestBed.configureTestingModule({
@@ -190,6 +196,11 @@ describe('GraphVisualizerComponent (DONE)', () => {
             queryType: 'construct',
             queryLabel: 'Test Query 2',
             queryString: 'PREFIX example: <https://example.com/onto#> \n\n CONSTRUCT WHERE { ?test2 ?has ?success2 . }',
+        });
+        expectedGraphRDFData.queryList.push({
+            queryType: 'select',
+            queryLabel: 'Test Query 3',
+            queryString: 'PREFIX example: <https://example.com/onto#> \n\n SELECT * WHERE { ?test3 ?has ?success3 . }',
         });
         expectedGraphRDFData.triples =
             '@prefix example: <https://example.com/onto#> .\n\n example:Test example:has example:Success .';
@@ -327,7 +338,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
         it('... should have queryResult', () => {
             expect(component.queryResult$).toBeDefined();
 
-            component.queryResult$.subscribe(result => {
+            component.queryResult$.pipe(take(1)).subscribe(result => {
                 expectToEqual(result, expectedConstructResult);
             });
         });
@@ -660,7 +671,8 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
             it('... should trigger `_queryLocalStore` for select queries', async () => {
                 // Set select query type
-                serviceGetQueryTypeSpy.mockReturnValue('select');
+                component.query.queryType = expectedGraphRDFData.queryList[2].queryType;
+                component.query.queryString = expectedGraphRDFData.queryList[2].queryString;
 
                 // Perform query
                 component.performQuery();
@@ -670,7 +682,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
                 expectSpyCall(performQuerySpy, 2, undefined);
                 expectSpyCall(queryLocalStoreSpy, 2, [
                     'select',
-                    expectedGraphRDFData.queryList[0].queryString,
+                    expectedGraphRDFData.queryList[2].queryString,
                     expectedGraphRDFData.triples,
                 ]);
             });
@@ -690,7 +702,8 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
             it('... should get queryResult for select queries', async () => {
                 // Set select query type
-                serviceGetQueryTypeSpy.mockReturnValue('select');
+                component.query.queryType = expectedGraphRDFData.queryList[2].queryType;
+                component.query.queryString = expectedGraphRDFData.queryList[2].queryString;
 
                 // Perform query
                 component.performQuery();
@@ -698,7 +711,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
                 expectToBe(component.query.queryType, 'select');
                 await expect(lastValueFrom(component.queryResult$)).resolves.not.toThrow();
-                await expect(lastValueFrom(component.queryResult$)).resolves.toEqual(expectedConstructResult);
+                await expect(lastValueFrom(component.queryResult$)).resolves.toEqual(expectedSelectResult);
             });
 
             it('... should set empty observable for update query types', async () => {
@@ -752,7 +765,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
                 expectSpyCall(serviceSpy, 1, expectedCallback);
             });
 
-            it('... should return query result on success', async () => {
+            it('... should return query result on success (construct)', async () => {
                 const expectedCallback = [
                     'construct',
                     expectedGraphRDFData.queryList[0].queryString,
@@ -769,6 +782,29 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
                 await expect(lastValueFrom(component.queryResult$)).resolves.not.toThrow();
                 await expect(lastValueFrom(component.queryResult$)).resolves.toEqual(expectedConstructResult);
+            });
+
+            it('... should return query result on success (select)', async () => {
+                // Set select query type
+                component.query.queryType = expectedGraphRDFData.queryList[2].queryType;
+                component.query.queryString = expectedGraphRDFData.queryList[2].queryString;
+
+                const expectedCallback = [
+                    'select',
+                    expectedGraphRDFData.queryList[2].queryString,
+                    expectedGraphRDFData.triples,
+                ];
+
+                // Perform query
+                component.performQuery();
+                await detectChangesOnPush(fixture);
+
+                await expect(
+                    graphVisualizerService.doQuery(expectedCallback[0], expectedCallback[1], expectedCallback[2])
+                ).resolves.toEqual(expectedSelectResult);
+
+                await expect(lastValueFrom(component.queryResult$)).resolves.not.toThrow();
+                await expect(lastValueFrom(component.queryResult$)).resolves.toEqual(expectedSelectResult);
             });
 
             it('... should return string message on successful select query with no results', async () => {
@@ -1436,7 +1472,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
                     ) as ConstructResultsStubComponent;
 
                     expect(resultsCmp.queryResult$).toBeDefined();
-                    resultsCmp.queryResult$.subscribe(result => {
+                    resultsCmp.queryResult$.pipe(take(1)).subscribe(result => {
                         expectToEqual(result, expectedConstructResult);
                     });
                 });
@@ -1469,8 +1505,12 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
             describe('SelectResultsComponent', () => {
                 beforeEach(async () => {
-                    // Set select mode
-                    component.query.queryType = 'select';
+                    // Set select query type
+                    component.query.queryType = expectedGraphRDFData.queryList[2].queryType;
+                    component.query.queryString = expectedGraphRDFData.queryList[2].queryString;
+
+                    // Perform query to set SELECT queryResult
+                    component.performQuery();
                     await detectChangesOnPush(fixture);
                 });
 
@@ -1481,7 +1521,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
                     ) as SelectResultsStubComponent;
 
                     expect(resultsCmp.queryResult$).toBeDefined();
-                    resultsCmp.queryResult$.subscribe(result => {
+                    resultsCmp.queryResult$.pipe(take(1)).subscribe(result => {
                         expectToEqual(result, expectedSelectResult);
                     });
                 });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/graph-visualizer.component.spec.ts
@@ -48,7 +48,7 @@ class ConstructResultsStubComponent {
 })
 class SelectResultsStubComponent {
     @Input()
-    queryResult$: Observable<QuerySelectResult | string>;
+    queryResult$: Observable<QuerySelectResult | string | undefined>;
     @Input()
     queryTime: number;
     @Input()
@@ -128,7 +128,8 @@ describe('GraphVisualizerComponent (DONE)', () => {
     let toastService: ToastService;
 
     let expectedGraphRDFData: GraphRDFData;
-    let expectedResult: Triple[];
+    let expectedConstructResult: Triple[];
+    let expectedSelectResult: QuerySelectResult | string | undefined;
     let expectedIsFullscreen: boolean;
 
     let consoleSpy: Spy;
@@ -149,7 +150,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
             getQuerytype: (): string => 'construct',
             doQuery: (): Promise<Triple[]> =>
                 new Promise((resolve, reject) => {
-                    resolve(expectedResult);
+                    resolve(expectedConstructResult);
                     reject({ name: 'Error1', message: 'failed' });
                 }),
         };
@@ -193,13 +194,25 @@ describe('GraphVisualizerComponent (DONE)', () => {
         expectedGraphRDFData.triples =
             '@prefix example: <https://example.com/onto#> .\n\n example:Test example:has example:Success .';
 
-        expectedResult = [
+        expectedConstructResult = [
             {
                 subject: 'Test',
                 predicate: 'has',
                 object: 'Success',
             },
         ];
+        expectedSelectResult = {
+            head: { vars: ['test', 'has', 'success'] },
+            body: {
+                bindings: [
+                    {
+                        test: { type: 'uri', value: 'Test' },
+                        has: { type: 'uri', value: 'has' },
+                        success: { type: 'uri', value: 'Success' },
+                    },
+                ],
+            },
+        };
 
         expectedIsFullscreen = false;
 
@@ -315,7 +328,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
             expect(component.queryResult$).toBeDefined();
 
             component.queryResult$.subscribe(result => {
-                expectToEqual(result, expectedResult);
+                expectToEqual(result, expectedConstructResult);
             });
         });
 
@@ -328,7 +341,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
             await expect(
                 graphVisualizerService.doQuery(expectedCallback[0], expectedCallback[1], expectedCallback[2])
-            ).resolves.toEqual(expectedResult);
+            ).resolves.toEqual(expectedConstructResult);
 
             expect(component.queryTime).toBeDefined();
             // Value is not predictable
@@ -672,7 +685,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
                 expectToBe(component.query.queryType, 'construct');
                 await expect(lastValueFrom(component.queryResult$)).resolves.not.toThrow();
-                await expect(lastValueFrom(component.queryResult$)).resolves.toEqual(expectedResult);
+                await expect(lastValueFrom(component.queryResult$)).resolves.toEqual(expectedConstructResult);
             });
 
             it('... should get queryResult for select queries', async () => {
@@ -685,7 +698,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
                 expectToBe(component.query.queryType, 'select');
                 await expect(lastValueFrom(component.queryResult$)).resolves.not.toThrow();
-                await expect(lastValueFrom(component.queryResult$)).resolves.toEqual(expectedResult);
+                await expect(lastValueFrom(component.queryResult$)).resolves.toEqual(expectedConstructResult);
             });
 
             it('... should set empty observable for update query types', async () => {
@@ -752,10 +765,10 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
                 await expect(
                     graphVisualizerService.doQuery(expectedCallback[0], expectedCallback[1], expectedCallback[2])
-                ).resolves.toEqual(expectedResult);
+                ).resolves.toEqual(expectedConstructResult);
 
                 await expect(lastValueFrom(component.queryResult$)).resolves.not.toThrow();
-                await expect(lastValueFrom(component.queryResult$)).resolves.toEqual(expectedResult);
+                await expect(lastValueFrom(component.queryResult$)).resolves.toEqual(expectedConstructResult);
             });
 
             it('... should return string message on successful select query with no results', async () => {
@@ -1424,7 +1437,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
                     expect(resultsCmp.queryResult$).toBeDefined();
                     resultsCmp.queryResult$.subscribe(result => {
-                        expectToEqual(result, expectedResult);
+                        expectToEqual(result, expectedConstructResult);
                     });
                 });
 
@@ -1469,7 +1482,7 @@ describe('GraphVisualizerComponent (DONE)', () => {
 
                     expect(resultsCmp.queryResult$).toBeDefined();
                     resultsCmp.queryResult$.subscribe(result => {
-                        expectToEqual(result, expectedResult);
+                        expectToEqual(result, expectedSelectResult);
                     });
                 });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
@@ -1498,7 +1498,7 @@ describe('IntroComponent (DONE)', () => {
                     const result$ = (component as any)._fetchAndFilterIntroData(seriesRoute, sectionRoute, null);
 
                     result$.subscribe({
-                        next: (data: Observable<IntroList>) => {
+                        next: (data: IntroList) => {
                             expectToEqual(data, expectedEditionIntroData);
                         },
                         error: (err: any) => {
@@ -1597,7 +1597,7 @@ describe('IntroComponent (DONE)', () => {
                     const result$ = (component as any)._fetchAndFilterIntroData(seriesRoute, sectionRoute, complex);
 
                     result$.subscribe({
-                        next: (data: Observable<IntroList>) => {
+                        next: (data: IntroList) => {
                             expectToEqual(data, expectedEditionIntroFilteredData);
                         },
                         error: (err: any) => {

--- a/src/app/views/edition-view/edition-outlets/edition-series/edition-series.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series/edition-series.component.spec.ts
@@ -543,7 +543,7 @@ describe('EditionSeriesComponent (DONE)', () => {
             });
 
             it('...should set `editionOutline`', () => {
-                const anotherEditionOutline = structuredClone(mockEditionOutline);
+                const anotherEditionOutline: EditionOutlineSeries[] = structuredClone(mockEditionOutline);
                 anotherEditionOutline[0].series = EDITION_ROUTE_CONSTANTS.SERIES_2;
 
                 serviceGetEditionOutlineSpy.mockReturnValue(anotherEditionOutline);

--- a/src/app/views/statistics-view/statistics-view.component.spec.ts
+++ b/src/app/views/statistics-view/statistics-view.component.spec.ts
@@ -39,7 +39,7 @@ class StatisticsComplexBreakdownStubComponent {
     template: '',
 })
 class StatisticsSeriesBreakdownStubComponent {
-    seriesBreakdownData = input.required<StatisticsSeriesBreakdown>();
+    seriesBreakdownData = input.required<StatisticsSeriesBreakdown[]>();
 }
 
 @Component({
@@ -185,7 +185,7 @@ describe('StatisticsViewComponent', () => {
 
     describe('BEFORE initial data binding', () => {
         it('... should have a signal `statisticsData` (initialized with data from StatisticsService)', () => {
-            expectToEqual(component.statisticsData(), {});
+            expectToEqual(component.statisticsData(), {} as Statistics);
 
             expect(mockStatisticsService.getStatisticsFromOutline).toHaveBeenCalled();
         });

--- a/src/testing/expect-helper.ts
+++ b/src/testing/expect-helper.ts
@@ -121,52 +121,52 @@ export function getAndExpectDebugElementByDirective(
 /**
  * Test helper function: expectToBe.
  *
- * It checks if a given source value is defined and if it is the same as the expected value ('toBe').
+ * It checks if a given actual value is defined and if it is the same as the expected value ('toBe').
  *
  * Exposed to be called from tests.
  *
- * @param {any} source The input value to be checked.
- * @param {any} expected The expected value.
+ * @param {T} actual The actual input value to be checked.
+ * @param {T} expected The expected value.
  *
  * @returns {void} Throws the expectation statements.
  */
-export function expectToBe(source: any, expected: any): void {
-    expect(source).toBeDefined();
-    expect(source, `should be ${expected}`).toBe(expected);
+export function expectToBe<T>(actual: T, expected: T): void {
+    expect(actual).toBeDefined();
+    expect(actual, `should be ${expected}`).toBe(expected);
 }
 
 /**
  * Test helper function: expectToContain.
  *
- * It checks if a given source value is defined and if it contains the expected value ('toContain').
+ * It checks if a given actual value is defined and if it contains the expected value ('toContain').
  *
  * Exposed to be called from tests.
  *
- * @param {any} source The input value to be checked.
- * @param {any} expected The expected value.
+ * @param {T} actual The input value to be checked (Array, String, etc. - cannot be a function).
+ * @param {any} expected The expected value that should be contained.
  *
  * @returns {void} Throws the expectation statements.
  */
-export function expectToContain(source: any, expected: any): void {
-    expect(source).toBeDefined();
-    expect(source, `should contain ${expected}`).toContain(expected);
+export function expectToContain<T>(actual: T extends Function ? never : T, expected: any): void {
+    expect(actual).toBeDefined();
+    expect(actual, `should contain ${expected}`).toContain(expected);
 }
 
 /**
  * Test helper function: expectToEqual.
  *
- * It checks if a given source value is defined and if it equals the expected value ('toEqual').
+ * It checks if a given actual value is defined and if it equals the expected value ('toEqual').
  *
  * Exposed to be called from tests.
  *
- * @param {any} source The input value to be checked.
- * @param {any} expected The expected value.
+ * @param {T} actual The actual input value to be checked.
+ * @param {T} expected The expected value
  *
  * @returns {void} Throws the expectation statements.
  */
-export function expectToEqual(source: any, expected: any): void {
-    expect(source).toBeDefined();
-    expect(source, `should equal ${expected}`).toEqual(expected);
+export function expectToEqual<T>(actual: T, expected: T): void {
+    expect(actual).toBeDefined();
+    expect(actual, `should equal ${expected}`).toEqual(expected);
 }
 
 /**

--- a/src/testing/mock-data/mockEditionOutline.ts
+++ b/src/testing/mock-data/mockEditionOutline.ts
@@ -1,4 +1,5 @@
 import { EDITION_ROUTE_CONSTANTS } from '@awg-views/edition-view/edition-route-constants';
+import { EditionOutlineSeries } from '@awg-views/edition-view/models';
 import { EditionComplexesService } from '@awg-views/edition-view/services';
 
 /**
@@ -9,45 +10,81 @@ import { EditionComplexesService } from '@awg-views/edition-view/services';
  *
  * Exposed to be called from tests.
  */
-export const mockEditionOutline = [
+export const mockEditionOutline: EditionOutlineSeries[] = [
     {
         series: EDITION_ROUTE_CONSTANTS.SERIES_1,
         sections: [
             {
+                seriesParent: EDITION_ROUTE_CONSTANTS.SERIES_1,
                 section: EDITION_ROUTE_CONSTANTS.SECTION_1,
-                complexTypes: { opus: [], mnr: [] },
-                disabled: true,
-            },
-            {
-                section: EDITION_ROUTE_CONSTANTS.SECTION_2,
-                complexTypes: { opus: [], mnr: [] },
-                disabled: true,
-            },
-            {
-                section: EDITION_ROUTE_CONSTANTS.SECTION_3,
-                complexTypes: { opus: [], mnr: [] },
-                disabled: true,
-            },
-            {
-                section: EDITION_ROUTE_CONSTANTS.SECTION_4,
-                complexTypes: { opus: [], mnr: [] },
-                disabled: true,
-            },
-            {
-                section: EDITION_ROUTE_CONSTANTS.SECTION_5,
-                complexTypes: {
-                    opus: [
-                        { complex: EditionComplexesService.getEditionComplexById('op12'), disabled: false },
-                        { complex: EditionComplexesService.getEditionComplexById('op23'), disabled: false },
-                        { complex: EditionComplexesService.getEditionComplexById('op25'), disabled: false },
-                    ],
-                    mnr: [
-                        { complex: EditionComplexesService.getEditionComplexById('m212'), disabled: false },
-                        { complex: EditionComplexesService.getEditionComplexById('m213'), disabled: false },
-                        { complex: EditionComplexesService.getEditionComplexById('m216'), disabled: false },
-                        { complex: EditionComplexesService.getEditionComplexById('m217'), disabled: false },
-                    ],
+                content: {
+                    intro: {
+                        disabled: true,
+                        preview: '',
+                    },
+                    complexTypes: { opus: [], mnr: [] },
                 },
+                disabled: true,
+            },
+            {
+                seriesParent: EDITION_ROUTE_CONSTANTS.SERIES_1,
+                section: EDITION_ROUTE_CONSTANTS.SECTION_2,
+                content: {
+                    intro: {
+                        disabled: true,
+                        preview: '',
+                    },
+                    complexTypes: { opus: [], mnr: [] },
+                },
+                disabled: true,
+            },
+            {
+                seriesParent: EDITION_ROUTE_CONSTANTS.SERIES_1,
+                section: EDITION_ROUTE_CONSTANTS.SECTION_3,
+                content: {
+                    intro: {
+                        disabled: true,
+                        preview: '',
+                    },
+                    complexTypes: { opus: [], mnr: [] },
+                },
+                disabled: true,
+            },
+            {
+                seriesParent: EDITION_ROUTE_CONSTANTS.SERIES_1,
+                section: EDITION_ROUTE_CONSTANTS.SECTION_4,
+                content: {
+                    intro: {
+                        disabled: true,
+                        preview: '',
+                    },
+                    complexTypes: { opus: [], mnr: [] },
+                },
+                disabled: true,
+            },
+            {
+                seriesParent: EDITION_ROUTE_CONSTANTS.SERIES_1,
+                section: EDITION_ROUTE_CONSTANTS.SECTION_5,
+                content: {
+                    intro: {
+                        disabled: false,
+                        preview: 'This is a preview for the intro of section 5.',
+                    },
+                    complexTypes: {
+                        opus: [
+                            { complex: EditionComplexesService.getEditionComplexById('op12'), disabled: false },
+                            { complex: EditionComplexesService.getEditionComplexById('op23'), disabled: false },
+                            { complex: EditionComplexesService.getEditionComplexById('op25'), disabled: false },
+                        ],
+                        mnr: [
+                            { complex: EditionComplexesService.getEditionComplexById('m212'), disabled: false },
+                            { complex: EditionComplexesService.getEditionComplexById('m213'), disabled: false },
+                            { complex: EditionComplexesService.getEditionComplexById('m216'), disabled: false },
+                            { complex: EditionComplexesService.getEditionComplexById('m217'), disabled: false },
+                        ],
+                    },
+                },
+
                 disabled: true,
             },
         ],


### PR DESCRIPTION
This PR improves the type checking in tests by making the test expect helpers using stricter type expectations. This way signals are detected when called without parenthesis. Any occuring type errors were fixed, too.