### PR TITLE
test(app): unify usage of test helpers

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -162,11 +162,11 @@ export class AppConfig {
      */
     public static get CONTACT_MAP_UNSAFE_EMBED_URL(): string {
         const mapApi = 'https://www.openstreetmap.org/export/embed.html';
-        const bbox = 'bbox=7.582175731658936%2C47.55789611508066%2C7.586840093135835%2C47.56003739001212';
-        const layer = 'layer=mapnik';
+        const bbox = '7.582175731658936%2C47.55789611508066%2C7.586840093135835%2C47.56003739001212';
+        const layer = 'mapnik';
         const marker = '47.55896585846639%2C7.584506571292877';
 
-        return mapApi + '?' + bbox + '&' + layer + '&' + marker;
+        return `${mapApi}?bbox=${bbox}&layer=${layer}&marker=${marker}`;
     }
 
     /**

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 import localeDeDE from '@angular/common/locales/de';
 import { LOCALE_ID, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { provideAnimations } from '@angular/platform-browser/animations';
 
 //
 // Main app modules
@@ -25,11 +25,12 @@ registerLocaleData(localeDeDE);
  * as well as the {@link CoreModule}, {@link SharedModule} and {@link SideInfoModule}.
  */
 @NgModule({
-    imports: [BrowserModule, BrowserAnimationsModule, CoreModule, SharedModule, SideInfoModule, AppRoutingModule],
+    imports: [BrowserModule, CoreModule, SharedModule, SideInfoModule, AppRoutingModule],
     declarations: [AppComponent],
     providers: [
         { provide: LOCALE_ID, useValue: 'de-DE' }, // Change global LOCALE-ID
         provideHttpClient(withInterceptorsFromDi()),
+        provideAnimations(),
     ],
     bootstrap: [AppComponent],
 })

--- a/src/app/core/footer/footer-declaration/footer-declaration.component.spec.ts
+++ b/src/app/core/footer/footer-declaration/footer-declaration.component.spec.ts
@@ -5,7 +5,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectToBe,
     expectToContain,
@@ -138,27 +138,25 @@ describe('FooterDeclarationComponent (DONE)', () => {
                 expectToBe(routerLinks[1].fragment, 'awg-documentation');
             });
 
-            it('... can click imprint link in template', () => {
-                const imprintLinkDes = linkDes[0]; // Contact link DebugElement
+            it('... can click imprint link in template', async () => {
+                const imprintLinkDe = linkDes[0]; // Contact link DebugElement
                 const imprintLink = routerLinks[0]; // Contact link directive
 
                 expectToBe(imprintLink.navigatedTo, null);
 
-                click(imprintLinkDes);
-                fixture.detectChanges();
+                await clickAndAwaitChanges(imprintLinkDe, fixture);
 
                 expectToEqual(imprintLink.navigatedTo, ['/contact']);
                 expectToBe(imprintLink.navigatedToFragment, 'awg-imprint');
             });
 
-            it('... can click documentation link in template', () => {
-                const documentationLinkDes = linkDes[1]; // Contact link DebugElement
+            it('... can click documentation link in template', async () => {
+                const documentationLinkDe = linkDes[1]; // Contact link DebugElement
                 const documentationLink = routerLinks[1]; // Contact link directive
 
                 expectToBe(documentationLink.navigatedTo, null);
 
-                click(documentationLinkDes);
-                fixture.detectChanges();
+                await clickAndAwaitChanges(documentationLinkDe, fixture);
 
                 expectToEqual(documentationLink.navigatedTo, ['/contact']);
                 expectToBe(documentationLink.navigatedToFragment, 'awg-documentation');

--- a/src/app/core/footer/footer-logo/footer-logo.component.spec.ts
+++ b/src/app/core/footer/footer-logo/footer-logo.component.spec.ts
@@ -10,6 +10,7 @@ import {
     expectToBe,
     expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
 } from '@testing/expect-helper';
 
@@ -183,7 +184,7 @@ describe('FooterLogoComponent (DONE)', () => {
                 await detectChangesOnPush(fixture);
 
                 expect(imageDes[0].classes[cssClassFloatEnd]).not.toBeTruthy();
-                expect(imageEl.classList).not.toContain(cssClassFloatEnd);
+                expectToNotContain(imageEl.classList, cssClassFloatEnd);
 
                 // Not main footer logo
                 // Trigger changes in data binding
@@ -191,7 +192,7 @@ describe('FooterLogoComponent (DONE)', () => {
                 await detectChangesOnPush(fixture);
 
                 expect(imageDes[0].classes[cssClassFloatEnd]).not.toBeTruthy();
-                expect(imageEl.classList).not.toContain(cssClassFloatEnd);
+                expectToNotContain(imageEl.classList, cssClassFloatEnd);
             });
 
             it('... should have CSS class `my-2` applied only to main footer logos', async () => {
@@ -219,7 +220,7 @@ describe('FooterLogoComponent (DONE)', () => {
                 await detectChangesOnPush(fixture);
 
                 expect(imageDes[0].classes[cssClassMarginY2]).not.toBeTruthy();
-                expect(imageEl.classList).not.toContain(cssClassMarginY2);
+                expectToNotContain(imageEl.classList, cssClassMarginY2);
             });
 
             it('... should have [ngClass] resolve to correct classes', async () => {
@@ -283,7 +284,7 @@ describe('FooterLogoComponent (DONE)', () => {
                 classList = component.getLogoClass(component.logo.id);
 
                 expect(classList).toBeTruthy();
-                expect(classList).not.toContain(cssClassFloatEnd);
+                expectToNotContain(classList, cssClassFloatEnd);
 
                 // Not main footer logo
                 // Trigger changes in data binding

--- a/src/app/core/services/fullscreen-service/fullscreen.service.spec.ts
+++ b/src/app/core/services/fullscreen-service/fullscreen.service.spec.ts
@@ -108,13 +108,13 @@ describe('FullscreenService (DONE)', () => {
         it('... should return false if the document is not in fullscreen mode', () => {
             fullScreenElementSpy.mockReturnValue(null);
 
-            expect(fullscreenService.isFullscreen()).toBe(false);
+            expectToBe(fullscreenService.isFullscreen(), false);
         });
 
         it('... should return true if the document is in fullscreen mode', () => {
             fullScreenElementSpy.mockReturnValue({});
 
-            expect(fullscreenService.isFullscreen()).toBe(true);
+            expectToBe(fullscreenService.isFullscreen(), true);
         });
     });
 

--- a/src/app/core/view-container/view-container.component.spec.ts
+++ b/src/app/core/view-container/view-container.component.spec.ts
@@ -7,6 +7,7 @@ import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectToBe,
     expectToContain,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -58,14 +59,14 @@ describe('ViewContainerComponent (DONE)', () => {
                 const divDes = getAndExpectDebugElementByCss(compDe, 'div.container-fluid > div.row', 1, 1);
                 const divEl: HTMLDivElement = divDes[0].nativeElement;
 
-                expect(divEl.classList).not.toContain('justify-content-center');
+                expectToNotContain(divEl.classList, 'justify-content-center');
             });
 
             it('... should contain one child div (maincontent) in `div.row`', () => {
                 const divDes = getAndExpectDebugElementByCss(compDe, 'div.container-fluid > div.row > div', 1, 1);
                 const divEl0: HTMLDivElement = divDes[0].nativeElement;
 
-                expectToBe(divEl0.classList.contains('awg-maincontent'), true);
+                expectToContain(divEl0.classList, 'awg-maincontent');
             });
 
             it('... should contain one router outlet (stubbed)', () => {
@@ -97,7 +98,7 @@ describe('ViewContainerComponent (DONE)', () => {
                     const divDes = getAndExpectDebugElementByCss(compDe, 'div.container-fluid > div.row', 1, 1);
                     const divEl: HTMLDivElement = divDes[0].nativeElement;
 
-                    expect(divEl.classList).not.toContain('justify-content-center');
+                    expectToNotContain(divEl.classList, 'justify-content-center');
                 });
 
                 it('... should contain two child divs in `div.row`', () => {
@@ -105,8 +106,8 @@ describe('ViewContainerComponent (DONE)', () => {
                     const divEl0: HTMLDivElement = divDes[0].nativeElement;
                     const divEl1: HTMLDivElement = divDes[1].nativeElement;
 
-                    expectToBe(divEl0.classList.contains('awg-maincontent'), true);
-                    expectToBe(divEl1.classList.contains('awg-side-outlet'), true);
+                    expectToContain(divEl0.classList, 'awg-maincontent');
+                    expectToContain(divEl1.classList, 'awg-side-outlet');
                 });
 
                 it('... should have correct grid classes on `div.awg-maincontent`', () => {
@@ -115,7 +116,7 @@ describe('ViewContainerComponent (DONE)', () => {
 
                     expectToContain(divEl.classList, 'col-md-8');
                     expectToContain(divEl.classList, 'col-xl-9');
-                    expect(divEl.classList).not.toContain('col-md-10');
+                    expectToNotContain(divEl.classList, 'col-md-10');
                 });
 
                 it('... should have correct grid classes on `div.awg-side-outlet`', () => {
@@ -164,7 +165,7 @@ describe('ViewContainerComponent (DONE)', () => {
                     const divDes = getAndExpectDebugElementByCss(compDe, 'div.container-fluid > div.row > div', 1, 1);
                     const divEl0: HTMLDivElement = divDes[0].nativeElement;
 
-                    expectToBe(divEl0.classList.contains('awg-maincontent'), true);
+                    expectToContain(divEl0.classList, 'awg-maincontent');
                 });
 
                 it('... should have correct grid classes on `div.awg-maincontent`', () => {
@@ -172,8 +173,8 @@ describe('ViewContainerComponent (DONE)', () => {
                     const divEl: HTMLDivElement = divDes[0].nativeElement;
 
                     expectToContain(divEl.classList, 'col-md-10');
-                    expect(divEl.classList).not.toContain('col-md-8');
-                    expect(divEl.classList).not.toContain('col-xl-9');
+                    expectToNotContain(divEl.classList, 'col-md-8');
+                    expectToNotContain(divEl.classList, 'col-xl-9');
                 });
 
                 it('... should contain one router outlet (stubbed)', () => {

--- a/src/app/shared/abbr/abbr.directive.spec.ts
+++ b/src/app/shared/abbr/abbr.directive.spec.ts
@@ -1,9 +1,9 @@
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, it } from 'vitest';
 
-import { expectToBe, expectToContain, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+import { expectToBe, expectToContain, expectToNotContain, getAndExpectDebugElementByCss } from '@testing/expect-helper';
 
 import { AbbrDirective } from './abbr.directive';
 
@@ -93,7 +93,7 @@ describe('AbbrDirective (DONE)', () => {
         const pDes = getAndExpectDebugElementByCss(compDe, 'p', 1, 1);
         const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 
-        expect(pEl.innerHTML).not.toContain('<abbr title="Klavier">Klaviert</abbr>');
+        expectToNotContain(pEl.innerHTML, '<abbr title="Klavier">Klaviert</abbr>');
         expectToContain(pEl.innerHTML, '<abbr title="Klavier oben">Klav. o.</abbr>');
         expectToContain(pEl.innerHTML, '<abbr title="Gesang">Ges.</abbr>');
     });

--- a/src/app/shared/alert-info/alert-info.component.spec.ts
+++ b/src/app/shared/alert-info/alert-info.component.spec.ts
@@ -90,9 +90,9 @@ describe('AlertInfoComponent (DONE)', () => {
                 const pDes = getAndExpectDebugElementByCss(alertDes[0], 'p', 1, 1);
                 const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 
-                expectToBe(pEl.classList.contains('small'), true);
-                expectToBe(pEl.classList.contains('text-muted'), true);
-                expectToBe(pEl.classList.contains('text-center'), true);
+                expectToContain(pEl.classList, 'small');
+                expectToContain(pEl.classList, 'text-muted');
+                expectToContain(pEl.classList, 'text-center');
             });
 
             it('... should display circle info icon in alert paragraph', () => {

--- a/src/app/shared/fullscreen-toggle/fullscreen-toggle.component.spec.ts
+++ b/src/app/shared/fullscreen-toggle/fullscreen-toggle.component.spec.ts
@@ -7,7 +7,7 @@ type Spy = ReturnType<typeof vi.spyOn>;
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
 import { faCompress, faExpand, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import { expectSpyCall, expectToBe, expectToEqual, getAndExpectDebugElementByCss } from '@testing/expect-helper';
 
@@ -209,11 +209,9 @@ describe('FullscreenToggleComponent (DONE)', () => {
                 await detectChangesOnPush(fixture);
 
                 const btnDes = getAndExpectDebugElementByCss(compDe, 'button.btn', 1, 1);
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Click button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
 
                 expectSpyCall(closeFullScreenSpy, 1);
             });
@@ -250,11 +248,9 @@ describe('FullscreenToggleComponent (DONE)', () => {
 
             it('... should trigger on click on "open fullscreen" button (not in fullscreen mode)', async () => {
                 const btnDes = getAndExpectDebugElementByCss(compDe, 'button.btn', 1, 1);
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Click button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
 
                 expectSpyCall(openFullScreenSpy, 1, expectedFsElement);
             });

--- a/src/app/shared/json-viewer/json-viewer.component.spec.ts
+++ b/src/app/shared/json-viewer/json-viewer.component.spec.ts
@@ -11,6 +11,7 @@ import {
     expectToBe,
     expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -32,33 +33,35 @@ function getNavLinks(fixture: ComponentFixture<any>): HTMLElement[] {
 function expectNavLinks(fixture: ComponentFixture<any>, expected: boolean[], shouldHaveNavItemClass = false) {
     const links = getNavLinks(fixture);
 
-    expect(links.length, `expected to find ${expected.length} links, but found ${links.length}`).toBe(expected.length);
+    expectToBe(links.length, expected.length);
 
     links.forEach(({ classList }, i) => {
-        expect(classList.contains('nav-link'), `link should have 'nav-link' class`).toBe(true);
+        expectToContain(classList, 'nav-link');
 
-        expect(classList.contains('active'), `link should ${expected[i] ? '' : 'not'} have 'active' class`).toBe(
-            expected[i]
-        );
+        if (expected[i]) {
+            expectToContain(classList, 'active');
+        } else {
+            expectToNotContain(classList, 'active');
+        }
 
-        expect(
-            classList.contains('nav-item'),
-            `link should ${shouldHaveNavItemClass ? '' : 'not'} have 'nav-item' class`
-        ).toBe(shouldHaveNavItemClass);
+        if (shouldHaveNavItemClass) {
+            expectToContain(classList, 'nav-item');
+        } else {
+            expectToNotContain(classList, 'nav-item');
+        }
     });
 }
 
 function expectNavContents(fixture: ComponentFixture<any>, expected: string[], activeIndex = 0) {
     const contents = getNavContents(fixture);
-    expect(contents.length, `expected to find ${expected.length} contents, but found ${contents.length}`).toBe(
-        expected.length
-    );
+    expectToBe(contents.length, expected.length);
 
     for (let i = 0; i < expected.length; ++i) {
-        expect(
-            contents[i].classList.contains('active'),
-            `content should ${i === activeIndex ? '' : 'not'} have 'active' class`
-        ).toBe(i === activeIndex);
+        if (i === activeIndex) {
+            expectToContain(contents[i].classList, 'active');
+        } else {
+            expectToNotContain(contents[i].classList, 'active');
+        }
     }
 }
 

--- a/src/app/shared/json-viewer/json-viewer.component.spec.ts
+++ b/src/app/shared/json-viewer/json-viewer.component.spec.ts
@@ -5,8 +5,7 @@ import { By } from '@angular/platform-browser';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { click } from '@testing/click-helper';
-import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectToBe,
     expectToContain,
@@ -26,28 +25,30 @@ function getNavContents(fixture: ComponentFixture<any>): HTMLElement[] {
     return Array.from(outletEl.children) as HTMLElement[];
 }
 
-function getNavLinks(fixture: ComponentFixture<any>): HTMLElement[] {
-    return fixture.debugElement.queryAll(By.directive(NgbNavLink)).map(debugElement => debugElement.nativeElement);
+function getNavLinks(fixture: ComponentFixture<any>): DebugElement[] {
+    return fixture.debugElement.queryAll(By.directive(NgbNavLink));
 }
 
 function expectNavLinks(fixture: ComponentFixture<any>, expected: boolean[], shouldHaveNavItemClass = false) {
-    const links = getNavLinks(fixture);
+    const linkDes = getNavLinks(fixture);
 
-    expectToBe(links.length, expected.length);
+    expectToBe(linkDes.length, expected.length);
 
-    links.forEach(({ classList }, i) => {
-        expectToContain(classList, 'nav-link');
+    linkDes.forEach((linkDe, i) => {
+        const linkEl = linkDe.nativeElement;
+
+        expectToContain(linkEl.classList, 'nav-link');
 
         if (expected[i]) {
-            expectToContain(classList, 'active');
+            expectToContain(linkEl.classList, 'active');
         } else {
-            expectToNotContain(classList, 'active');
+            expectToNotContain(linkEl.classList, 'active');
         }
 
         if (shouldHaveNavItemClass) {
-            expectToContain(classList, 'nav-item');
+            expectToContain(linkEl.classList, 'nav-item');
         } else {
-            expectToNotContain(classList, 'nav-item');
+            expectToNotContain(linkEl.classList, 'nav-item');
         }
     });
 }
@@ -156,7 +157,8 @@ describe('JsonViewerComponent (DONE)', () => {
             });
 
             it('... should have one Formatted and one Plain navItem and display titles', () => {
-                const navLinks = getNavLinks(fixture);
+                const navLinkDes = getNavLinks(fixture);
+                const navLinks = navLinkDes.map(de => de.nativeElement);
 
                 expectToBe(navLinks[0].textContent, 'Formatted');
                 expectToBe(navLinks[1].textContent, 'Plain');
@@ -193,23 +195,21 @@ describe('JsonViewerComponent (DONE)', () => {
             });
 
             it('... should change active navItem on click', async () => {
-                const navLinks = getNavLinks(fixture);
+                const navLinkDes = getNavLinks(fixture);
 
                 expectNavPanel(fixture, [true, false], ['content1']);
 
-                click(navLinks[1] as HTMLElement);
-                await detectChangesOnPush(fixture); // Replacement for fixture.detectChanges with OnPush
+                await clickAndAwaitChanges(navLinkDes[1], fixture);
 
                 expectNavPanel(fixture, [false, true], ['content2']);
 
-                click(navLinks[0] as HTMLElement);
-                await detectChangesOnPush(fixture); // Replacement for fixture.detectChanges with OnPush
+                await clickAndAwaitChanges(navLinkDes[0], fixture);
 
                 expectNavPanel(fixture, [true, false], ['content1']);
             });
 
             it('... should contain one ngx-json-viewer component (stubbed) only in Formatted view', async () => {
-                const navLinks = getNavLinks(fixture);
+                const navLinkDes = getNavLinks(fixture);
                 getAndExpectDebugElementByDirective(
                     compDe,
                     NgxJsonViewerStubComponent,
@@ -218,8 +218,7 @@ describe('JsonViewerComponent (DONE)', () => {
                     'in default (formatted) view'
                 );
 
-                click(navLinks[1] as HTMLElement);
-                await detectChangesOnPush(fixture); // Replacement for fixture.detectChanges with OnPush
+                await clickAndAwaitChanges(navLinkDes[1], fixture);
 
                 getAndExpectDebugElementByDirective(compDe, NgxJsonViewerStubComponent, 0, 0, 'in plain view');
             });
@@ -232,11 +231,10 @@ describe('JsonViewerComponent (DONE)', () => {
             });
 
             it('... should render `jsonViewerData` in Plain view', async () => {
-                const navLinks = getNavLinks(fixture);
+                const navLinkDes = getNavLinks(fixture);
 
                 // Change navLink to plain view
-                click(navLinks[1] as HTMLElement);
-                await detectChangesOnPush(fixture); // Replacement for fixture.detectChanges with OnPush
+                await clickAndAwaitChanges(navLinkDes[1], fixture);
 
                 const navContent = getNavContents(fixture);
 

--- a/src/app/shared/language-switcher/language-switcher.component.spec.ts
+++ b/src/app/shared/language-switcher/language-switcher.component.spec.ts
@@ -5,7 +5,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.spyOn>;
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
-import { expectSpyCall, expectToBe, expectToContain, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+import {
+    expectSpyCall,
+    expectToBe,
+    expectToContain,
+    expectToNotContain,
+    getAndExpectDebugElementByCss,
+} from '@testing/expect-helper';
 
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import { LanguageSwitcherComponent } from './language-switcher.component';
@@ -133,7 +139,7 @@ describe('LanguageSwitcherComponent (DONE)', () => {
                 const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
 
                 expectToContain(aEl0.classList, 'active');
-                expect(aEl1.classList).not.toContain('active');
+                expectToNotContain(aEl1.classList, 'active');
             });
 
             it('... should have .active class on second anchor element when currentLanguage is 1', async () => {
@@ -146,7 +152,7 @@ describe('LanguageSwitcherComponent (DONE)', () => {
                 const aEl0: HTMLAnchorElement = aDes[0].nativeElement;
                 const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
 
-                expect(aEl0.classList).not.toContain('active');
+                expectToNotContain(aEl0.classList, 'active');
                 expectToContain(aEl1.classList, 'active');
             });
         });

--- a/src/app/shared/meta-identifier-badges/meta-identifier-badges.component.html
+++ b/src/app/shared/meta-identifier-badges/meta-identifier-badges.component.html
@@ -1,4 +1,4 @@
-@for (badge of activeIdentifierBadges(); track badge.key) {
+@for (badge of displayedBadges(); track badge.key) {
     <a class="awg-meta-identifier-badge awg-logo-link" [href]="badge.fullUrl"
         ><img class="awg-meta-identifier-badge-icon" [src]="badge.src" [alt]="badge.label" [title]="badge.titleText"
     /></a>

--- a/src/app/shared/meta-identifier-badges/meta-identifier-badges.component.spec.ts
+++ b/src/app/shared/meta-identifier-badges/meta-identifier-badges.component.spec.ts
@@ -93,11 +93,11 @@ describe('MetaIdentifierBadgesComponent (DONE)', () => {
             expect(component.identifiers()).toBeUndefined();
         });
 
-        it('... should have computed `activeIdentifierBadges` (empty array due to identifiers=undefined)', () => {
-            const activeIdentifierBadges: MetaIdentifierBadge[] = component.activeIdentifierBadges();
+        it('... should have computed `displayedBadges` (empty array due to identifiers=undefined)', () => {
+            const displayedBadges: MetaIdentifierBadge[] = component.displayedBadges();
 
-            expectToEqual(activeIdentifierBadges, []);
-            expectToBe(activeIdentifierBadges.length, 0);
+            expectToBe(displayedBadges.length, 0);
+            expectToEqual(displayedBadges, []);
         });
 
         describe('VIEW', () => {
@@ -119,37 +119,37 @@ describe('MetaIdentifierBadgesComponent (DONE)', () => {
             expectToEqual(component.identifiers(), expectedIdentifiers);
         });
 
-        it('... should have computed `activeIdentifierBadges`', () => {
-            const activeIdentifierBadges: MetaIdentifierBadge[] = component.activeIdentifierBadges();
+        it('... should have computed `displayedBadges`', () => {
+            const displayedBadges: MetaIdentifierBadge[] = component.displayedBadges();
 
-            expectToEqual(activeIdentifierBadges, expectedActiveIdentifierBadges);
-            expectToBe(activeIdentifierBadges.length, 2);
+            expectToEqual(displayedBadges, expectedActiveIdentifierBadges);
+            expectToBe(displayedBadges.length, 2);
 
-            expectToBe(activeIdentifierBadges[0].key, expectedActiveIdentifierBadges[0].key);
-            expectToBe(activeIdentifierBadges[1].key, expectedActiveIdentifierBadges[1].key);
+            expectToBe(displayedBadges[0].key, expectedActiveIdentifierBadges[0].key);
+            expectToBe(displayedBadges[1].key, expectedActiveIdentifierBadges[1].key);
 
-            expectToBe(activeIdentifierBadges[0].fullUrl, expectedActiveIdentifierBadges[0].fullUrl);
-            expectToBe(activeIdentifierBadges[1].fullUrl, expectedActiveIdentifierBadges[1].fullUrl);
+            expectToBe(displayedBadges[0].fullUrl, expectedActiveIdentifierBadges[0].fullUrl);
+            expectToBe(displayedBadges[1].fullUrl, expectedActiveIdentifierBadges[1].fullUrl);
 
-            expectToBe(activeIdentifierBadges[0].src, expectedActiveIdentifierBadges[0].src);
-            expectToBe(activeIdentifierBadges[1].src, expectedActiveIdentifierBadges[1].src);
+            expectToBe(displayedBadges[0].src, expectedActiveIdentifierBadges[0].src);
+            expectToBe(displayedBadges[1].src, expectedActiveIdentifierBadges[1].src);
 
-            expectToBe(activeIdentifierBadges[0].label, expectedActiveIdentifierBadges[0].label);
-            expectToBe(activeIdentifierBadges[1].label, expectedActiveIdentifierBadges[1].label);
+            expectToBe(displayedBadges[0].label, expectedActiveIdentifierBadges[0].label);
+            expectToBe(displayedBadges[1].label, expectedActiveIdentifierBadges[1].label);
 
-            expectToBe(activeIdentifierBadges[0].titleText, expectedActiveIdentifierBadges[0].titleText);
-            expectToBe(activeIdentifierBadges[1].titleText, expectedActiveIdentifierBadges[1].titleText);
+            expectToBe(displayedBadges[0].titleText, expectedActiveIdentifierBadges[0].titleText);
+            expectToBe(displayedBadges[1].titleText, expectedActiveIdentifierBadges[1].titleText);
         });
 
         describe('VIEW', () => {
             it('... should render one badge link per present identifier', () => {
-                const expectedCount = component.activeIdentifierBadges().length;
+                const expectedCount = component.displayedBadges().length;
 
                 getAndExpectDebugElementByCss(compDe, 'a.awg-meta-identifier-badge', expectedCount, expectedCount);
             });
 
             it('... should have correct href on each badge link', () => {
-                const expectedBadges = component.activeIdentifierBadges();
+                const expectedBadges = component.displayedBadges();
 
                 const badgeAnchorDes = getAndExpectDebugElementByCss(
                     compDe,
@@ -166,7 +166,7 @@ describe('MetaIdentifierBadgesComponent (DONE)', () => {
             });
 
             it('... should have one image on each badge link', () => {
-                const expectedBadges = component.activeIdentifierBadges();
+                const expectedBadges = component.displayedBadges();
 
                 const badgeAnchorDes = getAndExpectDebugElementByCss(
                     compDe,
@@ -181,7 +181,7 @@ describe('MetaIdentifierBadgesComponent (DONE)', () => {
             });
 
             it('... should render image with correct src, alt and title', () => {
-                const expectedBadges = component.activeIdentifierBadges();
+                const expectedBadges = component.displayedBadges();
 
                 const badgeAnchorDes = getAndExpectDebugElementByCss(
                     compDe,

--- a/src/app/shared/meta-identifier-badges/meta-identifier-badges.component.ts
+++ b/src/app/shared/meta-identifier-badges/meta-identifier-badges.component.ts
@@ -29,17 +29,18 @@ export class MetaIdentifierBadgesComponent {
      * It holds the authority identifiers of a person.
      * @default undefined
      */
-    // eslint-disable-next-line @typescript-eslint/member-ordering
     identifiers = input<MetaIdentifiers | undefined>(undefined);
 
     /**
-     * Computed signal: activeIdentifierBadges.
+     * Computed signal: displayedBadges.
      *
-     * It computes the active identifier badges based on the given identifiers input and the LOGOS_DATA
+     * It computes the badges to be displayed based on the given identifiers input and the LOGOS_DATA
      */
-    // eslint-disable-next-line @typescript-eslint/member-ordering
-    activeIdentifierBadges = computed<MetaIdentifierBadge[]>(() => {
-        const currentIds = this.identifiers() ?? ({} as MetaIdentifiers);
+    displayedBadges = computed<MetaIdentifierBadge[]>(() => {
+        const currentIds = this.identifiers();
+        if (!currentIds) {
+            return [];
+        }
         const logosData = this._coreService.getLogos();
 
         return (['gnd', 'viaf', 'orcid'] as (keyof MetaIdentifiers)[])

--- a/src/app/shared/router-link-button-group/router-link-button-group.component.spec.ts
+++ b/src/app/shared/router-link-button-group/router-link-button-group.component.spec.ts
@@ -9,7 +9,9 @@ import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectSpyCall,
     expectToBe,
+    expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -151,9 +153,9 @@ describe('RouterLinkButtonGroupComponent (DONE)', () => {
                     const btnEl: HTMLButtonElement = btnDe.nativeElement;
 
                     if (expectedRouterLinkButtons[index].disabled) {
-                        expect(btnEl.classList.contains('disabled')).toBe(true);
+                        expectToContain(btnEl.classList, 'disabled');
                     } else {
-                        expect(btnEl.classList.contains('disabled')).toBe(false);
+                        expectToNotContain(btnEl.classList, 'disabled');
                     }
                 });
             });
@@ -266,19 +268,19 @@ describe('RouterLinkButtonGroupComponent (DONE)', () => {
                 // Trigger click with click helper & wait for changes
                 await clickAndAwaitChanges(btnDes[0], fixture);
 
-                expect(btnEl0.classList.contains('disabled')).toBe(false);
+                expectToNotContain(btnEl0.classList, 'disabled');
                 expectSpyCall(selectButtonSpy, 1, expectedRouterLinkButtons[0]);
 
                 // Trigger click with click helper & wait for changes
                 await clickAndAwaitChanges(btnDes[1], fixture);
 
-                expect(btnEl1.classList.contains('disabled')).toBe(true);
+                expectToContain(btnEl1.classList, 'disabled');
                 expectSpyCall(selectButtonSpy, 2, expectedRouterLinkButtons[1]);
 
                 // Trigger click with click helper & wait for changes
                 await clickAndAwaitChanges(btnDes[2], fixture);
 
-                expect(btnEl2.classList.contains('disabled')).toBe(true);
+                expectToContain(btnEl2.classList, 'disabled');
                 expectSpyCall(selectButtonSpy, 3, expectedRouterLinkButtons[2]);
             });
 

--- a/src/app/shared/table/table-pagination/table-pagination.component.spec.ts
+++ b/src/app/shared/table/table-pagination/table-pagination.component.spec.ts
@@ -10,7 +10,9 @@ import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
     expectToBe,
+    expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -150,11 +152,8 @@ describe('TablePaginationComponent (DONE)', () => {
                 const liEl1: HTMLLIElement = liDes[0].nativeElement;
                 const liEl2: HTMLLIElement = liDes[1].nativeElement;
 
-                expect(liEl1.classList.contains('disabled')).toBeTruthy();
-                expect(liEl1.classList.contains('disabled')).toBe(true);
-
-                expect(liEl2.classList.contains('disabled')).toBeTruthy();
-                expect(liEl2.classList.contains('disabled')).toBe(true);
+                expectToContain(liEl1.classList, 'disabled');
+                expectToContain(liEl2.classList, 'disabled');
             });
 
             it('... should have last two li.page-item not with class .disabled', () => {
@@ -164,11 +163,8 @@ describe('TablePaginationComponent (DONE)', () => {
                 const liEl3: HTMLLIElement = liDes[2].nativeElement;
                 const liEl4: HTMLLIElement = liDes[3].nativeElement;
 
-                expect(liEl3.classList.contains('disabled')).toBeFalsy();
-                expect(liEl3.classList.contains('disabled')).toBe(false);
-
-                expect(liEl4.classList.contains('disabled')).toBeFalsy();
-                expect(liEl4.classList.contains('disabled')).toBe(false);
+                expectToNotContain(liEl3.classList, 'disabled');
+                expectToNotContain(liEl4.classList, 'disabled');
             });
 
             it('... should have a.page-link in all li.page-item', () => {

--- a/src/app/shared/table/table.component.html
+++ b/src/app/shared/table/table.component.html
@@ -15,7 +15,8 @@
                     name="searchFilter"
                     [(ngModel)]="searchFilter"
                     (ngModelChange)="onPageSizeChange(searchFilter)"
-                    placeholder="Ergebnisse filtern..." />
+                    placeholder="Ergebnisse filtern..."
+                    aria-label="Filter results" />
             </div>
         </div>
     </form>

--- a/src/app/shared/table/table.component.spec.ts
+++ b/src/app/shared/table/table.component.spec.ts
@@ -11,7 +11,7 @@ import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testi
 import { faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons';
 import { NgbHighlight, NgbPaginationModule } from '@ng-bootstrap/ng-bootstrap';
 
-import { BUTTON_CLICK_EVENTS, clickAndAwaitChanges } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
@@ -864,7 +864,7 @@ describe('TableComponent', () => {
                 for (const [index, rowDe] of rowDes.entries()) {
                     await clickAndAwaitChanges(rowDe, fixture);
 
-                    expectSpyCall(onTableRowClickSpy, index + 1, BUTTON_CLICK_EVENTS.left);
+                    expectSpyCall(onTableRowClickSpy, index + 1);
                 }
             });
 

--- a/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.spec.ts
+++ b/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.spec.ts
@@ -41,7 +41,7 @@ function _assertPseudoContentFromStyles(index: number, expectedContent: string):
 
     expect(styles).toMatch(/>\s*div[^\n]*:before/i);
     expect(styles).toMatch(/content:\s*"\\2669"/i);
-    expect(expectedContent).toBe('\u2669');
+    expectToBe(expectedContent, '\u2669');
 }
 
 describe('TwelveToneSpinnerComponent', () => {

--- a/src/app/shared/view-handle-button-group/view-handle-button-group.component.html
+++ b/src/app/shared/view-handle-button-group/view-handle-button-group.component.html
@@ -1,20 +1,21 @@
 <!-- View Handle -->
-<div class="btn-group awg-view-handle-btn-group" role="group">
+<div class="awg-view-handle-btn-group btn-group" role="group">
     <form [formGroup]="viewHandleControlForm">
         <div class="btn-group" role="group" name="viewHandle" aria-label="View handle button group">
             @for (viewHandle of viewHandles; track viewHandle.type) {
                 <input
                     type="radio"
+                    class="btn-check"
+                    [id]="viewHandle.type + '-view-button'"
                     [formControl]="viewHandleControl"
                     value="{{ viewHandle.type }}"
-                    class="btn-check"
-                    id="{{ viewHandle.type }}-view-button"
                     autocomplete="off" />
                 <label
                     class="btn btn-sm btn-outline-info"
-                    for="{{ viewHandle.type }}-view-button"
+                    [for]="viewHandle.type + '-view-button'"
                     ngbTooltip="{{ viewHandle.type }} view"
                     ><fa-icon [icon]="viewHandle.icon" />
+                    <span class="visually-hidden">{{ viewHandle.type }} view</span>
                 </label>
             }
         </div>

--- a/src/app/side-info/edition-info/edition-info.component.spec.ts
+++ b/src/app/side-info/edition-info/edition-info.component.spec.ts
@@ -15,6 +15,7 @@ import {
     expectToBe,
     expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -285,7 +286,7 @@ describe('EditionInfoComponent (DONE)', () => {
                         if (index === 0 || index === sectionIndex + 1) {
                             expectToContain(itemBodyEl.classList, 'show');
                         } else {
-                            expect(itemBodyEl.classList).not.toContain('show');
+                            expectToNotContain(itemBodyEl.classList, 'show');
                         }
                     });
                 }
@@ -363,7 +364,7 @@ describe('EditionInfoComponent (DONE)', () => {
                         );
                         itemBodyEl = itemBodyDes[0].nativeElement;
 
-                        expect(itemBodyEl.classList).not.toContain('show');
+                        expectToNotContain(itemBodyEl.classList, 'show');
 
                         // Click header button
                         await clickAndAwaitChanges(btnDes[0], fixture);

--- a/src/app/views/contact-view/contact-side-info/contact-side-info.component.ts
+++ b/src/app/views/contact-view/contact-side-info/contact-side-info.component.ts
@@ -63,7 +63,7 @@ export class ContactSideInfoComponent {
      * It holds the sanitized link to embed the map.
      */
     mapEmbedUrl = signal<SafeResourceUrl>(
-        this._sanitizer.bypassSecurityTrustResourceUrl(AppConfig.CONTACT_MAP_UNSAFE_EMBED_URL)
+        this._sanitizer.bypassSecurityTrustResourceUrl(AppConfig.CONTACT_MAP_UNSAFE_EMBED_URL) // NOSONAR: URL is a static, trusted source
     ).asReadonly();
 
     /**

--- a/src/app/views/contact-view/contact-view.component.spec.ts
+++ b/src/app/views/contact-view/contact-view.component.spec.ts
@@ -32,6 +32,7 @@ class HeadingStubComponent {
     title = input<string>('');
     id = input<string>('');
 }
+
 @Component({
     selector: 'awg-meta-identifier-badges',
     template: '',

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
@@ -16,7 +16,7 @@ import {
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
 import { faCompress, faExpand, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
@@ -509,11 +509,9 @@ describe('EditionGraphComponent (DONE)', () => {
                             1,
                             1
                         );
-                        const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                         // Click button
-                        click(btnEl as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         expectSpyCall(modalOpenSpy, 1, 'HINT_EDITION_GRAPH');
                         expectToBe(modalCmp.modalContent, 'HINT_EDITION_GRAPH');

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/construct-results/construct-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/construct-results/construct-results.component.spec.ts
@@ -8,7 +8,7 @@ import { EMPTY, Observable, of as observableOf } from 'rxjs';
 
 import { NgbAccordionDirective, NgbAccordionModule, NgbConfig } from '@ng-bootstrap/ng-bootstrap';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 
 import {
@@ -241,8 +241,6 @@ describe('ConstructResultsComponent (DONE)', () => {
 
                     // Button debug elements
                     const btnDes = getAndExpectDebugElementByCss(itemHeaderDes[0], 'button.accordion-button', 1, 1);
-                    // Button native elements to click on
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Item body is open
                     let itemBodyDes = getAndExpectDebugElementByCss(
@@ -257,8 +255,7 @@ describe('ConstructResultsComponent (DONE)', () => {
                     expectToContain(itemBodyEl.classList, 'show');
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item body is collapsed
                     itemBodyDes = getAndExpectDebugElementByCss(
@@ -273,8 +270,7 @@ describe('ConstructResultsComponent (DONE)', () => {
                     expectToContain(itemBodyEl.classList, 'collapse');
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item body is open again
                     itemBodyDes = getAndExpectDebugElementByCss(
@@ -621,8 +617,7 @@ describe('ConstructResultsComponent (DONE)', () => {
                     expectToContain(itemBodyEl.classList, 'show');
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item body does not close again
                     itemBodyDes = getAndExpectDebugElementByCss(

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/select-results/select-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/select-results/select-results.component.spec.ts
@@ -8,7 +8,7 @@ import { EMPTY, Observable, lastValueFrom, of as observableOf } from 'rxjs';
 
 import { NgbAccordionDirective, NgbAccordionModule, NgbConfig } from '@ng-bootstrap/ng-bootstrap';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
@@ -232,7 +232,6 @@ describe('SelectResultsComponent (DONE)', () => {
                     );
 
                     const btnDes = getAndExpectDebugElementByCss(itemHeaderDes[0], 'button.accordion-button', 1, 1);
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Item body is open
                     let itemBodyDes = getAndExpectDebugElementByCss(
@@ -247,8 +246,7 @@ describe('SelectResultsComponent (DONE)', () => {
                     expectToContain(itemBodyEl.classList, 'show');
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item body is collapsed
                     itemBodyDes = getAndExpectDebugElementByCss(
@@ -263,8 +261,7 @@ describe('SelectResultsComponent (DONE)', () => {
                     expectToContain(itemBodyEl.classList, 'collapse');
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item body is open again
                     itemBodyDes = getAndExpectDebugElementByCss(
@@ -494,8 +491,7 @@ describe('SelectResultsComponent (DONE)', () => {
                     expectToContain(itemBodyEl.classList, 'show');
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item body does not close again
                     itemBodyDes = getAndExpectDebugElementByCss(

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/services/graph-visualizer.service.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/services/graph-visualizer.service.spec.ts
@@ -881,7 +881,7 @@ describe('GraphVisualizerService', () => {
 
                 const result = (graphVisualizerService as any)._abbreviate(iri, namespaces);
 
-                expect(result).toBe(expectedAbbreviation);
+                expectToBe(result, expectedAbbreviation);
             });
         });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-editor/sparql-editor.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-editor/sparql-editor.component.spec.ts
@@ -21,6 +21,7 @@ import {
     expectToBe,
     expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -272,7 +273,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         );
                         const itemBodyEl: HTMLDivElement = itemBodyDes[0].nativeElement;
 
-                        expect(itemBodyEl.classList).not.toContain('show');
+                        expectToNotContain(itemBodyEl.classList, 'show');
                     });
 
                     it('... should display item header button', () => {
@@ -319,7 +320,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         );
                         let itemBodyEl: HTMLDivElement = itemBodyDes[0].nativeElement;
 
-                        expect(itemBodyEl.classList).not.toContain('show');
+                        expectToNotContain(itemBodyEl.classList, 'show');
 
                         // Click header button
                         click(btnEl as HTMLElement);
@@ -349,7 +350,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         );
                         itemBodyEl = itemBodyDes[0].nativeElement;
 
-                        expect(itemBodyEl.classList).not.toContain('show');
+                        expectToNotContain(itemBodyEl.classList, 'show');
                     });
 
                     describe('View handle button group', () => {
@@ -533,14 +534,14 @@ describe('SparqlEditorComponent (DONE)', () => {
                             const aEl0: HTMLAnchorElement = aDes[0].nativeElement;
                             const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
 
-                            expect(aEl0.classList.contains('disabled')).toBe(true);
-                            expect(aEl1.classList.contains('disabled')).toBe(false);
+                            expectToContain(aEl0.classList, 'disabled');
+                            expectToNotContain(aEl1.classList, 'disabled');
 
                             component.query = expectedConstructQuery2;
                             await detectChangesOnPush(fixture);
 
-                            expect(aEl0.classList.contains('disabled')).toBe(false);
-                            expect(aEl1.classList.contains('disabled')).toBe(true);
+                            expectToNotContain(aEl0.classList, 'disabled');
+                            expectToContain(aEl1.classList, 'disabled');
                         });
 
                         it('... should trigger `onQueryListChange()` by click on dropdown item links', async () => {
@@ -556,7 +557,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                             const aEl0: HTMLAnchorElement = aDes[0].nativeElement;
                             const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
 
-                            expect(aEl1.classList.contains('disabled')).toBe(false);
+                            expectToNotContain(aEl1.classList, 'disabled');
 
                             // Click on second item (first disabled)
                             click(aEl1 as HTMLElement);
@@ -568,7 +569,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                             component.query = expectedConstructQuery2;
                             await detectChangesOnPush(fixture);
 
-                            expect(aEl0.classList.contains('disabled')).toBe(false);
+                            expectToNotContain(aEl0.classList, 'disabled');
 
                             // Click on first item (second disabled)
                             click(aEl0 as HTMLElement);
@@ -652,7 +653,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         );
                         itemBodyEl = itemBodyDes[0].nativeElement;
 
-                        expect(itemBodyEl.classList).not.toContain('show');
+                        expectToNotContain(itemBodyEl.classList, 'show');
 
                         // Click header button
                         click(btnEl as HTMLElement);
@@ -1024,14 +1025,14 @@ describe('SparqlEditorComponent (DONE)', () => {
                         const aEl0: HTMLAnchorElement = aDes[0].nativeElement;
                         const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
 
-                        expect(aEl0.classList.contains('disabled')).toBe(true);
-                        expect(aEl1.classList.contains('disabled')).toBe(false);
+                        expectToContain(aEl0.classList, 'disabled');
+                        expectToNotContain(aEl1.classList, 'disabled');
 
                         component.query = expectedConstructQuery2;
                         await detectChangesOnPush(fixture);
 
-                        expect(aEl0.classList.contains('disabled')).toBe(false);
-                        expect(aEl1.classList.contains('disabled')).toBe(true);
+                        expectToNotContain(aEl0.classList, 'disabled');
+                        expectToContain(aEl1.classList, 'disabled');
                     });
 
                     it('... should trigger `onQueryListChange()` by click on dropdown item links', async () => {
@@ -1047,7 +1048,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         const aEl0: HTMLAnchorElement = aDes[0].nativeElement;
                         const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
 
-                        expect(aEl1.classList.contains('disabled')).toBe(false);
+                        expectToNotContain(aEl1.classList, 'disabled');
 
                         // Click on second item (first disabled)
                         click(aEl1 as HTMLElement);
@@ -1059,7 +1060,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         component.query = expectedConstructQuery2;
                         await detectChangesOnPush(fixture);
 
-                        expect(aEl0.classList.contains('disabled')).toBe(false);
+                        expectToNotContain(aEl0.classList, 'disabled');
 
                         // Click on first item (second disabled)
                         click(aEl0 as HTMLElement);
@@ -1316,7 +1317,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                 component.query = expectedConstructQuery2;
                 await detectChangesOnPush(fixture);
 
-                expect(aEl0.classList.contains('disabled')).toBe(false);
+                expectToNotContain(aEl0.classList, 'disabled');
 
                 // Click on first item (second disabled)
                 click(aEl0 as HTMLElement);

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-editor/sparql-editor.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-editor/sparql-editor.component.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '@ng-bootstrap/ng-bootstrap';
 import { EditorView } from 'codemirror';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
@@ -309,7 +309,6 @@ describe('SparqlEditorComponent (DONE)', () => {
                             1,
                             1
                         );
-                        const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                         // Item body is closed
                         let itemBodyDes = getAndExpectDebugElementByCss(
@@ -323,8 +322,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         expectToNotContain(itemBodyEl.classList, 'show');
 
                         // Click header button
-                        click(btnEl as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         // Item is open
                         itemBodyDes = getAndExpectDebugElementByCss(
@@ -338,8 +336,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         expectToContain(itemBodyEl.classList, 'show');
 
                         // Click header button
-                        click(btnEl as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         // Item body is closed again
                         itemBodyDes = getAndExpectDebugElementByCss(
@@ -560,8 +557,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                             expectToNotContain(aEl1.classList, 'disabled');
 
                             // Click on second item (first disabled)
-                            click(aEl1 as HTMLElement);
-                            await detectChangesOnPush(fixture);
+                            await clickAndAwaitChanges(aDes[1], fixture);
 
                             // Spy call with second query
                             expectSpyCall(onQueryListChangeSpy, 1, expectedConstructQuery2);
@@ -572,8 +568,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                             expectToNotContain(aEl0.classList, 'disabled');
 
                             // Click on first item (second disabled)
-                            click(aEl0 as HTMLElement);
-                            await detectChangesOnPush(fixture);
+                            await clickAndAwaitChanges(aDes[0], fixture);
 
                             // Spy call with first query
                             expectSpyCall(onQueryListChangeSpy, 2, expectedConstructQuery1);
@@ -592,11 +587,9 @@ describe('SparqlEditorComponent (DONE)', () => {
                             1,
                             1
                         );
-                        const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                         // Click header button
-                        click(btnEl as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         // Item body is open
                         const collapseDes = getAndExpectDebugElementByCss(
@@ -627,7 +620,6 @@ describe('SparqlEditorComponent (DONE)', () => {
                             1,
                             1
                         );
-                        const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                         // Item body is open
                         let itemBodyDes = getAndExpectDebugElementByCss(
@@ -641,8 +633,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         expectToContain(itemBodyEl.classList, 'show');
 
                         // Click header button
-                        click(btnEl as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         // Item is closed
                         itemBodyDes = getAndExpectDebugElementByCss(
@@ -656,8 +647,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         expectToNotContain(itemBodyEl.classList, 'show');
 
                         // Click header button
-                        click(btnEl as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         // Item body is open again
                         itemBodyDes = getAndExpectDebugElementByCss(
@@ -705,8 +695,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         expectToBe(btnEl0.textContent, 'Query');
 
                         // Click query button
-                        click(btnEl0 as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         expectSpyCall(performQuerySpy, 1);
                         expectSpyCall(resetQuerySpy, 0);
@@ -724,8 +713,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         expectToBe(btnEl1.textContent, 'Reset');
 
                         // Click reset button
-                        click(btnEl1 as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[1], fixture);
 
                         expectSpyCall(performQuerySpy, 0);
                         expectSpyCall(resetQuerySpy, 1);
@@ -743,8 +731,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         expectToBe(btnEl2.textContent, 'Clear');
 
                         // Click clear button
-                        click(btnEl2 as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[2], fixture);
 
                         expectSpyCall(onEditorInputChangeSpy, 1, '');
                     });
@@ -762,11 +749,9 @@ describe('SparqlEditorComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item body
                     bodyDes = getAndExpectDebugElementByCss(
@@ -839,7 +824,6 @@ describe('SparqlEditorComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Item body does not close
                     getAndExpectDebugElementByCss(
@@ -851,8 +835,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                     );
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item is open again
                     getAndExpectDebugElementByCss(
@@ -1051,8 +1034,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         expectToNotContain(aEl1.classList, 'disabled');
 
                         // Click on second item (first disabled)
-                        click(aEl1 as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(aDes[1], fixture);
 
                         // Spy call with second query
                         expectSpyCall(onQueryListChangeSpy, 1, expectedConstructQuery2);
@@ -1063,8 +1045,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                         expectToNotContain(aEl0.classList, 'disabled');
 
                         // Click on first item (second disabled)
-                        click(aEl0 as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(aDes[0], fixture);
 
                         // Spy call with first query
                         expectSpyCall(onQueryListChangeSpy, 2, expectedConstructQuery1);
@@ -1095,8 +1076,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                     expectToBe(btnEl0.textContent, 'Query');
 
                     // Click query button
-                    click(btnEl0 as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     expectSpyCall(performQuerySpy, 1);
                     expectSpyCall(resetQuerySpy, 0);
@@ -1109,8 +1089,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                     expectToBe(btnEl1.textContent, 'Reset');
 
                     // Click reset button
-                    click(btnEl1 as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[1], fixture);
 
                     expectSpyCall(performQuerySpy, 0);
                     expectSpyCall(resetQuerySpy, 1);
@@ -1123,8 +1102,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                     expectToBe(btnEl2.textContent, 'Clear');
 
                     // Click clear button
-                    click(btnEl2 as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[2], fixture);
 
                     expectSpyCall(onEditorInputChangeSpy, 1, '');
                 });
@@ -1205,11 +1183,9 @@ describe('SparqlEditorComponent (DONE)', () => {
                     1,
                     1
                 );
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Click header button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
             });
 
             it('... should have a method `onEditorInputChange`', () => {
@@ -1238,8 +1214,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                 expectToBe(btnEl2.textContent, 'Clear');
 
                 // Click clear button
-                click(btnEl2 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[2], fixture);
 
                 expectSpyCall(onEditorInputChangeSpy, 1, '');
             });
@@ -1256,8 +1231,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                 expectToBe(btnEl2.textContent, 'Clear');
 
                 // Click clear button
-                click(btnEl2 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[2], fixture);
 
                 expectSpyCall(onEditorInputChangeSpy, 1, '');
                 expectSpyCall(emitUpdateQueryStringRequestSpy, 1);
@@ -1305,11 +1279,9 @@ describe('SparqlEditorComponent (DONE)', () => {
                     expectedQueryList.length
                 );
                 const aEl0: HTMLAnchorElement = aDes[0].nativeElement;
-                const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
 
                 // Click on second item (first disabled)
-                click(aEl1 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(aDes[1], fixture);
 
                 // Spy call with second query
                 expectSpyCall(onQueryListChangeSpy, 1, expectedConstructQuery2);
@@ -1320,8 +1292,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                 expectToNotContain(aEl0.classList, 'disabled');
 
                 // Click on first item (second disabled)
-                click(aEl0 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(aDes[0], fixture);
 
                 // Spy call with first query
                 expectSpyCall(onQueryListChangeSpy, 2, expectedConstructQuery1);
@@ -1334,12 +1305,9 @@ describe('SparqlEditorComponent (DONE)', () => {
                     expectedQueryList.length,
                     expectedQueryList.length
                 );
-                // Get second item (first disabled)
-                const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
 
                 // Click on second item (first disabled)
-                click(aEl1 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(aDes[1], fixture);
 
                 expectSpyCall(onQueryListChangeSpy, 1, expectedConstructQuery2);
                 expectSpyCall(resetQuerySpy, 1, expectedConstructQuery2);
@@ -1438,11 +1406,9 @@ describe('SparqlEditorComponent (DONE)', () => {
                     1,
                     1
                 );
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Click header button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
             });
 
             it('... should have a method `performQuery`', () => {
@@ -1461,8 +1427,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                 expectToBe(btnEl0.textContent, 'Query');
 
                 // Click query button
-                click(btnEl0 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
 
                 expectSpyCall(performQuerySpy, 1);
             });
@@ -1480,8 +1445,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                     expectToBe(btnEl0.textContent, 'Query');
 
                     // Click query button
-                    click(btnEl0 as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     expectSpyCall(performQuerySpy, 1);
                     expectSpyCall(emitPerformQueryRequestSpy, 1);
@@ -1505,8 +1469,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                     expectToBe(btnEl0.textContent, 'Query');
 
                     // Click query button
-                    click(btnEl0 as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     expectSpyCall(performQuerySpy, 1);
                     expectSpyCall(emitPerformQueryRequestSpy, 0);
@@ -1524,11 +1487,9 @@ describe('SparqlEditorComponent (DONE)', () => {
                     1,
                     1
                 );
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Click header button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
             });
 
             it('... should have a method `resetQuery`', () => {
@@ -1547,8 +1508,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                 expectToBe(btnEl1.textContent, 'Reset');
 
                 // Click query button
-                click(btnEl1 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[1], fixture);
 
                 expectSpyCall(resetQuerySpy, 1);
             });
@@ -1574,8 +1534,7 @@ describe('SparqlEditorComponent (DONE)', () => {
                 expectToBe(btnEl1.textContent, 'Reset');
 
                 // Click reset button
-                click(btnEl1 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[1], fixture);
 
                 expectSpyCall(resetQuerySpy, 1);
                 expectSpyCall(emitResestQueryRequestSpy, 1);

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/triples-editor/triples-editor.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/triples-editor/triples-editor.component.spec.ts
@@ -15,6 +15,7 @@ import {
     expectToBe,
     expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -188,7 +189,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                         );
                         const itemBodyEl: HTMLDivElement = itemBodyDes[0].nativeElement;
 
-                        expect(itemBodyEl.classList).not.toContain('show');
+                        expectToNotContain(itemBodyEl.classList, 'show');
                     });
 
                     it('... should display item header button', () => {
@@ -230,7 +231,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                         );
                         let itemBodyEl: HTMLDivElement = itemBodyDes[0].nativeElement;
 
-                        expect(itemBodyEl.classList).not.toContain('show');
+                        expectToNotContain(itemBodyEl.classList, 'show');
 
                         // Click header button
                         click(btnEl as HTMLElement);
@@ -259,7 +260,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                         );
                         itemBodyEl = itemBodyDes[0].nativeElement;
 
-                        expect(itemBodyEl.classList).not.toContain('show');
+                        expectToNotContain(itemBodyEl.classList, 'show');
                     });
                 });
 
@@ -334,7 +335,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                         );
                         itemBodyEl = itemBodyDes[0].nativeElement;
 
-                        expect(itemBodyEl.classList).not.toContain('show');
+                        expectToNotContain(itemBodyEl.classList, 'show');
 
                         // Click header button
                         click(btnEl as HTMLElement);

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/triples-editor/triples-editor.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/triples-editor/triples-editor.component.spec.ts
@@ -8,7 +8,7 @@ import { turtle } from '@codemirror/legacy-modes/mode/turtle';
 import { NgbAccordionDirective, NgbAccordionModule, NgbConfig } from '@ng-bootstrap/ng-bootstrap';
 import { EditorView } from 'codemirror';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
@@ -220,7 +220,6 @@ describe('TriplesEditorComponent (DONE)', () => {
                             1,
                             1
                         );
-                        const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                         // Item body is closed
                         let itemBodyDes = getAndExpectDebugElementByCss(
@@ -234,8 +233,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                         expectToNotContain(itemBodyEl.classList, 'show');
 
                         // Click header button
-                        click(btnEl as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         // Item is open
                         itemBodyDes = getAndExpectDebugElementByCss(
@@ -249,8 +247,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                         expectToContain(itemBodyEl.classList, 'show');
 
                         // Click header button
-                        click(btnEl as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         itemBodyDes = getAndExpectDebugElementByCss(
                             compDe,
@@ -275,11 +272,9 @@ describe('TriplesEditorComponent (DONE)', () => {
                             1,
                             1
                         );
-                        const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                         // Click header button
-                        click(btnEl as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         // Item body is open
                         const collapseDes = getAndExpectDebugElementByCss(
@@ -309,7 +304,6 @@ describe('TriplesEditorComponent (DONE)', () => {
                             1,
                             1
                         );
-                        const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                         // Item body is open
                         let itemBodyDes = getAndExpectDebugElementByCss(
@@ -323,8 +317,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                         expectToContain(itemBodyEl.classList, 'show');
 
                         // Click header button
-                        click(btnEl as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         // Item is closed
                         itemBodyDes = getAndExpectDebugElementByCss(
@@ -338,8 +331,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                         expectToNotContain(itemBodyEl.classList, 'show');
 
                         // Click header button
-                        click(btnEl as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         // Item body is open again
                         itemBodyDes = getAndExpectDebugElementByCss(
@@ -387,8 +379,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                         expectToBe(btnEl0.textContent, 'Query');
 
                         // Click query button
-                        click(btnEl0 as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[0], fixture);
 
                         expectSpyCall(performQuerySpy, 1);
                         expectSpyCall(resetTriplesSpy, 0);
@@ -406,8 +397,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                         expectToBe(btnEl1.textContent, 'Reset');
 
                         // Click reset button
-                        click(btnEl1 as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[1], fixture);
 
                         expectSpyCall(performQuerySpy, 0);
                         expectSpyCall(resetTriplesSpy, 1);
@@ -425,8 +415,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                         expectToBe(btnEl2.textContent, 'Clear');
 
                         // Click clear button
-                        click(btnEl2 as HTMLElement);
-                        await detectChangesOnPush(fixture);
+                        await clickAndAwaitChanges(btnDes[2], fixture);
 
                         expectSpyCall(onEditorInputChangeSpy, 1, '');
                     });
@@ -444,11 +433,9 @@ describe('TriplesEditorComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item body
                     bodyDes = getAndExpectDebugElementByCss(
@@ -509,7 +496,6 @@ describe('TriplesEditorComponent (DONE)', () => {
                     );
 
                     const btnDes = getAndExpectDebugElementByCss(itemHeaderDes[0], 'button.accordion-button', 1, 1);
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Item body does not close
                     let itemBodyDes = getAndExpectDebugElementByCss(
@@ -524,8 +510,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                     expectToContain(itemBodyEl.classList, 'show');
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item body does not close again
                     itemBodyDes = getAndExpectDebugElementByCss(
@@ -564,8 +549,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                     expectToBe(btnEl0.textContent, 'Query');
 
                     // Click query button
-                    click(btnEl0 as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     expectSpyCall(performQuerySpy, 1);
                     expectSpyCall(resetTriplesSpy, 0);
@@ -578,8 +562,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                     expectToBe(btnEl1.textContent, 'Reset');
 
                     // Click reset button
-                    click(btnEl1 as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[1], fixture);
 
                     expectSpyCall(performQuerySpy, 0);
                     expectSpyCall(resetTriplesSpy, 1);
@@ -592,8 +575,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                     expectToBe(btnEl2.textContent, 'Clear');
 
                     // Click clear button
-                    click(btnEl2 as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[2], fixture);
 
                     expectSpyCall(onEditorInputChangeSpy, 1, '');
                 });
@@ -609,11 +591,9 @@ describe('TriplesEditorComponent (DONE)', () => {
                     1,
                     1
                 );
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Click header button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
             });
 
             it('... should have a method `onEditorInputChange`', () => {
@@ -642,8 +622,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                 expectToBe(btnEl2.textContent, 'Clear');
 
                 // Click clear button
-                click(btnEl2 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[2], fixture);
 
                 expectSpyCall(onEditorInputChangeSpy, 1, '');
             });
@@ -660,8 +639,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                 expectToBe(btnEl2.textContent, 'Clear');
 
                 // Click clear button
-                click(btnEl2 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[2], fixture);
 
                 expectSpyCall(onEditorInputChangeSpy, 1, '');
                 expectSpyCall(emitUpdateTriplesRequestSpy, 1);
@@ -704,11 +682,9 @@ describe('TriplesEditorComponent (DONE)', () => {
                     1,
                     1
                 );
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Click header button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
             });
 
             it('... should have a method `performQuery`', () => {
@@ -727,8 +703,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                 expectToBe(btnEl0.textContent, 'Query');
 
                 // Click query button
-                click(btnEl0 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
 
                 expectSpyCall(performQuerySpy, 1);
             });
@@ -746,8 +721,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                     expectToBe(btnEl0.textContent, 'Query');
 
                     // Click query button
-                    click(btnEl0 as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     expectSpyCall(performQuerySpy, 1);
                     expectSpyCall(emitPerformQueryRequestSpy, 1);
@@ -771,8 +745,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                     expectToBe(btnEl0.textContent, 'Query');
 
                     // Click query button
-                    click(btnEl0 as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     expectSpyCall(performQuerySpy, 1);
                     expectSpyCall(emitPerformQueryRequestSpy, 0);
@@ -790,11 +763,9 @@ describe('TriplesEditorComponent (DONE)', () => {
                     1,
                     1
                 );
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Click header button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
             });
 
             it('... should have a method `resetTriples`', () => {
@@ -813,8 +784,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                 expectToBe(btnEl1.textContent, 'Reset');
 
                 // Click reset button
-                click(btnEl1 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[1], fixture);
 
                 expectSpyCall(resetTriplesSpy, 1);
             });
@@ -831,8 +801,7 @@ describe('TriplesEditorComponent (DONE)', () => {
                 expectToBe(btnEl1.textContent, 'Reset');
 
                 // Click reset button
-                click(btnEl1 as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[1], fixture);
 
                 expectSpyCall(resetTriplesSpy, 1);
                 expectSpyCall(emitResetTriplesRequestSpy, 1);

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/unsupported-type-results/unsupported-type-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/unsupported-type-results/unsupported-type-results.component.spec.ts
@@ -7,7 +7,13 @@ type Spy = ReturnType<typeof vi.spyOn>;
 import { NgbAccordionModule, NgbConfig } from '@ng-bootstrap/ng-bootstrap';
 
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
-import { expectSpyCall, expectToBe, expectToContain, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+import {
+    expectSpyCall,
+    expectToBe,
+    expectToContain,
+    expectToNotContain,
+    getAndExpectDebugElementByCss,
+} from '@testing/expect-helper';
 
 import { click } from '@testing/click-helper';
 import { UnsupportedTypeResultsComponent } from './unsupported-type-results.component';
@@ -126,7 +132,7 @@ describe('UnsupportedTypeResultsComponent (DONE)', () => {
                     );
                     const itemHeaderEl: HTMLDivElement = itemHeaderDes[0].nativeElement;
 
-                    expect(itemHeaderEl.classList).not.toContain('collapsed');
+                    expectToNotContain(itemHeaderEl.classList, 'collapsed');
 
                     const itemBodyDes = getAndExpectDebugElementByCss(
                         itemDes[0],
@@ -192,7 +198,7 @@ describe('UnsupportedTypeResultsComponent (DONE)', () => {
                     );
                     itemBodyEl = itemBodyDes[0].nativeElement;
 
-                    expect(itemBodyEl.classList).not.toContain('show');
+                    expectToNotContain(itemBodyEl.classList, 'show');
 
                     // Click header button
                     click(btnEl as HTMLElement);
@@ -221,8 +227,8 @@ describe('UnsupportedTypeResultsComponent (DONE)', () => {
 
                     pDes.forEach((pDe: DebugElement) => {
                         const pEl: HTMLParagraphElement = pDe.nativeElement;
-                        expect(pEl).toBeTruthy();
-                        expect(pEl.classList.contains('text-center')).toBe(true);
+
+                        expectToContain(pEl.classList, 'text-center');
                     });
                 });
 
@@ -298,7 +304,7 @@ describe('UnsupportedTypeResultsComponent (DONE)', () => {
                     );
                     const itemHeaderEl: HTMLDivElement = itemHeaderDes[0].nativeElement;
 
-                    expect(itemHeaderEl.classList).not.toContain('collapsed');
+                    expectToNotContain(itemHeaderEl.classList, 'collapsed');
 
                     const itemBodyDes = getAndExpectDebugElementByCss(
                         itemDes[0],
@@ -381,8 +387,8 @@ describe('UnsupportedTypeResultsComponent (DONE)', () => {
 
                     pDes.forEach((pDe: DebugElement) => {
                         const pEl: HTMLParagraphElement = pDe.nativeElement;
-                        expect(pEl).toBeTruthy();
-                        expect(pEl.classList.contains('text-center')).toBe(true);
+
+                        expectToContain(pEl.classList, 'text-center');
                     });
                 });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/unsupported-type-results/unsupported-type-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/unsupported-type-results/unsupported-type-results.component.spec.ts
@@ -15,7 +15,7 @@ import {
     getAndExpectDebugElementByCss,
 } from '@testing/expect-helper';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { UnsupportedTypeResultsComponent } from './unsupported-type-results.component';
 
 describe('UnsupportedTypeResultsComponent (DONE)', () => {
@@ -173,7 +173,6 @@ describe('UnsupportedTypeResultsComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     let itemBodyDes = getAndExpectDebugElementByCss(
                         compDe,
@@ -186,8 +185,7 @@ describe('UnsupportedTypeResultsComponent (DONE)', () => {
                     expectToContain(itemBodyEl.classList, 'show');
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item is open
                     itemBodyDes = getAndExpectDebugElementByCss(
@@ -201,8 +199,7 @@ describe('UnsupportedTypeResultsComponent (DONE)', () => {
                     expectToNotContain(itemBodyEl.classList, 'show');
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     itemBodyDes = getAndExpectDebugElementByCss(
                         compDe,
@@ -345,7 +342,6 @@ describe('UnsupportedTypeResultsComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Item body does not closed
                     let itemBodyDes = getAndExpectDebugElementByCss(
@@ -360,8 +356,7 @@ describe('UnsupportedTypeResultsComponent (DONE)', () => {
                     expectToContain(itemBodyEl.classList, 'show');
 
                     // Click header button
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     // Item is open
                     itemBodyDes = getAndExpectDebugElementByCss(

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-content/edition-intro-content.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-content/edition-intro-content.component.spec.ts
@@ -166,9 +166,10 @@ describe('EditionIntroContentComponent (DONE)', () => {
                 );
 
                 sectionDes.forEach((sectionDe, index) => {
-                    expect(sectionDe.attributes['id']).toBe(
-                        index < expectedIntroBlockContent.length ? expectedIntroBlockContent[index].blockId : 'notes'
-                    );
+                    const expectedId =
+                        index < expectedIntroBlockContent.length ? expectedIntroBlockContent[index].blockId : 'notes';
+
+                    expectToBe(sectionDe.attributes['id'], expectedId);
                 });
             });
 
@@ -239,7 +240,7 @@ describe('EditionIntroContentComponent (DONE)', () => {
 
                         if (index < expectedIntroBlockContent.length) {
                             const pEl: HTMLParagraphElement = pDes[0].nativeElement;
-                            expect(pEl.textContent).toBe(expectedIntroBlockContent[index].blockHeader);
+                            expectToBe(pEl.textContent, expectedIntroBlockContent[index].blockHeader);
                         }
                     });
                 });
@@ -330,7 +331,7 @@ describe('EditionIntroContentComponent (DONE)', () => {
                     );
 
                     const notesSectionDe = sectionDes.at(-1);
-                    expect(notesSectionDe.attributes['id']).toBe('notes');
+                    expectToBe(notesSectionDe.attributes['id'], 'notes');
                 });
 
                 it('... should contain one horizontal line', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.spec.ts
@@ -202,7 +202,7 @@ describe('EditionIntroNavComponent (DONE)', () => {
                             ? expectedNotesLabel
                             : expectedIntroBlockContent[index].blockHeader;
 
-                    expect(aEl.textContent).toEqual(expectedText);
+                    expectToBe(aEl.textContent, expectedText);
                 });
             });
         });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.spyOn>;
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectSpyCall,
     expectToBe,
@@ -288,21 +288,20 @@ describe('EditionIntroNavComponent (DONE)', () => {
                 });
             });
 
-            it('... can click any router links in template', () => {
-                routerLinks.forEach((link: RouterLinkStubDirective, index: number) => {
+            it('... can click any router links in template', async () => {
+                for (const [index, link] of routerLinks.entries()) {
                     const linkDe = linkDes[index]; // Link DebugElement
 
                     expectToBe(link.navigatedTo, null);
 
-                    click(linkDe);
-                    fixture.detectChanges();
+                    await clickAndAwaitChanges(linkDe, fixture);
 
                     const blockFragment = expectedIntroBlockContent[index]?.blockId;
                     const expectedFragment = index === routerLinks.length - 1 ? expectedNotesFragment : blockFragment;
 
                     expectToBe(link.navigatedTo, expectedLinkParam);
                     expectToBe(link.navigatedToFragment, expectedFragment);
-                });
+                }
             });
         });
     });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-partial-disclaimer/edition-intro-partial-disclaimer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-partial-disclaimer/edition-intro-partial-disclaimer.component.spec.ts
@@ -6,6 +6,7 @@ import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectToBe,
+    expectToContain,
     expectToEqual,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
@@ -96,8 +97,8 @@ describe('EditionIntroPartialDisclaimerComponent (DONE)', () => {
                 const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
                 const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 
-                expect(pEl.classList.contains('text-muted')).toBe(true);
-                expect(pEl.classList.contains('no-para-margin')).toBe(true);
+                expectToContain(pEl.classList, 'text-muted');
+                expectToContain(pEl.classList, 'no-para-margin');
             });
         });
     });
@@ -146,8 +147,8 @@ describe('EditionIntroPartialDisclaimerComponent (DONE)', () => {
                 const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
                 const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 
-                expect(pEl.classList.contains('text-muted')).toBe(true);
-                expect(pEl.classList.contains('no-para-margin')).toBe(true);
+                expectToContain(pEl.classList, 'text-muted');
+                expectToContain(pEl.classList, 'no-para-margin');
 
                 const awg = component.editionLabel;
                 const series = component.editionComplex?.pubStatement?.series?.short;

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-placeholder/edition-intro-placeholder.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-placeholder/edition-intro-placeholder.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
-import { expectToBe, expectToEqual, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+import { expectToBe, expectToContain, expectToEqual, getAndExpectDebugElementByCss } from '@testing/expect-helper';
 
 import { EditionComplex } from '@awg-views/edition-view/models';
 import { EditionComplexesService } from '@awg-views/edition-view/services';
@@ -65,8 +65,8 @@ describe('EditionIntroPlaceholderComponent (DONE)', () => {
                 const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
                 const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 
-                expect(pEl.classList.contains('text-muted')).toBe(true);
-                expect(pEl.classList.contains('small')).toBe(true);
+                expectToContain(pEl.classList, 'text-muted');
+                expectToContain(pEl.classList, 'small');
             });
         });
     });
@@ -95,8 +95,8 @@ describe('EditionIntroPlaceholderComponent (DONE)', () => {
                 const pDes = getAndExpectDebugElementByCss(divDes[0], 'p', 1, 1);
                 const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 
-                expect(pEl.classList.contains('text-muted')).toBe(true);
-                expect(pEl.classList.contains('small')).toBe(true);
+                expectToContain(pEl.classList, 'text-muted');
+                expectToContain(pEl.classList, 'small');
 
                 // Create intro placeholder
                 const fullComplexSpan = mockDocument.createElement('span');

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
@@ -23,7 +23,9 @@ import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
     expectToBe,
+    expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -953,7 +955,7 @@ describe('IntroComponent (DONE)', () => {
 
                 component.onLanguageSet(newLanguage);
 
-                expect(component.currentLanguage).toBe(newLanguage);
+                expectToBe(component.currentLanguage, newLanguage);
             });
 
             it('... should not change `currentLanguage` if the same language is passed', () => {
@@ -961,7 +963,7 @@ describe('IntroComponent (DONE)', () => {
 
                 component.onLanguageSet(initialLanguage);
 
-                expect(component.currentLanguage).toBe(initialLanguage);
+                expectToBe(component.currentLanguage, initialLanguage);
             });
 
             it('... should change `currentLanguage` if a different language is passed', () => {
@@ -972,7 +974,7 @@ describe('IntroComponent (DONE)', () => {
 
                 expect(component.currentLanguage).not.toBe(initialLanguage);
 
-                expect(component.currentLanguage).toBe(newLanguage);
+                expectToBe(component.currentLanguage, newLanguage);
             });
         });
 
@@ -1672,17 +1674,17 @@ describe('IntroComponent (DONE)', () => {
 
             it('... should return true for NavigationEnd event with `intro` in URL', () => {
                 const event = new NavigationEnd(1, '/some/path', '/some/path/intro');
-                expect(component['_isNavigationEndToIntro'](event)).toBe(true);
+                expectToBe(component['_isNavigationEndToIntro'](event), true);
             });
 
             it('... should return false for NavigationEnd event without `intro` in URL', () => {
                 const event = new NavigationEnd(1, '/some/path', '/some/path/other');
-                expect(component['_isNavigationEndToIntro'](event)).toBe(false);
+                expectToBe(component['_isNavigationEndToIntro'](event), false);
             });
 
             it('... should return false for non-NavigationEnd event', () => {
                 const event = { urlAfterRedirects: '/some/path/intro' };
-                expect(component['_isNavigationEndToIntro'](event)).toBe(false);
+                expectToBe(component['_isNavigationEndToIntro'](event), false);
             });
         });
 
@@ -1892,22 +1894,22 @@ describe('IntroComponent (DONE)', () => {
                 it('... event is undefined', () => {
                     (component as any)._onIntroScroll(undefined);
 
-                    expectToBe(navLink1.classList.contains('active'), false);
-                    expectToBe(navLink2.classList.contains('active'), false);
+                    expectToNotContain(navLink1.classList, 'active');
+                    expectToNotContain(navLink2.classList, 'active');
                 });
 
                 it('... event is null', () => {
                     (component as any)._onIntroScroll(null);
 
-                    expectToBe(navLink1.classList.contains('active'), false);
-                    expectToBe(navLink2.classList.contains('active'), false);
+                    expectToNotContain(navLink1.classList, 'active');
+                    expectToNotContain(navLink2.classList, 'active');
                 });
 
                 it('... event is not of type `scroll`', () => {
                     (component as any)._onIntroScroll(new Event('click'));
 
-                    expectToBe(navLink1.classList.contains('active'), false);
-                    expectToBe(navLink2.classList.contains('active'), false);
+                    expectToNotContain(navLink1.classList, 'active');
+                    expectToNotContain(navLink2.classList, 'active');
                 });
             });
 
@@ -1926,8 +1928,8 @@ describe('IntroComponent (DONE)', () => {
 
                 (component as any)._onIntroScroll(new Event('scroll'));
 
-                expectToBe(navLink1.classList.contains('active'), true);
-                expectToBe(navLink2.classList.contains('active'), false);
+                expectToContain(navLink1.classList, 'active');
+                expectToNotContain(navLink2.classList, 'active');
             });
 
             it('... should update nav link classes based on scroll position (window.scrollY)', async () => {
@@ -1945,8 +1947,8 @@ describe('IntroComponent (DONE)', () => {
 
                 (component as any)._onIntroScroll(new Event('scroll'));
 
-                expectToBe(navLink1.classList.contains('active'), true);
-                expectToBe(navLink2.classList.contains('active'), false);
+                expectToContain(navLink1.classList, 'active');
+                expectToNotContain(navLink2.classList, 'active');
             });
 
             afterEach(() => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-content-table/source-description-content-table.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-content-table/source-description-content-table.component.spec.ts
@@ -6,7 +6,13 @@ type Spy = ReturnType<typeof vi.spyOn>;
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
-import { expectSpyCall, expectToBe, expectToEqual, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+import {
+    expectSpyCall,
+    expectToBe,
+    expectToContain,
+    expectToEqual,
+    getAndExpectDebugElementByCss,
+} from '@testing/expect-helper';
 import { mockEditionData } from '@testing/mock-data';
 
 import { UtilityService } from '@awg-core/services';
@@ -91,7 +97,7 @@ describe('SourceDescriptionContentTableComponent', () => {
                 );
                 const tableEl: HTMLTableElement = tableDes[0].nativeElement;
 
-                expect(tableEl.classList.contains('half-para-margin')).toBe(true);
+                expectToContain(tableEl.classList, 'half-para-margin');
             });
 
             it('... should contain no table rows (yet)', () => {
@@ -130,7 +136,7 @@ describe('SourceDescriptionContentTableComponent', () => {
                 );
                 const tableEl: HTMLTableElement = tableDes[0].nativeElement;
 
-                expect(tableEl.classList.contains('half-para-margin')).toBe(true);
+                expectToContain(tableEl.classList, 'half-para-margin');
             });
 
             it('... should contain as many table rows in the table as folio systemgroups in the given content item', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.spec.ts
@@ -8,6 +8,7 @@ import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectSpyCall,
     expectToBe,
+    expectToContain,
     expectToEqual,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
@@ -115,7 +116,7 @@ describe('SourceDescriptionContentsComponent', () => {
                 const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-source-description-contents-label', 1, 1);
                 const pEl = pDes[0].nativeElement;
 
-                expect(pEl.classList.contains('no-para-margin')).toBe(true);
+                expectToContain(pEl.classList, 'no-para-margin');
 
                 const spanDes = getAndExpectDebugElementByCss(pDes[0], 'span.smallcaps', 1, 1);
                 const spanEl: HTMLSpanElement = spanDes[0].nativeElement;
@@ -133,8 +134,8 @@ describe('SourceDescriptionContentsComponent', () => {
                 );
                 const toggleSpanEl: HTMLSpanElement = toggleSpanDes[0].nativeElement;
 
-                expect(toggleSpanEl.classList.contains('small')).toBe(true);
-                expect(toggleSpanEl.classList.contains('text-muted')).toBe(true);
+                expectToContain(toggleSpanEl.classList, 'small');
+                expectToContain(toggleSpanEl.classList, 'text-muted');
             });
 
             it('... should not display a text in the toggle span yet', () => {
@@ -237,7 +238,7 @@ describe('SourceDescriptionContentsComponent', () => {
                     detailDes.forEach(detailDe => {
                         const detailEl = detailDe.nativeElement;
 
-                        expect(detailEl.classList.contains('half-para-margin')).toBe(true);
+                        expectToContain(detailEl.classList, 'half-para-margin');
                     });
                 });
 
@@ -300,7 +301,7 @@ describe('SourceDescriptionContentsComponent', () => {
                     summaryDes.forEach(summaryDe => {
                         const summaryEl = summaryDe.nativeElement;
 
-                        expect(summaryEl.classList.contains('no-para-margin')).toBe(true);
+                        expectToContain(summaryEl.classList, 'no-para-margin');
                     });
                 });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.spec.ts
@@ -136,7 +136,7 @@ describe('SourceDescriptionCorrectionsComponent (DONE)', () => {
                 const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-source-description-corrections-label', 1, 1);
                 const pEl = pDes[0].nativeElement;
 
-                expect(pEl.classList.contains('no-para-margin')).toBe(true);
+                expectToContain(pEl.classList, 'no-para-margin');
 
                 const spanDes = getAndExpectDebugElementByCss(pDes[0], 'span.smallcaps', 1, 1);
                 const spanEl: HTMLSpanElement = spanDes[0].nativeElement;
@@ -154,8 +154,8 @@ describe('SourceDescriptionCorrectionsComponent (DONE)', () => {
                 );
                 const toggleSpanEl: HTMLSpanElement = toggleSpanDes[0].nativeElement;
 
-                expect(toggleSpanEl.classList.contains('small')).toBe(true);
-                expect(toggleSpanEl.classList.contains('text-muted')).toBe(true);
+                expectToContain(toggleSpanEl.classList, 'small');
+                expectToContain(toggleSpanEl.classList, 'text-muted');
             });
 
             it('... should not display a text in the toggle span yet', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-writing-materials/source-description-writing-materials.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-writing-materials/source-description-writing-materials.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { expectToBe, expectToEqual, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+import { expectToBe, expectToContain, expectToEqual, getAndExpectDebugElementByCss } from '@testing/expect-helper';
 import { mockEditionData } from '@testing/mock-data';
 
 import { EDITION_TRADEMARKS_DATA } from '@awg-views/edition-view/data';
@@ -87,7 +87,7 @@ describe('SourceDescriptionWritingMaterialsComponent (DONE)', () => {
                 const spanEl: HTMLSpanElement = spanDes[0].nativeElement;
 
                 expectToBe(spanEl.textContent.trim(), 'Beschreibstoff:');
-                expect(spanEl.classList.contains('smallcaps')).toBe(true);
+                expectToContain(spanEl.classList, 'smallcaps');
             });
         });
     });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.spec.ts
@@ -267,11 +267,11 @@ describe('SourceDescriptionComponent (DONE)', () => {
                     const siglumSpanDes = spanDes[0];
                     const siglumSpanEl: HTMLSpanElement = siglumSpanDes.nativeElement;
 
-                    expect(pEl.classList.contains('awg-source-description-siglum-container')).toBe(true);
-                    expect(pEl.classList.contains('bold')).toBe(true);
+                    expectToContain(pEl.classList, 'awg-source-description-siglum-container');
+                    expectToContain(pEl.classList, 'bold');
                     expectToBe(pEl.textContent.trim(), expectedSiglum.trim());
 
-                    expect(siglumSpanEl.classList.contains('awg-source-description-siglum')).toBe(true);
+                    expectToContain(siglumSpanEl.classList, 'awg-source-description-siglum');
                     expectToBe(siglumSpanEl.textContent.trim(), expectedSiglum.trim());
                 });
 
@@ -287,7 +287,7 @@ describe('SourceDescriptionComponent (DONE)', () => {
 
                     const pEl: HTMLParagraphElement = pDes[1].nativeElement;
 
-                    expect(pEl.classList.contains('awg-source-description-type')).toBe(true);
+                    expectToContain(pEl.classList, 'awg-source-description-type');
                     expectToBe(pEl.textContent.trim(), expectedSourceDescriptionListData.sources[0].type.trim());
                 });
 
@@ -303,7 +303,7 @@ describe('SourceDescriptionComponent (DONE)', () => {
 
                     const pEl: HTMLParagraphElement = pDes[2].nativeElement;
 
-                    expect(pEl.classList.contains('awg-source-description-location')).toBe(true);
+                    expectToContain(pEl.classList, 'awg-source-description-location');
                     expectToBe(pEl.textContent.trim(), expectedSourceDescriptionListData.sources[0].location.trim());
                 });
             });
@@ -353,14 +353,14 @@ describe('SourceDescriptionComponent (DONE)', () => {
                     const addendumSpanDes = spanDes[1];
                     const addendumSpanEl: HTMLSpanElement = addendumSpanDes.nativeElement;
 
-                    expect(pEl.classList.contains('awg-source-description-siglum-container')).toBe(true);
-                    expect(pEl.classList.contains('bold')).toBe(true);
+                    expectToContain(pEl.classList, 'awg-source-description-siglum-container');
+                    expectToContain(pEl.classList, 'bold');
                     expectToBe(pEl.textContent.trim(), expectedSiglum.trim() + expectedAddendum.trim());
 
-                    expect(siglumSpanEl.classList.contains('awg-source-description-siglum')).toBe(true);
+                    expectToContain(siglumSpanEl.classList, 'awg-source-description-siglum');
                     expectToBe(siglumSpanEl.textContent.trim(), expectedSiglum.trim());
 
-                    expect(addendumSpanEl.classList.contains('awg-source-description-siglum-addendum')).toBe(true);
+                    expectToContain(addendumSpanEl.classList, 'awg-source-description-siglum-addendum');
                     expectToBe(addendumSpanEl.textContent.trim(), expectedAddendum.trim());
                 });
 
@@ -375,7 +375,7 @@ describe('SourceDescriptionComponent (DONE)', () => {
                     const pDes = getAndExpectDebugElementByCss(descHeadDes[1], 'p', 2, 2);
                     const pEl: HTMLParagraphElement = pDes[1].nativeElement;
 
-                    expect(pEl.classList.contains('awg-source-description-location')).toBe(true);
+                    expectToContain(pEl.classList, 'awg-source-description-location');
                     expectToBe(pEl.textContent.trim(), expectedSourceDescriptionListData.sources[1].location.trim());
                 });
 
@@ -418,7 +418,7 @@ describe('SourceDescriptionComponent (DONE)', () => {
                         instruments.secondary.join(', ') +
                         '.</span>';
 
-                    expect(pEl.classList.contains('awg-source-description-writing-instruments')).toBe(true);
+                    expectToContain(pEl.classList, 'awg-source-description-writing-instruments');
                     expectToBe(
                         pEl.textContent.trim().toLowerCase(),
                         expectedHtmlTextContent.textContent.trim().toLowerCase()
@@ -812,14 +812,14 @@ describe('SourceDescriptionComponent (DONE)', () => {
                     const addendumSpanDes = spanDes[2];
                     const addendumSpanEl: HTMLSpanElement = addendumSpanDes.nativeElement;
 
-                    expect(pEl.classList.contains('awg-source-description-siglum-container')).toBe(true);
-                    expect(pEl.classList.contains('bold')).toBe(true);
+                    expectToContain(pEl.classList, 'awg-source-description-siglum-container');
+                    expectToContain(pEl.classList, 'bold');
                     expectToBe(pEl.textContent.trim(), `[${expectedSiglum}${expectedAddendum}]`);
 
-                    expect(siglumSpanEl.classList.contains('awg-source-description-siglum')).toBe(true);
+                    expectToContain(siglumSpanEl.classList, 'awg-source-description-siglum');
                     expectToBe(siglumSpanEl.textContent.trim(), expectedSiglum.trim());
 
-                    expect(addendumSpanEl.classList.contains('awg-source-description-siglum-addendum')).toBe(true);
+                    expectToContain(addendumSpanEl.classList, 'awg-source-description-siglum-addendum');
                     expectToBe(addendumSpanEl.textContent.trim(), expectedAddendum.trim());
                 });
 
@@ -838,7 +838,7 @@ describe('SourceDescriptionComponent (DONE)', () => {
                     const expectedHtmlTextContent = mockDocument.createElement('p');
                     expectedHtmlTextContent.innerHTML = expectedSourceDescriptionListData.sources[2].type;
 
-                    expect(pEl.classList.contains('awg-source-description-type')).toBe(true);
+                    expectToContain(pEl.classList, 'awg-source-description-type');
                     expectToBe(pEl.textContent.trim(), expectedHtmlTextContent.textContent.trim());
                 });
 
@@ -853,7 +853,7 @@ describe('SourceDescriptionComponent (DONE)', () => {
                     const pDes = getAndExpectDebugElementByCss(descHeadDes[2], 'p', 3, 3);
                     const pEl: HTMLParagraphElement = pDes[2].nativeElement;
 
-                    expect(pEl.classList.contains('awg-source-description-location')).toBe(true);
+                    expectToContain(pEl.classList, 'awg-source-description-location');
                     expectToBe(pEl.textContent.trim(), expectedSourceDescriptionListData.sources[2].location.trim());
                 });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-list/source-list.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-list/source-list.component.spec.ts
@@ -7,7 +7,13 @@ type Spy = ReturnType<typeof vi.spyOn>;
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
-import { expectSpyCall, expectToBe, expectToEqual, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+import {
+    expectSpyCall,
+    expectToBe,
+    expectToContain,
+    expectToEqual,
+    getAndExpectDebugElementByCss,
+} from '@testing/expect-helper';
 import { mockEditionData } from '@testing/mock-data';
 import { RouterLinkStubDirective } from '@testing/router-stubs';
 
@@ -208,7 +214,7 @@ describe('SourceListComponent (DONE)', () => {
 
                         expectToBe(aEl.textContent.trim(), expectedSiglum.trim());
                         expectToBe(siglumSpanEl.textContent.trim(), expectedSiglum.trim());
-                        expect(siglumSpanEl.classList.contains('awg-source-list-siglum')).toBe(true);
+                        expectToContain(siglumSpanEl.classList, 'awg-source-list-siglum');
                     });
                 });
 
@@ -255,10 +261,10 @@ describe('SourceListComponent (DONE)', () => {
                         expectToBe(aEl.textContent.trim(), expectedSiglum.trim() + expectedAddendum.trim());
 
                         expectToBe(siglumSpanEl.textContent.trim(), expectedSiglum.trim());
-                        expect(siglumSpanEl.classList.contains('awg-source-list-siglum')).toBe(true);
+                        expectToContain(siglumSpanEl.classList, 'awg-source-list-siglum');
 
                         expectToBe(siglumAddendumSpanEl.textContent.trim(), expectedAddendum.trim());
-                        expect(siglumAddendumSpanEl.classList.contains('awg-source-list-siglum-addendum')).toBe(true);
+                        expectToContain(siglumAddendumSpanEl.classList, 'awg-source-list-siglum-addendum');
                     });
                 });
 
@@ -308,7 +314,7 @@ describe('SourceListComponent (DONE)', () => {
                         expectToBe(closingBracketSpanEl.textContent.trim(), ']');
 
                         expectToBe(siglumSpanEl.textContent.trim(), expectedSiglum.trim());
-                        expect(siglumSpanEl.classList.contains('awg-source-list-siglum')).toBe(true);
+                        expectToContain(siglumSpanEl.classList, 'awg-source-list-siglum');
                     });
                 });
 
@@ -365,10 +371,10 @@ describe('SourceListComponent (DONE)', () => {
                         expectToBe(closingBracketSpanEl.textContent.trim(), ']');
 
                         expectToBe(siglumSpanEl.textContent.trim(), expectedSiglum.trim());
-                        expect(siglumSpanEl.classList.contains('awg-source-list-siglum')).toBe(true);
+                        expectToContain(siglumSpanEl.classList, 'awg-source-list-siglum');
 
                         expectToBe(siglumAddendumSpanEl.textContent.trim(), expectedAddendum.trim());
-                        expect(siglumAddendumSpanEl.classList.contains('awg-source-list-siglum-addendum')).toBe(true);
+                        expectToContain(siglumAddendumSpanEl.classList, 'awg-source-list-siglum-addendum');
                     });
                 });
 
@@ -486,7 +492,7 @@ describe('SourceListComponent (DONE)', () => {
                         expectToBe(closingBracketSpanEl.textContent.trim(), ']');
 
                         expectToBe(siglumSpanEl.textContent.trim(), expectedSiglum.trim());
-                        expect(siglumSpanEl.classList.contains('awg-source-list-siglum')).toBe(true);
+                        expectToContain(siglumSpanEl.classList, 'awg-source-list-siglum');
                     });
                 });
 
@@ -661,12 +667,10 @@ describe('SourceListComponent (DONE)', () => {
 
                         expectToBe(containerSpanEl.textContent.trim(), expectedSiglum.trim() + expectedAddendum.trim());
 
-                        expect(siglumSpanEl.classList.contains('awg-source-list-text-siglum')).toBe(true);
+                        expectToContain(siglumSpanEl.classList, 'awg-source-list-text-siglum');
                         expectToBe(siglumSpanEl.textContent.trim(), expectedSiglum.trim());
 
-                        expect(siglumAddendumSpanEl.classList.contains('awg-source-list-text-siglum-addendum')).toBe(
-                            true
-                        );
+                        expectToContain(siglumAddendumSpanEl.classList, 'awg-source-list-text-siglum-addendum');
                         expectToBe(siglumAddendumSpanEl.textContent.trim(), expectedAddendum.trim());
                     });
                 });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.spec.ts
@@ -297,7 +297,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                     const expectedButtonLabel = mockDocument.createElement('span');
                     expectedButtonLabel.innerHTML = expectedTextcriticsData.textcritics[index].label;
 
-                    expect(btnEl.classList.contains('text-start')).toBe(true);
+                    expectToContain(btnEl.classList, 'text-start');
                     expectToBe(btnEl.textContent.trim(), expectedButtonLabel.textContent.trim());
                 });
             });
@@ -325,7 +325,7 @@ describe('TextcriticsListComponent (DONE)', () => {
 
                     const expectedButtonLabel = 'Zum edierten Notentext';
 
-                    expect(btnEl.classList.contains('btn-outline-info')).toBe(true);
+                    expectToContain(btnEl.classList, 'btn-outline-info');
                     expectToBe(btnEl.disabled, false);
                     expectToBe(btnEl.textContent.trim(), expectedButtonLabel);
                 });
@@ -367,7 +367,7 @@ describe('TextcriticsListComponent (DONE)', () => {
 
                         getAndExpectDebugElementByDirective(btnDes[0], DisclaimerWorkeditionsStubComponent, 1, 1);
 
-                        expect(btnEl1.classList.contains('btn-outline-info')).toBe(true);
+                        expectToContain(btnEl1.classList, 'btn-outline-info');
                         expectToBe(btnEl1.textContent.trim(), expectedButtonLabel);
                     });
                 });
@@ -396,7 +396,7 @@ describe('TextcriticsListComponent (DONE)', () => {
 
                         getAndExpectDebugElementByDirective(btnDes[0], DisclaimerWorkeditionsStubComponent, 1, 1);
 
-                        expect(btnEl1.classList.contains('btn-outline-info')).toBe(true);
+                        expectToContain(btnEl1.classList, 'btn-outline-info');
                         expectToBe(btnEl1.disabled, true);
                         expectToBe(btnEl1.textContent.trim(), expectedButtonLabel);
                     });
@@ -595,7 +595,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                         const smallEl: HTMLElement = smallDes[0].nativeElement;
 
                         expectToContain(smallEl.textContent, '[Nicht vorhanden.]');
-                        expect(smallEl.classList.contains('text-muted')).toBe(true);
+                        expectToContain(smallEl.classList, 'text-muted');
                     });
                 });
 
@@ -718,7 +718,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                         const smallEl: HTMLElement = smallDes[0].nativeElement;
 
                         expectToContain(smallEl.textContent, '[Nicht vorhanden.]');
-                        expect(smallEl.classList.contains('text-muted')).toBe(true);
+                        expectToContain(smallEl.classList, 'text-muted');
                     });
                 });
 
@@ -843,32 +843,32 @@ describe('TextcriticsListComponent (DONE)', () => {
                 it('... id is undefined', () => {
                     const result = component.isWorkEditionId(undefined);
 
-                    expect(result).toBe(false);
+                    expectToBe(result, false);
                 });
 
                 it('... id is null', () => {
                     const result = component.isWorkEditionId(null);
 
-                    expect(result).toBe(false);
+                    expectToBe(result, false);
                 });
 
                 it('... id is empty string', () => {
                     const result = component.isWorkEditionId('');
 
-                    expect(result).toBe(false);
+                    expectToBe(result, false);
                 });
 
                 it('... id is not a work edition id', () => {
                     const result = component.isWorkEditionId('test_id');
 
-                    expect(result).toBe(false);
+                    expectToBe(result, false);
                 });
             });
 
             it('... should return true if id is a work edition id', () => {
                 const result = component.isWorkEditionId('op12_WE');
 
-                expect(result).toBe(true);
+                expectToBe(result, true);
             });
         });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.spec.ts
@@ -6,7 +6,7 @@ type Spy = ReturnType<typeof vi.spyOn>;
 
 import { NgbAccordionModule, NgbConfig } from '@ng-bootstrap/ng-bootstrap';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
@@ -415,7 +415,6 @@ describe('TextcriticsListComponent (DONE)', () => {
                 );
 
                 const btnDes = getAndExpectDebugElementByCss(headerDes0[0], 'div.accordion-button > button.btn', 1, 1);
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Item body is closed
                 let itemBodyDes = getAndExpectDebugElementByCss(
@@ -430,8 +429,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                 expectToContain(itemBodyEl.classList, 'collapse');
 
                 // Click header button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
 
                 // Item body is open
                 itemBodyDes = getAndExpectDebugElementByCss(
@@ -446,8 +444,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                 expectToContain(itemBodyEl.classList, 'show');
 
                 // Click header button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
 
                 // Item body is closed
                 itemBodyDes = getAndExpectDebugElementByCss(
@@ -474,7 +471,6 @@ describe('TextcriticsListComponent (DONE)', () => {
                 );
 
                 const btnDes = getAndExpectDebugElementByCss(headerDes1[0], 'div.accordion-button > button.btn', 1, 1);
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Item body is closed
                 let itemBodyDes = getAndExpectDebugElementByCss(
@@ -489,8 +485,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                 expectToContain(itemBodyEl.classList, 'collapse');
 
                 // Click header button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
 
                 // Item body is open
                 itemBodyDes = getAndExpectDebugElementByCss(
@@ -505,8 +500,7 @@ describe('TextcriticsListComponent (DONE)', () => {
                 expectToContain(itemBodyEl.classList, 'show');
 
                 // Click header button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
 
                 // Item body is closed
                 itemBodyDes = getAndExpectDebugElementByCss(
@@ -549,13 +543,10 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl0: HTMLButtonElement = btnDes0[0].nativeElement;
-                    const btnEl1: HTMLButtonElement = btnDes1[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl0 as HTMLElement);
-                    click(btnEl1 as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes0[0], fixture);
+                    await clickAndAwaitChanges(btnDes1[0], fixture);
                 });
 
                 describe('...  if evaluations array is empty', () => {
@@ -893,11 +884,9 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     const evaluationsDes = getAndExpectDebugElementByDirective(
                         compDe,
@@ -931,11 +920,9 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     const tableDes = getAndExpectDebugElementByDirective(compDe, EditionTkaTableStubComponent, 1, 1);
                     const tableCmp = tableDes[0].injector.get(
@@ -1026,11 +1013,9 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     const evaluationsDes = getAndExpectDebugElementByDirective(
                         compDe,
@@ -1062,11 +1047,9 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     const tableDes = getAndExpectDebugElementByDirective(compDe, EditionTkaTableStubComponent, 1, 1);
                     const tableCmp = tableDes[0].injector.get(
@@ -1126,11 +1109,9 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     const evaluationsDes = getAndExpectDebugElementByDirective(
                         compDe,
@@ -1163,11 +1144,9 @@ describe('TextcriticsListComponent (DONE)', () => {
                         1,
                         1
                     );
-                    const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                     // Click header buttons to open body
-                    click(btnEl as HTMLElement);
-                    await detectChangesOnPush(fixture);
+                    await clickAndAwaitChanges(btnDes[0], fixture);
 
                     const tableDes = getAndExpectDebugElementByDirective(compDe, EditionTkaTableStubComponent, 1, 1);
                     const tableCmp = tableDes[0].injector.get(

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-accolade.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-accolade.component.spec.ts
@@ -13,6 +13,7 @@ import {
     expectToBe,
     expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -323,7 +324,7 @@ describe('EditionAccoladeComponent (DONE)', () => {
                 const accordionDes = getAndExpectDebugElementByCss(compDe, 'div.accordion', 1, 1);
                 const accordionEl: HTMLDivElement = accordionDes[0].nativeElement;
 
-                expect(accordionEl.classList).not.toContain('fullscreen');
+                expectToNotContain(accordionEl.classList, 'fullscreen');
 
                 // Set fullscreen
                 component.isFullscreen = true;
@@ -453,9 +454,9 @@ describe('EditionAccoladeComponent (DONE)', () => {
                     const facetDivEl: HTMLDivElement = facetDivDes[0].nativeElement;
 
                     expectToContain(facetDivEl.classList, 'col-auto');
-                    expect(facetDivEl.classList).not.toContain('col-12');
-                    expect(facetDivEl.classList).not.toContain('col-lg-4');
-                    expect(facetDivEl.classList).not.toContain('col-xl-3');
+                    expectToNotContain(facetDivEl.classList, 'col-12');
+                    expectToNotContain(facetDivEl.classList, 'col-lg-4');
+                    expectToNotContain(facetDivEl.classList, 'col-xl-3');
                 });
 
                 it('... should apply col-12 col-lg-4 col-xl-3 to sheet facet container div when not minimized', async () => {
@@ -473,7 +474,7 @@ describe('EditionAccoladeComponent (DONE)', () => {
                     expectToContain(facetDivEl.classList, 'col-12');
                     expectToContain(facetDivEl.classList, 'col-lg-4');
                     expectToContain(facetDivEl.classList, 'col-xl-3');
-                    expect(facetDivEl.classList).not.toContain('col-auto');
+                    expectToNotContain(facetDivEl.classList, 'col-auto');
                 });
 
                 it('... should apply col to sheet viewer container div when minimized', async () => {
@@ -489,9 +490,9 @@ describe('EditionAccoladeComponent (DONE)', () => {
                     const viewerDivEl: HTMLDivElement = viewerDivDes[0].nativeElement;
 
                     expectToContain(viewerDivEl.classList, 'col');
-                    expect(viewerDivEl.classList).not.toContain('col-12');
-                    expect(viewerDivEl.classList).not.toContain('col-lg-8');
-                    expect(viewerDivEl.classList).not.toContain('col-xl-9');
+                    expectToNotContain(viewerDivEl.classList, 'col-12');
+                    expectToNotContain(viewerDivEl.classList, 'col-lg-8');
+                    expectToNotContain(viewerDivEl.classList, 'col-xl-9');
                 });
 
                 it('... should apply col-12 col-lg-8 col-xl-9 to sheet viewer container div when not minimized', async () => {
@@ -509,7 +510,7 @@ describe('EditionAccoladeComponent (DONE)', () => {
                     expectToContain(viewerDivEl.classList, 'col-12');
                     expectToContain(viewerDivEl.classList, 'col-lg-8');
                     expectToContain(viewerDivEl.classList, 'col-xl-9');
-                    expect(viewerDivEl.classList).not.toContain('col');
+                    expectToNotContain(viewerDivEl.classList, 'col');
                 });
             });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-facet/edition-svg-sheet-facet-item/edition-svg-sheet-facet-item.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-facet/edition-svg-sheet-facet-item/edition-svg-sheet-facet-item.component.spec.ts
@@ -11,6 +11,7 @@ import {
     expectToBe,
     expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -199,10 +200,10 @@ describe('EditionSvgSheetFacetItemComponent (DONE)', () => {
                 const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
 
                 expectToContain(aEl0.classList, 'active');
-                expect(aEl0.classList).not.toContain('text-muted');
+                expectToNotContain(aEl0.classList, 'text-muted');
 
                 expectToContain(aEl1.classList, 'text-muted');
-                expect(aEl1.classList).not.toContain('active');
+                expectToNotContain(aEl1.classList, 'active');
             });
 
             it('... should display sheet label in direct anchors (no partials)', () => {
@@ -312,7 +313,7 @@ describe('EditionSvgSheetFacetItemComponent (DONE)', () => {
                     const aEl: HTMLAnchorElement = aDe.nativeElement;
 
                     expectToContain(aEl.classList, 'text-muted');
-                    expect(aEl.classList).not.toContain('active');
+                    expectToNotContain(aEl.classList, 'active');
                 });
             });
 
@@ -330,10 +331,10 @@ describe('EditionSvgSheetFacetItemComponent (DONE)', () => {
                 let aEl1: HTMLAnchorElement = aDes[1].nativeElement;
 
                 expectToContain(aEl0.classList, 'active');
-                expect(aEl0.classList).not.toContain('text-muted');
+                expectToNotContain(aEl0.classList, 'text-muted');
 
                 expectToContain(aEl1.classList, 'text-muted');
-                expect(aEl1.classList).not.toContain('active');
+                expectToNotContain(aEl1.classList, 'active');
 
                 component.selectedSvgSheet = structuredClone(mockEditionData.mockSvgSheet_Sk3b);
                 await detectChangesOnPush(fixture);
@@ -348,10 +349,10 @@ describe('EditionSvgSheetFacetItemComponent (DONE)', () => {
                 aEl1 = aDes[1].nativeElement;
 
                 expectToContain(aEl0.classList, 'text-muted');
-                expect(aEl0.classList).not.toContain('active');
+                expectToNotContain(aEl0.classList, 'active');
 
                 expectToContain(aEl1.classList, 'active');
-                expect(aEl1.classList).not.toContain('text-muted');
+                expectToNotContain(aEl1.classList, 'text-muted');
             });
 
             it('... should have as many item anchors (.dropdown-item) in dropdown as partials in sheet content', () => {
@@ -387,10 +388,10 @@ describe('EditionSvgSheetFacetItemComponent (DONE)', () => {
                 const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
 
                 expectToContain(aEl0.classList, 'active');
-                expect(aEl0.classList).not.toContain('text-muted');
+                expectToNotContain(aEl0.classList, 'text-muted');
 
                 expectToContain(aEl1.classList, 'text-muted');
-                expect(aEl1.classList).not.toContain('active');
+                expectToNotContain(aEl1.classList, 'active');
             });
 
             it('... should display sheet labels in dropdown item anchors (with numbered partials)', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-facet/edition-svg-sheet-facet.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-facet/edition-svg-sheet-facet.component.spec.ts
@@ -20,7 +20,7 @@ import { mockEditionData } from '@testing/mock-data';
 
 import { EditionSvgSheet, EditionSvgSheetList } from '@awg-views/edition-view/models';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { EditionSvgSheetFacetComponent } from './edition-svg-sheet-facet.component';
 
 // Mock components
@@ -428,11 +428,9 @@ describe('EditionSvgSheetFacetComponent (DONE)', () => {
 
             it('... should trigger on click on button', async () => {
                 const btnDes = getAndExpectDebugElementByCss(compDe, 'button.btn', 1, 1);
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
                 // Click button
-                click(btnEl as HTMLElement);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
 
                 expectSpyCall(toggleSheetFacetSpy, 1);
             });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.spec.ts
@@ -1196,8 +1196,8 @@ describe('EditionSvgSheetViewerComponent (DONE)', () => {
                     component.svgSheetElementRef.nativeElement,
                     component.svgSheetRootGroupRef.nativeElement
                 );
-                expect(component.svgSheetSelection).toBe(mockSvgSelection);
-                expect(component.svgSheetRootGroupSelection).toBe(mockRootGroupSelection);
+                expectToEqual(component.svgSheetSelection, mockSvgSelection);
+                expectToEqual(component.svgSheetRootGroupSelection, mockRootGroupSelection);
             });
 
             it('... should trigger `_getContainerDimensions` with svgSheetContainerRef', async () => {
@@ -1255,14 +1255,14 @@ describe('EditionSvgSheetViewerComponent (DONE)', () => {
                 (component as any)._createSvgOverlays();
 
                 expectSpyCall(getterSpy, 1);
-                expect(component.hasAvailableTkkOverlays).toBe(true);
+                expectToBe(component.hasAvailableTkkOverlays, true);
 
                 getterSpy.mockReturnValue(false);
 
                 (component as any)._createSvgOverlays();
 
                 expectSpyCall(getterSpy, 2);
-                expect(component.hasAvailableTkkOverlays).toBe(false);
+                expectToBe(component.hasAvailableTkkOverlays, false);
             });
         });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.spec.ts
@@ -597,7 +597,7 @@ describe('EditionSvgSheetViewerComponent (DONE)', () => {
                             EditionSvgSheetViewerSwitchStubComponent
                         ) as EditionSvgSheetViewerSwitchStubComponent;
 
-                        expectToEqual(switchCmp.id, expectedSvgSheet.id);
+                        expectToBe(switchCmp.id, expectedSvgSheet.id);
                     });
 
                     it('... should pass the correct suppliedClasses to the switch component', async () => {
@@ -631,7 +631,7 @@ describe('EditionSvgSheetViewerComponent (DONE)', () => {
                             EditionSvgSheetViewerSwitchStubComponent
                         ) as EditionSvgSheetViewerSwitchStubComponent;
 
-                        expectToEqual(switchCmp.hasAvailableTkkOverlays, false);
+                        expectToBe(switchCmp.hasAvailableTkkOverlays, false);
                     });
 
                     it('... should pass the updated `hasAvailableTkkOverlays` flag (true) to the switch component', async () => {
@@ -648,7 +648,7 @@ describe('EditionSvgSheetViewerComponent (DONE)', () => {
                             EditionSvgSheetViewerSwitchStubComponent
                         ) as EditionSvgSheetViewerSwitchStubComponent;
 
-                        expectToEqual(switchCmp.hasAvailableTkkOverlays, true);
+                        expectToBe(switchCmp.hasAvailableTkkOverlays, true);
                     });
                 });
             });
@@ -1196,8 +1196,8 @@ describe('EditionSvgSheetViewerComponent (DONE)', () => {
                     component.svgSheetElementRef.nativeElement,
                     component.svgSheetRootGroupRef.nativeElement
                 );
-                expectToEqual(component.svgSheetSelection, mockSvgSelection);
-                expectToEqual(component.svgSheetRootGroupSelection, mockRootGroupSelection);
+                expectToBe(component.svgSheetSelection, mockSvgSelection);
+                expectToBe(component.svgSheetRootGroupSelection, mockRootGroupSelection);
             });
 
             it('... should trigger `_getContainerDimensions` with svgSheetContainerRef', async () => {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-convolute.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-convolute.component.spec.ts
@@ -8,7 +8,7 @@ import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testi
 import { faSquare, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { NgbAccordionModule, NgbConfig, NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectSpyCall,
     expectToBe,
@@ -409,26 +409,24 @@ describe('EditionConvoluteComponent (DONE)', () => {
                 expectToEqual(routerLinks[0].fragment, expectedFragment);
             });
 
-            it('... can click report link in template', () => {
-                const reportLinkDe = linkDes[0]; // Contact link DebugElement
-                const reportLink = routerLinks[0]; // Contact link directive
+            it('... can click report link in template', async () => {
+                const reportLinkDe = linkDes[0];
+                const reportLink = routerLinks[0];
 
                 expectToBe(reportLink.navigatedTo, null);
 
-                click(reportLinkDe);
-                fixture.detectChanges();
+                await clickAndAwaitChanges(reportLinkDe, fixture);
 
                 expectToEqual(reportLink.navigatedTo, ['../report']);
             });
 
-            it('... should navigate to report page with fragment when report link is clicked', () => {
-                const reportLinkDe = linkDes[0]; // Contact link DebugElement
-                const reportLink = routerLinks[0]; // Contact link directive
+            it('... should navigate to report page with fragment when report link is clicked', async () => {
+                const reportLinkDe = linkDes[0];
+                const reportLink = routerLinks[0];
 
                 expectToBe(reportLink.navigatedTo, null);
 
-                click(reportLinkDe);
-                fixture.detectChanges();
+                await clickAndAwaitChanges(reportLinkDe, fixture);
 
                 expectToEqual(reportLink.navigatedTo, ['../report']);
                 expectToEqual(reportLink.navigatedToFragment, expectedFragment);

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/folio.service.spec.ts
@@ -5,7 +5,7 @@ type Spy = ReturnType<typeof vi.spyOn>;
 
 import * as D3_SELECTION from 'd3-selection';
 
-import { expectSpyCall, expectToBe, expectToContain, expectToEqual } from '@testing/expect-helper';
+import { expectSpyCall, expectToBe, expectToContain, expectToEqual, expectToNotContain } from '@testing/expect-helper';
 import { mockEditionData } from '@testing/mock-data';
 import { mockConsole } from '@testing/mock-helper';
 
@@ -531,7 +531,8 @@ describe('FolioService (DONE)', () => {
                     expectToBe(trademarkSymbolElement.attr('d'), expectedTradeMarkSymbolPath);
                     expectToContain(trademarkSymbolElement.attr('transform'), 'translate');
                     expectToContain(trademarkSymbolElement.attr('transform'), 'scale(0.5)');
-                    expect(trademarkSymbolElement.attr('transform')).not.toContain(
+                    expectToNotContain(
+                        trademarkSymbolElement.attr('transform'),
                         `rotate(${expectedReversedRotationAngle}`
                     );
                     expectToBe(trademarkSymbolElement.attr('fill'), expectedDisabledColor);
@@ -636,7 +637,8 @@ describe('FolioService (DONE)', () => {
                     expectToBe(trademarkSymbolElement.attr('d'), expectedTradeMarkSymbolPath);
                     expectToContain(trademarkSymbolElement.attr('transform'), 'translate');
                     expectToContain(trademarkSymbolElement.attr('transform'), 'scale(0.5)');
-                    expect(trademarkSymbolElement.attr('transform')).not.toContain(
+                    expectToNotContain(
+                        trademarkSymbolElement.attr('transform'),
                         `rotate(${expectedReversedRotationAngle}`
                     );
                     expectToBe(trademarkSymbolElement.attr('fill'), expectedDisabledColor);
@@ -738,7 +740,8 @@ describe('FolioService (DONE)', () => {
                     expectToBe(trademarkSymbolElement.attr('d'), expectedTradeMarkSymbolPath);
                     expectToContain(trademarkSymbolElement.attr('transform'), 'translate');
                     expectToContain(trademarkSymbolElement.attr('transform'), 'scale(0.5)');
-                    expect(trademarkSymbolElement.attr('transform')).not.toContain(
+                    expectToNotContain(
+                        trademarkSymbolElement.attr('transform'),
                         `rotate(${expectedReversedRotationAngle}`
                     );
                     expectToBe(trademarkSymbolElement.attr('fill'), expectedDisabledColor);
@@ -842,7 +845,8 @@ describe('FolioService (DONE)', () => {
                     expectToBe(trademarkSymbolElement.attr('d'), expectedTradeMarkSymbolPath);
                     expectToContain(trademarkSymbolElement.attr('transform'), 'translate');
                     expectToContain(trademarkSymbolElement.attr('transform'), 'scale(0.5)');
-                    expect(trademarkSymbolElement.attr('transform')).not.toContain(
+                    expectToNotContain(
+                        trademarkSymbolElement.attr('transform'),
                         `rotate(${expectedReversedRotationAngle}`
                     );
                     expectToBe(trademarkSymbolElement.attr('fill'), expectedDisabledColor);
@@ -941,7 +945,8 @@ describe('FolioService (DONE)', () => {
                     expectToBe(trademarkSymbolElement.attr('d'), expectedTradeMarkSymbolPath);
                     expectToContain(trademarkSymbolElement.attr('transform'), 'translate');
                     expectToContain(trademarkSymbolElement.attr('transform'), 'scale(0.5)');
-                    expect(trademarkSymbolElement.attr('transform')).not.toContain(
+                    expectToNotContain(
+                        trademarkSymbolElement.attr('transform'),
                         `rotate(${expectedReversedRotationAngle}`
                     );
                     expectToBe(trademarkSymbolElement.attr('fill'), expectedDisabledColor);

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.spec.ts
@@ -695,7 +695,7 @@ describe('EditionSheetsComponent (DONE)', () => {
 
                     component.getEditionSheetsData();
 
-                    expect(component.errorObject).toEqual(expectedError);
+                    expectToEqual(component.errorObject, expectedError);
                 });
 
                 it('...  fetching edition sheets data fails', () => {
@@ -706,7 +706,7 @@ describe('EditionSheetsComponent (DONE)', () => {
 
                     component.getEditionSheetsData();
 
-                    expect(component.errorObject).toEqual(expectedError);
+                    expectToEqual(component.errorObject, expectedError);
                 });
             });
         });

--- a/src/app/views/edition-view/edition-outlets/edition-row-tables/edition-row-tables.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-row-tables/edition-row-tables.component.spec.ts
@@ -12,6 +12,7 @@ import {
     expectToBe,
     expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -205,7 +206,7 @@ describe('EditionRowTablesComponent (DONE)', () => {
                     if (expectedRowTablesData.rowTables[index].disabled) {
                         expectToContain(hEl.classList, 'text-muted');
                     } else {
-                        expect(hEl.classList).not.toContain('text-muted');
+                        expectToNotContain(hEl.classList, 'text-muted');
                     }
                 });
             });
@@ -256,7 +257,7 @@ describe('EditionRowTablesComponent (DONE)', () => {
                     if (expectedRowTablesData.rowTables[index].disabled) {
                         expectToContain(aEl.classList, 'disabled');
                     } else {
-                        expect(aEl.classList).not.toContain('disabled');
+                        expectToNotContain(aEl.classList, 'disabled');
                     }
                 });
             });

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail-complex-card/edition-section-detail-complex-card.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail-complex-card/edition-section-detail-complex-card.component.spec.ts
@@ -8,7 +8,9 @@ import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectToBe,
+    expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -151,7 +153,11 @@ describe('EditionSectionDetailComplexCardComponent (DONE)', () => {
                     const cardTitleDes = getAndExpectDebugElementByCss(colDe, 'h5.card-title', 1, 1);
                     const cardTitleEl: HTMLHeadingElement = cardTitleDes[0].nativeElement;
 
-                    expectToBe(cardTitleEl.classList.contains('text-muted'), expectedComplexes[index].disabled);
+                    if (expectedComplexes[index].disabled) {
+                        expectToContain(cardTitleEl.classList, 'text-muted');
+                    } else {
+                        expectToNotContain(cardTitleEl.classList, 'text-muted');
+                    }
                 });
             });
 
@@ -344,7 +350,11 @@ describe('EditionSectionDetailComplexCardComponent (DONE)', () => {
                     const aDes = getAndExpectDebugElementByCss(pDe, 'a', 1, 1);
                     const aEl: HTMLAnchorElement = aDes[0].nativeElement;
 
-                    expectToBe(aEl.classList.contains('disabled'), expectedComplexes[index].disabled);
+                    if (expectedComplexes[index].disabled) {
+                        expectToContain(aEl.classList, 'disabled');
+                    } else {
+                        expectToNotContain(aEl.classList, 'disabled');
+                    }
                 });
             });
         });

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail-intro-card/edition-section-detail-intro-card.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail-intro-card/edition-section-detail-intro-card.component.spec.ts
@@ -6,7 +6,9 @@ import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectToBe,
+    expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -153,7 +155,11 @@ describe('EditionSectionDetailIntroCardComponent (DONE)', () => {
                 const aDes = getAndExpectDebugElementByCss(pDes[0], 'a', 1, 1);
                 const aEl: HTMLAnchorElement = aDes[0].nativeElement;
 
-                expectToBe(aEl.classList.contains('disabled'), expectedSelectedSection.content.intro.disabled);
+                if (expectedSelectedSection.content.intro.disabled) {
+                    expectToContain(aEl.classList, 'disabled');
+                } else {
+                    expectToNotContain(aEl.classList, 'disabled');
+                }
             });
         });
 

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-sections/edition-sections.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-sections/edition-sections.component.spec.ts
@@ -13,6 +13,7 @@ import {
     expectToBe,
     expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -319,8 +320,8 @@ describe('EditionSectionsComponent (DONE)', () => {
                             expectToContain(contentEl.classList, 'col-8');
                             expectToContain(contentEl.classList, 'col-sm-10');
                         } else {
-                            expect(contentEl.classList).not.toContain('col-8');
-                            expect(contentEl.classList).not.toContain('col-sm-10');
+                            expectToNotContain(contentEl.classList, 'col-8');
+                            expectToNotContain(contentEl.classList, 'col-sm-10');
                         }
                     });
                 });
@@ -387,7 +388,7 @@ describe('EditionSectionsComponent (DONE)', () => {
                             if (!expectedSection.disabled) {
                                 expectToContain(bodyEl.classList, 'awg-card-border-top');
                             } else {
-                                expect(bodyEl.classList).not.toContain('awg-card-border-top');
+                                expectToNotContain(bodyEl.classList, 'awg-card-border-top');
                             }
                         });
                     });
@@ -448,7 +449,7 @@ describe('EditionSectionsComponent (DONE)', () => {
                             if (expectedSelectedSeries.sections[index].disabled) {
                                 expectToContain(hEl.classList, 'text-muted');
                             } else {
-                                expect(hEl.classList).not.toContain('text-muted');
+                                expectToNotContain(hEl.classList, 'text-muted');
                             }
                         });
                     });
@@ -550,7 +551,7 @@ describe('EditionSectionsComponent (DONE)', () => {
                             if (expectedSection.disabled) {
                                 expectToContain(footerLinkEl.classList, 'disabled');
                             } else {
-                                expect(footerLinkEl.classList).not.toContain('disabled');
+                                expectToNotContain(footerLinkEl.classList, 'disabled');
                             }
                         });
                     });

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-sections/edition-sections.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-sections/edition-sections.component.spec.ts
@@ -6,7 +6,7 @@ type Spy = ReturnType<typeof vi.spyOn>;
 
 import { Observable, of as observableOf } from 'rxjs';
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
@@ -626,26 +626,24 @@ describe('EditionSectionsComponent (DONE)', () => {
                 });
             });
 
-            it('... can click section link in template', () => {
+            it('... can click section link in template', async () => {
                 const sectionLinkDe = linkDes[0];
                 const sectionLink = routerLinks[0];
 
                 expectToBe(sectionLink.navigatedTo, null);
 
-                click(sectionLinkDe);
-                fixture.detectChanges();
+                await clickAndAwaitChanges(sectionLinkDe, fixture);
 
                 expectToEqual(sectionLink.navigatedTo, [expectedSelectedSeries.sections[0].section.route]);
             });
 
-            it('... should navigate to section page when section link is clicked', () => {
+            it('... should navigate to section page when section link is clicked', async () => {
                 const sectionLinkDe = linkDes[4];
                 const sectionLink = routerLinks[4];
 
                 expectToBe(sectionLink.navigatedTo, null);
 
-                click(sectionLinkDe);
-                fixture.detectChanges();
+                await clickAndAwaitChanges(sectionLinkDe, fixture);
 
                 expectToEqual(sectionLink.navigatedTo, [expectedSelectedSeries.sections[4].section.route]);
             });

--- a/src/app/views/edition-view/edition-outlets/edition-series/edition-series.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series/edition-series.component.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.spyOn>;
 
-import { click } from '@testing/click-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectSpyCall,
     expectToBe,
@@ -458,50 +458,46 @@ describe('EditionSeriesComponent (DONE)', () => {
                 });
             });
 
-            it('... can click section link in template', () => {
+            it('... can click section link in template', async () => {
                 const sectionLinkDe = linkDes[0];
                 const sectionLink = routerLinks[0];
 
                 expectToBe(sectionLink.navigatedTo, null);
 
-                click(sectionLinkDe);
-                fixture.detectChanges();
+                await clickAndAwaitChanges(sectionLinkDe, fixture);
 
                 expectToEqual(sectionLink.navigatedTo, ['1', 'section', '5']);
             });
 
-            it('... should navigate to section page when section link is clicked', () => {
+            it('... should navigate to section page when section link is clicked', async () => {
                 const sectionLinkDe = linkDes[0];
                 const sectionLink = routerLinks[0];
 
                 expectToBe(sectionLink.navigatedTo, null);
 
-                click(sectionLinkDe);
-                fixture.detectChanges();
+                await clickAndAwaitChanges(sectionLinkDe, fixture);
 
                 expectToEqual(sectionLink.navigatedTo, ['1', 'section', '5']);
             });
 
-            it('... can click series link in template', () => {
+            it('... can click series link in template', async () => {
                 const seriesLinkDe = linkDes[1];
                 const seriesLink = routerLinks[1];
 
                 expectToBe(seriesLink.navigatedTo, null);
 
-                click(seriesLinkDe);
-                fixture.detectChanges();
+                await clickAndAwaitChanges(seriesLinkDe, fixture);
 
                 expectToEqual(seriesLink.navigatedTo, ['1']);
             });
 
-            it('... should navigate to series page when series link is clicked', () => {
+            it('... should navigate to series page when series link is clicked', async () => {
                 const seriesLinkDe = linkDes[1];
                 const seriesLink = routerLinks[1];
 
                 expectToBe(seriesLink.navigatedTo, null);
 
-                click(seriesLinkDe);
-                fixture.detectChanges();
+                await clickAndAwaitChanges(seriesLinkDe, fixture);
 
                 expectToEqual(seriesLink.navigatedTo, ['1']);
             });

--- a/src/app/views/edition-view/services/edition-data.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-data.service.spec.ts
@@ -2389,7 +2389,7 @@ describe('EditionDataService (DONE)', () => {
 
             const result = (editionDataService as any)._generateAssetPath(seriesRoute, sectionRoute);
 
-            expect(result).toBe(expectedPath);
+            expectToBe(result, expectedPath);
         });
 
         it('... should generate the correct path with complexIdRoute', () => {
@@ -2400,7 +2400,7 @@ describe('EditionDataService (DONE)', () => {
 
             const result = (editionDataService as any)._generateAssetPath(seriesRoute, sectionRoute, complexIdRoute);
 
-            expect(result).toBe(expectedPath);
+            expectToBe(result, expectedPath);
         });
     });
 
@@ -2470,8 +2470,7 @@ describe('EditionDataService (DONE)', () => {
 
             result.subscribe({
                 next: (res: any) => {
-                    expect(res).toBeTruthy();
-                    expect(res).toEqual(expectedData);
+                    expectToEqual(res, expectedData);
                 },
                 error: () => {
                     throw new Error('should not call error');

--- a/src/app/views/edition-view/services/edition-svg-drawing.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-svg-drawing.service.spec.ts
@@ -344,7 +344,7 @@ describe('EditionSvgDrawingService (DONE)', () => {
             expect(d3selections).toBeDefined();
             expect(d3selections.nodes()).toBeInstanceOf(Array);
             expectToBe(d3selections.nodes().length, 1);
-            expect(d3selections.nodes()[0].getAttribute('data-tkk-id')).toBe('custom-data-id');
+            expectToBe(d3selections.nodes()[0].getAttribute('data-tkk-id'), 'custom-data-id');
             expectToBe(d3selections.nodes()[0].id, 'actual-id');
         });
 
@@ -356,7 +356,7 @@ describe('EditionSvgDrawingService (DONE)', () => {
             expect(d3selections).toBeDefined();
             expect(d3selections.nodes()).toBeInstanceOf(Array);
             expectToBe(d3selections.nodes().length, 1);
-            expect(d3selections.nodes()[0].id).toBe('tkk-1');
+            expectToBe(d3selections.nodes()[0].id, 'tkk-1');
 
             const d3selections2 = service.getD3SelectionByDataId(expectedSvgRootGroup, 'tkk-2');
 

--- a/src/app/views/edition-view/services/edition-svg-overlay.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-svg-overlay.service.spec.ts
@@ -222,7 +222,7 @@ describe('EditionSvgOverlayService', () => {
 
             service.clearSvgOverlays();
 
-            expect((service as any)._tkkOverlaysState).toEqual({ available: [], selected: [] });
+            expectToEqual((service as any)._tkkOverlaysState, { available: [], selected: [] });
         });
     });
 
@@ -347,7 +347,7 @@ describe('EditionSvgOverlayService', () => {
                     const dataId = (service as any)._getSvgGroupDataId(groupWithDataTkkId);
 
                     expect(getSvgGroupDataIdSpy).toHaveBeenCalledWith(groupWithDataTkkId);
-                    expect(dataId).toBe('custom-data-id-1');
+                    expectToBe(dataId, 'custom-data-id-1');
                 });
                 it('... without data-tkk-id attribute', () => {
                     const groupWithoutDataTkkId = {
@@ -358,7 +358,7 @@ describe('EditionSvgOverlayService', () => {
                     const dataId = (service as any)._getSvgGroupDataId(groupWithoutDataTkkId);
 
                     expect(getSvgGroupDataIdSpy).toHaveBeenCalledWith(groupWithoutDataTkkId);
-                    expect(dataId).toBe('tkk-2');
+                    expectToBe(dataId, 'tkk-2');
                 });
             });
 
@@ -1080,13 +1080,13 @@ describe('EditionSvgOverlayService', () => {
                     expectedOverlayType
                 );
 
-                expect(expectedTkkOverlays[0].isSelected).toBe(true);
-                expect(expectedTkkOverlays[1].isSelected).toBe(true);
+                expectToBe(expectedTkkOverlays[0].isSelected, true);
+                expectToBe(expectedTkkOverlays[1].isSelected, true);
 
                 mockOverlayGroupRectSelection._handlers['click']();
 
-                expect(expectedTkkOverlays[0].isSelected).toBe(true);
-                expect(expectedTkkOverlays[1].isSelected).toBe(false);
+                expectToBe(expectedTkkOverlays[0].isSelected, true);
+                expectToBe(expectedTkkOverlays[1].isSelected, false);
             });
 
             it('... should trigger update color', () => {
@@ -1116,13 +1116,13 @@ describe('EditionSvgOverlayService', () => {
                     expectedOverlayType
                 );
 
-                expect(expectedTkkOverlays[0].isSelected).toBe(true);
-                expect(expectedTkkOverlays[1].isSelected).toBe(true);
+                expectToBe(expectedTkkOverlays[0].isSelected, true);
+                expectToBe(expectedTkkOverlays[1].isSelected, true);
 
                 mockOverlayGroupRectSelection._handlers['click']();
 
-                expect(expectedTkkOverlays[0].isSelected).toBe(true);
-                expect(expectedTkkOverlays[1].isSelected).toBe(false);
+                expectToBe(expectedTkkOverlays[0].isSelected, true);
+                expectToBe(expectedTkkOverlays[1].isSelected, false);
 
                 expectToEqual((service as any)._tkkOverlaysState.selected, expectedSelectedOverlays);
 
@@ -1180,8 +1180,8 @@ describe('EditionSvgOverlayService', () => {
                 mockOverlayGroupRectSelection._handlers['click']();
 
                 // Both overlays should have toggled selection
-                expect(overlays[0].isSelected).toBe(true);
-                expect(overlays[1].isSelected).toBe(true);
+                expectToBe(overlays[0].isSelected, true);
+                expectToBe(overlays[1].isSelected, true);
             });
 
             it('... should update color for all overlays with the same data-id', () => {
@@ -1214,8 +1214,8 @@ describe('EditionSvgOverlayService', () => {
                 // Simulate click event
                 mockOverlayGroupRectSelection._handlers['click']();
 
-                expect(overlays[0].isSelected).toBe(true);
-                expect(overlays[1].isSelected).toBe(true);
+                expectToBe(overlays[0].isSelected, true);
+                expectToBe(overlays[1].isSelected, true);
 
                 // Should emit both overlays as selected
                 expect(onOverlaySelectSpy).toHaveBeenCalledWith(overlays);
@@ -1331,7 +1331,7 @@ describe('EditionSvgOverlayService', () => {
 
                 expect(d3selections).toBeDefined();
                 expect(d3selections.nodes()).toBeInstanceOf(Array);
-                expect(d3selections.nodes().length).toBe(0);
+                expectToBe(d3selections.nodes().length, 0);
             });
         });
 
@@ -1376,7 +1376,7 @@ describe('EditionSvgOverlayService', () => {
 
                 expect(d3selections).toBeDefined();
                 expect(d3selections.nodes()).toBeInstanceOf(Array);
-                expect(d3selections.nodes().length).toBe(1);
+                expectToBe(d3selections.nodes().length, 1);
                 expectToContain(d3selections.nodes()[0].classList, 'tkk-overlay-group-box');
             });
 
@@ -1396,7 +1396,7 @@ describe('EditionSvgOverlayService', () => {
 
                 expect(d3Selections).toBeDefined();
                 expect(d3Selections.nodes()).toBeInstanceOf(Array);
-                expect(d3Selections.nodes().length).toBe(1);
+                expectToBe(d3Selections.nodes().length, 1);
                 expectToContain(d3Selections.nodes()[0].classList, `${expectedType}-overlay-group-box`);
             });
 
@@ -1423,7 +1423,7 @@ describe('EditionSvgOverlayService', () => {
 
                 expect(d3Selections).toBeDefined();
                 expect(d3Selections.nodes()).toBeInstanceOf(Array);
-                expect(d3Selections.nodes().length).toBe(2);
+                expectToBe(d3Selections.nodes().length, 2);
                 const nodeIds = d3Selections.nodes().map(node => node.parentNode.id);
                 expectToContain(nodeIds, 'group1');
                 expectToContain(nodeIds, 'group2');

--- a/src/app/views/home-view/home-view.component.spec.ts
+++ b/src/app/views/home-view/home-view.component.spec.ts
@@ -469,16 +469,14 @@ describe('HomeViewComponent (DONE)', () => {
 
                     const result = HomeViewComponent.createEditionSectionLinks(incompleteSections);
 
-                    expect(result.length).toBe(1);
-
-                    expect(result[0].routerLink).toEqual([
+                    expectToBe(result.length, 1);
+                    expectToEqual(result[0].routerLink, [
                         routes.EDITION.route,
                         routes.SERIES.route,
                         undefined,
                         routes.SECTION.route,
                         undefined,
                     ]);
-
                     expectToBe(result[0].label, `${routes.EDITION.short} undefined/undefined`);
                     expectToBe(result[0].separator, '');
                 });

--- a/src/app/views/page-not-found-view/page-not-found-view.component.spec.ts
+++ b/src/app/views/page-not-found-view/page-not-found-view.component.spec.ts
@@ -4,8 +4,7 @@ import { provideRouter, Router, RouterLink } from '@angular/router';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { click } from '@testing/click-helper';
-import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectToBe,
     expectToContain,
@@ -288,8 +287,7 @@ describe('PageNotFoundViewComponent (DONE)', () => {
 
                 const homeLinkDe = linkDes[0];
 
-                click(homeLinkDe);
-                await detectChangesOnPush(fixture);
+                await clickAndAwaitChanges(homeLinkDe, fixture);
 
                 expect(navigateSpy).toHaveBeenCalled();
                 const firstCallArg = navigateSpy.mock.calls[0][0];

--- a/src/app/views/statistics-view/statistics-breakdown-badge/statistics-breakdown-badge.component.html
+++ b/src/app/views/statistics-view/statistics-breakdown-badge/statistics-breakdown-badge.component.html
@@ -1,5 +1,5 @@
 <div class="awg-statistics-breakdown-badge-container" [class]="containerClasses()">
-    @for (badge of visibleBadges(); track badge.label) {
+    @for (badge of displayedBadges(); track badge.label) {
         <span
             class="awg-statistics-breakdown-badge badge me-1"
             [class.bg-primary]="badge.type === 'primary'"

--- a/src/app/views/statistics-view/statistics-breakdown-badge/statistics-breakdown-badge.component.spec.ts
+++ b/src/app/views/statistics-view/statistics-breakdown-badge/statistics-breakdown-badge.component.spec.ts
@@ -4,7 +4,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
-import { expectToBe, expectToContain, expectToEqual, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+import {
+    expectToBe,
+    expectToContain,
+    expectToEqual,
+    expectToNotContain,
+    getAndExpectDebugElementByCss,
+} from '@testing/expect-helper';
 
 import { StatisticsBreakDownBadge, StatisticsComplexBreakdown } from '../models/statistics.model';
 
@@ -69,9 +75,9 @@ describe('StatisticsBreakdownBadgeComponent', () => {
                 );
                 const containerEl = containerDes[0].nativeElement;
 
-                expectToContain(containerEl.className, 'awg-statistics-breakdown-badge-container');
-                expect(containerEl.className).not.toContain('small');
-                expect(containerEl.className).not.toContain('text-muted');
+                expectToContain(containerEl.classList, 'awg-statistics-breakdown-badge-container');
+                expectToNotContain(containerEl.classList, 'small');
+                expectToNotContain(containerEl.classList, 'text-muted');
             });
 
             it('... should contain no badge elements yet', () => {
@@ -101,11 +107,11 @@ describe('StatisticsBreakdownBadgeComponent', () => {
             expectToBe(component.showEmptyBadges(), false);
         });
 
-        it('... should have computed `visibleBadges` (empty array due to showEmptyBadges=false)', () => {
-            const currentVisibleBadges: StatisticsBreakDownBadge[] = component.visibleBadges();
+        it('... should have computed `displayedBadges` (empty array due to showEmptyBadges=false)', () => {
+            const currentDisplayedBadges: StatisticsBreakDownBadge[] = component.displayedBadges();
 
-            expectToEqual(currentVisibleBadges, []);
-            expectToBe(currentVisibleBadges.length, 0);
+            expectToEqual(currentDisplayedBadges, []);
+            expectToBe(currentDisplayedBadges.length, 0);
         });
 
         describe('VIEW', () => {
@@ -155,17 +161,17 @@ describe('StatisticsBreakdownBadgeComponent', () => {
             expectToBe(component.showEmptyBadges(), expectedShowEmptyBadges);
         });
 
-        it('... should have computed `visibleBadges` based on breakdown and showEmptyBadges', () => {
-            const expectedVisibleBadges: StatisticsBreakDownBadge[] = [
+        it('... should have computed `displayedBadges` based on breakdown and showEmptyBadges', () => {
+            const expectedDisplayedBadges: StatisticsBreakDownBadge[] = [
                 { label: 'Op', val: expectedBreakdown.opus, type: 'primary' },
                 { label: 'M', val: expectedBreakdown.mnr, type: 'secondary' },
                 { label: 'M*', val: expectedBreakdown.mnrX, type: 'info' },
             ];
 
-            const currentVisibleBadges: StatisticsBreakDownBadge[] = component.visibleBadges();
+            const currentDisplayedBadges: StatisticsBreakDownBadge[] = component.displayedBadges();
 
-            expectToEqual(currentVisibleBadges, expectedVisibleBadges);
-            expectToBe(currentVisibleBadges.length, 3);
+            expectToEqual(currentDisplayedBadges, expectedDisplayedBadges);
+            expectToBe(currentDisplayedBadges.length, 3);
         });
 
         describe('VIEW', () => {
@@ -323,9 +329,9 @@ describe('StatisticsBreakdownBadgeComponent', () => {
             });
         });
 
-        describe('#visibleBadges()', () => {
-            it('... should have a computed signal `visibleBadges()`', () => {
-                expect(component.visibleBadges).toBeDefined();
+        describe('#displayedBadges()', () => {
+            it('... should have a computed signal `displayedBadges()`', () => {
+                expect(component.displayedBadges).toBeDefined();
             });
 
             it('... should return an empty array if breakdown is empty and showEmptyBadges is false', () => {
@@ -335,7 +341,7 @@ describe('StatisticsBreakdownBadgeComponent', () => {
                 );
                 fixture.componentRef.setInput('showEmptyBadges', false);
 
-                const badges: StatisticsBreakDownBadge[] = component.visibleBadges();
+                const badges: StatisticsBreakDownBadge[] = component.displayedBadges();
 
                 expectToEqual(badges, []);
             });
@@ -348,7 +354,7 @@ describe('StatisticsBreakdownBadgeComponent', () => {
                     );
                     fixture.componentRef.setInput('showEmptyBadges', false);
 
-                    const badges: StatisticsBreakDownBadge[] = component.visibleBadges();
+                    const badges: StatisticsBreakDownBadge[] = component.displayedBadges();
 
                     expectToBe(badges.length, 3);
                 });
@@ -360,7 +366,7 @@ describe('StatisticsBreakdownBadgeComponent', () => {
                     );
                     fixture.componentRef.setInput('showEmptyBadges', true);
 
-                    const badges: StatisticsBreakDownBadge[] = component.visibleBadges();
+                    const badges: StatisticsBreakDownBadge[] = component.displayedBadges();
 
                     expectToBe(badges.length, 3);
                 });
@@ -372,7 +378,7 @@ describe('StatisticsBreakdownBadgeComponent', () => {
                     new StatisticsComplexBreakdown({ opus: 5, mnr: 3, mnrX: 1 })
                 );
 
-                const badges: StatisticsBreakDownBadge[] = component.visibleBadges();
+                const badges: StatisticsBreakDownBadge[] = component.displayedBadges();
 
                 expectToBe(badges[0].label, 'Op');
                 expectToBe(badges[1].label, 'M');
@@ -385,7 +391,7 @@ describe('StatisticsBreakdownBadgeComponent', () => {
                     new StatisticsComplexBreakdown({ opus: 5, mnr: 3, mnrX: 1 })
                 );
 
-                const badges: StatisticsBreakDownBadge[] = component.visibleBadges();
+                const badges: StatisticsBreakDownBadge[] = component.displayedBadges();
 
                 expectToBe(badges[0].type, 'primary');
                 expectToBe(badges[1].type, 'secondary');

--- a/src/app/views/statistics-view/statistics-breakdown-badge/statistics-breakdown-badge.component.ts
+++ b/src/app/views/statistics-view/statistics-breakdown-badge/statistics-breakdown-badge.component.ts
@@ -38,12 +38,12 @@ export class StatisticsBreakdownBadgeComponent {
     showEmptyBadges = input<boolean>(false);
 
     /**
-     * Computed signal: visibleBadges.
+     * Computed signal: displayedBadges.
      *
      * It computes the list of badges to be displayed
      * based on the breakdown data and the showEmptyBadges flag.
      */
-    visibleBadges = computed<StatisticsBreakDownBadge[]>(() => {
+    displayedBadges = computed<StatisticsBreakDownBadge[]>(() => {
         const data = this.breakdown();
         const showEmpty = this.showEmptyBadges();
 

--- a/src/app/views/statistics-view/statistics-progress-bar/statistics-progress-bar.component.spec.ts
+++ b/src/app/views/statistics-view/statistics-progress-bar/statistics-progress-bar.component.spec.ts
@@ -9,6 +9,7 @@ import {
     expectToBe,
     expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -124,7 +125,7 @@ describe('StatisticsProgressBarComponent', () => {
                 expectToBe(progressEl.classList.length, 2);
                 expectToContain(progressEl.classList, 'progress'); // Default class of NgbProgressbar
                 expectToContain(progressEl.classList, 'flex-grow-1');
-                expectToBe(progressEl.classList.contains('me-2'), false);
+                expectToNotContain(progressEl.classList, 'me-2');
             });
 
             it('... should not pass down type, height, value or ariaLabel yet', () => {
@@ -208,14 +209,14 @@ describe('StatisticsProgressBarComponent', () => {
                 const labelDes = getAndExpectDebugElementByCss(compDe, 'small', 1, 1);
                 const labelEl: HTMLElement = labelDes[0].nativeElement;
 
-                expectToBe(labelEl.classList.contains('fw-bold'), false);
+                expectToNotContain(labelEl.classList, 'fw-bold');
             });
 
             it('... should have text-muted class on percentage label due to 0%', () => {
                 const labelDes = getAndExpectDebugElementByCss(compDe, 'small', 1, 1);
                 const labelEl: HTMLElement = labelDes[0].nativeElement;
 
-                expectToBe(labelEl.classList.contains('text-muted'), true);
+                expectToContain(labelEl.classList, 'text-muted');
             });
         });
     });
@@ -304,7 +305,7 @@ describe('StatisticsProgressBarComponent', () => {
                 const labelDes = getAndExpectDebugElementByCss(compDe, 'small', 1, 1);
                 const labelEl: HTMLElement = labelDes[0].nativeElement;
 
-                expectToBe(labelEl.classList.contains('text-muted'), false);
+                expectToNotContain(labelEl.classList, 'text-muted');
             });
 
             describe('... when headerLabel is given', () => {
@@ -331,8 +332,8 @@ describe('StatisticsProgressBarComponent', () => {
                         expectToBe(headerEl.classList.length, 2);
                         expectToContain(headerEl.classList, 'awg-statistics-progress-header');
                         expectToContain(headerEl.classList, 'mb-1');
-                        expectToBe(headerEl.classList.contains('d-flex'), false);
-                        expectToBe(headerEl.classList.contains('justify-content-between'), false);
+                        expectToNotContain(headerEl.classList, 'd-flex');
+                        expectToNotContain(headerEl.classList, 'justify-content-between');
                     });
 
                     it('... should display the headerLabel in only span in progress-header div', () => {
@@ -473,7 +474,7 @@ describe('StatisticsProgressBarComponent', () => {
                     expectToBe(progressEl.classList.length, 2);
                     expectToContain(progressEl.classList, 'progress');
                     expectToContain(progressEl.classList, 'flex-grow-1');
-                    expectToBe(progressEl.classList.contains('me-2'), false);
+                    expectToNotContain(progressEl.classList, 'me-2');
                 });
 
                 it('... should not show percentage label', () => {
@@ -491,7 +492,7 @@ describe('StatisticsProgressBarComponent', () => {
                     const labelDes = getAndExpectDebugElementByCss(compDe, 'small', 1, 1);
                     const labelEl: HTMLElement = labelDes[0].nativeElement;
 
-                    expectToBe(labelEl.classList.contains('fw-bold'), false);
+                    expectToNotContain(labelEl.classList, 'fw-bold');
                 });
             });
         });

--- a/src/app/views/statistics-view/statistics-series-breakdown/statistics-series-breakdown.component.spec.ts
+++ b/src/app/views/statistics-view/statistics-series-breakdown/statistics-series-breakdown.component.spec.ts
@@ -11,6 +11,7 @@ import {
     expectToBe,
     expectToContain,
     expectToEqual,
+    expectToNotContain,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
@@ -178,7 +179,7 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                     expectToBe(thEl.getAttribute('rowspan'), expectedHeader.rowspan);
                     expectToBe(thEl.getAttribute('colspan'), expectedHeader.colspan);
                     expectedHeader.classes.split(' ').forEach(headerClass => {
-                        expectToBe(thEl.classList.contains(headerClass), true);
+                        expectToContain(thEl.classList, headerClass);
                     });
                 });
             });
@@ -200,7 +201,7 @@ describe('StatisticsSeriesBreakdownComponent', () => {
 
                     expectToBe(thEl.textContent?.trim(), expectedHeader.text);
                     expectedHeader.classes.split(' ').forEach(headerClass => {
-                        expectToBe(thEl.classList.contains(headerClass), true);
+                        expectToContain(thEl.classList, headerClass);
                     });
                 });
             });
@@ -296,9 +297,12 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                             const tdDes = getAndExpectDebugElementByCss(seriesTrDe, 'td', 5, 5);
                             const strongDes = getAndExpectDebugElementByCss(tdDes[0], 'strong', 1, 1);
                             const strongEl: HTMLElement = strongDes[0].nativeElement;
-                            const shouldBeMuted = mockData[index].activeSections === 0;
 
-                            expectToBe(strongEl.classList.contains('text-muted'), shouldBeMuted);
+                            if (mockData[index].activeSections === 0) {
+                                expectToContain(strongEl.classList, 'text-muted');
+                            } else {
+                                expectToNotContain(strongEl.classList, 'text-muted');
+                            }
                         });
                     });
 
@@ -317,7 +321,7 @@ describe('StatisticsSeriesBreakdownComponent', () => {
 
                             const expectedActiveSectionsText = `(${expectedSeriesBreakdownData[index].activeSections} active section)`;
 
-                            expectToBe(smallEl.classList.contains('text-muted'), true);
+                            expectToContain(smallEl.classList, 'text-muted');
                             expectToBe(smallEl.textContent?.trim(), expectedActiveSectionsText);
                         });
                     });
@@ -363,7 +367,7 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                             const strongDes = getAndExpectDebugElementByCss(tdDes[1], 'strong', 1, 1);
                             const strongEl: HTMLElement = strongDes[0].nativeElement;
 
-                            expectToBe(tdEl.classList.contains('text-center'), true);
+                            expectToContain(tdEl.classList, 'text-center');
                             expectToBe(
                                 strongEl.textContent?.trim(),
                                 expectedSeriesBreakdownData[index].totalComplexes.toString()
@@ -387,9 +391,12 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                         seriesTrDes.forEach((seriesTrDe, index) => {
                             const tdDes = getAndExpectDebugElementByCss(seriesTrDe, 'td', 5, 5);
                             const tdEl: HTMLTableCellElement = tdDes[1].nativeElement;
-                            const shouldBeMuted = mockData[index].activeSections === 0;
 
-                            expectToBe(tdEl.classList.contains('text-muted'), shouldBeMuted);
+                            if (mockData[index].activeSections === 0) {
+                                expectToContain(tdEl.classList, 'text-muted');
+                            } else {
+                                expectToNotContain(tdEl.classList, 'text-muted');
+                            }
                         });
                     });
                 });
@@ -408,7 +415,7 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                             const tdEl: HTMLTableCellElement = tdDes[2].nativeElement;
                             const expectedBadgeCount = expectedSeriesBreakdownData[0].totalComplexes > 0 ? 1 : 0;
 
-                            expectToBe(tdEl.classList.contains('text-center'), true);
+                            expectToContain(tdEl.classList, 'text-center');
                             getAndExpectDebugElementByDirective(
                                 tdDes[2],
                                 StatisticsBreakdownBadgeStubComponent,
@@ -486,7 +493,7 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                             const strongDes = getAndExpectDebugElementByCss(tdDes[3], 'strong', 1, 1);
                             const strongEl: HTMLElement = strongDes[0].nativeElement;
 
-                            expectToBe(tdEl.classList.contains('text-center'), true);
+                            expectToContain(tdEl.classList, 'text-center');
                             expectToBe(
                                 strongEl.textContent?.trim(),
                                 expectedSeriesBreakdownData[index].activeComplexes.toString()
@@ -510,9 +517,12 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                         seriesTrDes.forEach((seriesTrDe, index) => {
                             const tdDes = getAndExpectDebugElementByCss(seriesTrDe, 'td', 5, 5);
                             const tdEl: HTMLTableCellElement = tdDes[3].nativeElement;
-                            const shouldBeMuted = mockData[index].activeSections === 0;
 
-                            expectToBe(tdEl.classList.contains('text-muted'), shouldBeMuted);
+                            if (mockData[index].activeSections === 0) {
+                                expectToContain(tdEl.classList, 'text-muted');
+                            } else {
+                                expectToNotContain(tdEl.classList, 'text-muted');
+                            }
                         });
                     });
                 });
@@ -642,19 +652,19 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                         sectionRows.forEach(({ tdDes, sectionData }) => {
                             // Prefix
                             const spanDes = getAndExpectDebugElementByCss(tdDes[0], 'span', 1, 1);
-                            expectToBe(spanDes[0].nativeElement.classList.contains('text-muted'), true);
+                            expectToContain(spanDes[0].nativeElement.classList, 'text-muted');
 
                             // Section Label
                             const aDes = getAndExpectDebugElementByCss(tdDes[0], 'a', 1, 1);
                             const aEl: HTMLAnchorElement = aDes[0].nativeElement;
 
                             if (sectionData.disabled) {
-                                expectToBe(aEl.classList.contains('text-muted'), true);
-                                expectToBe(aEl.classList.contains('pe-none'), true);
+                                expectToContain(aEl.classList, 'text-muted');
+                                expectToContain(aEl.classList, 'pe-none');
                                 expectToBe(aEl.style.textDecoration, 'none');
                             } else {
-                                expectToBe(aEl.classList.contains('text-muted'), false);
-                                expectToBe(aEl.classList.contains('pe-none'), false);
+                                expectToNotContain(aEl.classList, 'text-muted');
+                                expectToNotContain(aEl.classList, 'pe-none');
                                 expectToBe(aEl.style.textDecoration, '');
                             }
                         });
@@ -718,7 +728,7 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                         sectionRows.forEach(({ tdDes, sectionData }) => {
                             const tdEl: HTMLTableCellElement = tdDes[1].nativeElement;
 
-                            expectToBe(tdEl.classList.contains('text-center'), true);
+                            expectToContain(tdEl.classList, 'text-center');
                             expectToBe(tdEl.textContent?.trim(), sectionData.totalComplexes.toString());
                         });
                     });
@@ -728,9 +738,12 @@ describe('StatisticsSeriesBreakdownComponent', () => {
 
                         sectionRows.forEach(({ tdDes, sectionData }) => {
                             const tdEl: HTMLTableCellElement = tdDes[1].nativeElement;
-                            const shouldBeMuted = sectionData.disabled === true;
 
-                            expectToBe(tdEl.classList.contains('text-muted'), shouldBeMuted);
+                            if (sectionData.disabled === true) {
+                                expectToContain(tdEl.classList, 'text-muted');
+                            } else {
+                                expectToNotContain(tdEl.classList, 'text-muted');
+                            }
                         });
                     });
                 });
@@ -743,7 +756,7 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                             const tdEl: HTMLTableCellElement = tdDes[2].nativeElement;
                             const expectedBadgeCount = sectionData.totalComplexes > 0 ? 1 : 0;
 
-                            expectToBe(tdEl.classList.contains('text-center'), true);
+                            expectToContain(tdEl.classList, 'text-center');
                             getAndExpectDebugElementByDirective(
                                 tdDes[2],
                                 StatisticsBreakdownBadgeStubComponent,
@@ -760,7 +773,7 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                             const tdEl: HTMLTableCellElement = tdDes[2].nativeElement;
                             const expectedBadgeCount = sectionData.totalComplexes > 0 ? 1 : 0;
 
-                            expectToBe(tdEl.classList.contains('text-center'), true);
+                            expectToContain(tdEl.classList, 'text-center');
                             const badgeDes = getAndExpectDebugElementByDirective(
                                 tdDes[2],
                                 StatisticsBreakdownBadgeStubComponent,
@@ -782,7 +795,7 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                         sectionRows.forEach(({ tdDes, sectionData }) => {
                             const tdEl: HTMLTableCellElement = tdDes[3].nativeElement;
 
-                            expectToBe(tdEl.classList.contains('text-center'), true);
+                            expectToContain(tdEl.classList, 'text-center');
                             expectToBe(tdEl.textContent?.trim(), sectionData.activeComplexes.toString());
                         });
                     });
@@ -792,9 +805,12 @@ describe('StatisticsSeriesBreakdownComponent', () => {
 
                         sectionRows.forEach(({ tdDes, sectionData }) => {
                             const tdEl: HTMLTableCellElement = tdDes[3].nativeElement;
-                            const shouldBeMuted = sectionData.disabled === true;
 
-                            expectToBe(tdEl.classList.contains('text-muted'), shouldBeMuted);
+                            if (sectionData.disabled === true) {
+                                expectToContain(tdEl.classList, 'text-muted');
+                            } else {
+                                expectToNotContain(tdEl.classList, 'text-muted');
+                            }
                         });
                     });
                 });

--- a/src/app/views/statistics-view/statistics-series-breakdown/statistics-series-breakdown.component.spec.ts
+++ b/src/app/views/statistics-view/statistics-series-breakdown/statistics-series-breakdown.component.spec.ts
@@ -4,8 +4,7 @@ import { provideRouter, Router, RouterLink } from '@angular/router';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { click } from '@testing/click-helper';
-import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectSpyCall,
     expectToBe,
@@ -702,10 +701,8 @@ describe('StatisticsSeriesBreakdownComponent', () => {
                             navigateSpy.mockClear();
 
                             const aDes = getAndExpectDebugElementByCss(tdDes[0], 'a', 1, 1);
-                            const aEl: HTMLAnchorElement = aDes[0].nativeElement;
 
-                            click(aEl as HTMLElement);
-                            await detectChangesOnPush(fixture);
+                            await clickAndAwaitChanges(aDes[0], fixture);
 
                             expectSpyCall(navigateSpy, 1);
                             const firstCallArg = navigateSpy.mock.calls[0][0];

--- a/src/app/views/statistics-view/statistics-summary-card/statistics-summary-card.component.ts
+++ b/src/app/views/statistics-view/statistics-summary-card/statistics-summary-card.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
-import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 
 /**
@@ -13,7 +13,7 @@ import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
     templateUrl: './statistics-summary-card.component.html',
     styleUrls: ['./statistics-summary-card.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FontAwesomeModule],
+    imports: [FaIconComponent],
 })
 export class StatisticsSummaryCardComponent {
     /**

--- a/src/app/views/statistics-view/statistics-view.component.spec.ts
+++ b/src/app/views/statistics-view/statistics-view.component.spec.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mocked } from 'vi
 
 import {
     expectToBe,
+    expectToContain,
     expectToEqual,
     getAndExpectDebugElementByCss,
     getAndExpectDebugElementByDirective,
@@ -288,7 +289,7 @@ describe('StatisticsViewComponent', () => {
                 const pDes = getAndExpectDebugElementByCss(headerDes[0], 'p.lead', 1, 1);
                 const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 
-                expectToBe(pEl.classList.contains('text-muted'), true);
+                expectToContain(pEl.classList, 'text-muted');
                 expectToBe(
                     pEl.textContent.trim(),
                     'Overview of key metrics in the online edition of the Anton Webern Gesamtausgabe'

--- a/src/testing/accordion-panel-helper.spec.ts
+++ b/src/testing/accordion-panel-helper.spec.ts
@@ -2,13 +2,15 @@ import { DebugElement } from '@angular/core';
 
 import { describe, expect, it } from 'vitest';
 
+import { expectToBe } from './expect-helper';
+
 import { expectCollapsedAccordionItem, expectOpenAccordionItem } from './accordion-panel-helper';
 
 describe('accordion-panel-helper', () => {
     describe('#expectCollapsedAccordionItem()', () => {
         it('... should have a method `expectCollapsedAccordionItem`', () => {
             expect(expectCollapsedAccordionItem).toBeDefined();
-            expect(typeof expectCollapsedAccordionItem).toBe('function');
+            expectToBe(typeof expectCollapsedAccordionItem, 'function');
         });
 
         it('... should have `expectCollapsedAccordionItem` pass for a collapsed header', () => {
@@ -30,7 +32,7 @@ describe('accordion-panel-helper', () => {
     describe('#expectOpenAccordionItem()', () => {
         it('... should have a method `expectOpenAccordionItem`', () => {
             expect(expectOpenAccordionItem).toBeDefined();
-            expect(typeof expectOpenAccordionItem).toBe('function');
+            expectToBe(typeof expectOpenAccordionItem, 'function');
         });
 
         it('... should have `expectOpenAccordionItem` pass for an open header', () => {

--- a/src/testing/click-helper.spec.ts
+++ b/src/testing/click-helper.spec.ts
@@ -3,51 +3,9 @@ import { ComponentFixture } from '@angular/core/testing';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { BUTTON_CLICK_EVENTS, click, clickAndAwaitChanges, clickDispatchAndAwaitChanges } from './click-helper';
+import { clickAndAwaitChanges, clickDispatchAndAwaitChanges } from './click-helper';
 
 describe('click-helper', () => {
-    describe('BUTTON_CLICK_EVENTS', () => {
-        it('... should have `BUTTON_CLICK_EVENTS` with `left` and `right`', () => {
-            expect(BUTTON_CLICK_EVENTS).toBeDefined();
-            expect(BUTTON_CLICK_EVENTS.left).toBeDefined();
-            expect(BUTTON_CLICK_EVENTS.right).toBeDefined();
-        });
-
-        it('... should expose left and right button event objects', () => {
-            expect(BUTTON_CLICK_EVENTS.left).toEqual({ button: 0 });
-            expect(BUTTON_CLICK_EVENTS.right).toEqual({ button: 2 });
-        });
-    });
-
-    describe('#click()', () => {
-        it('... should have a method `click`', () => {
-            expect(click).toBeDefined();
-            expect(typeof click).toBe('function');
-        });
-
-        it('... should call native click when target is an HTMLElement', () => {
-            const button = document.createElement('button');
-            const onClick = vi.fn();
-            button.addEventListener('click', onClick);
-
-            click(button);
-
-            expect(onClick).toHaveBeenCalledTimes(1);
-        });
-
-        it('... should call triggerEventHandler when target is a DebugElement', () => {
-            const eventObj = { button: 1 };
-            const debugElement = {
-                triggerEventHandler: vi.fn(),
-            } as unknown as DebugElement;
-
-            click(debugElement, eventObj);
-
-            expect(debugElement.triggerEventHandler).toHaveBeenCalledTimes(1);
-            expect(debugElement.triggerEventHandler).toHaveBeenCalledWith('click', eventObj);
-        });
-    });
-
     describe('#clickAndAwaitChanges()', () => {
         it('... should have a method `clickAndAwaitChanges`', () => {
             expect(clickAndAwaitChanges).toBeDefined();
@@ -55,36 +13,57 @@ describe('click-helper', () => {
         });
 
         it('... should return early when element is disabled', async () => {
-            const clickDe = {
-                nativeElement: { disabled: true },
-                triggerEventHandler: vi.fn(),
-            } as unknown as DebugElement;
+            const mockHtmlElement = {
+                disabled: true,
+                click: vi.fn(),
+            } as unknown as HTMLElement;
             const fixture = {
                 detectChanges: vi.fn(),
                 whenStable: vi.fn().mockResolvedValue(undefined),
             } as unknown as ComponentFixture<any>;
 
-            await clickAndAwaitChanges(clickDe, fixture);
+            await clickAndAwaitChanges(mockHtmlElement, fixture);
 
-            expect(clickDe.triggerEventHandler).not.toHaveBeenCalled();
+            expect(mockHtmlElement.click).not.toHaveBeenCalled();
+
             expect(fixture.detectChanges).not.toHaveBeenCalled();
             expect(fixture.whenStable).not.toHaveBeenCalled();
         });
 
-        it('... should trigger click and apply changes when element is enabled', async () => {
-            const clickDe = {
-                nativeElement: { disabled: false },
-                triggerEventHandler: vi.fn(),
+        it('... should trigger native click and apply changes for HTMLElement target', async () => {
+            const button = document.createElement('button');
+            const onClick = vi.fn();
+            button.addEventListener('click', onClick);
+
+            const fixture = {
+                detectChanges: vi.fn(),
+                whenStable: vi.fn().mockResolvedValue(undefined),
+            } as unknown as ComponentFixture<any>;
+
+            await clickAndAwaitChanges(button, fixture);
+
+            expect(onClick).toHaveBeenCalledTimes(1);
+
+            expect(fixture.detectChanges).toHaveBeenCalledTimes(2);
+            expect(fixture.whenStable).toHaveBeenCalledTimes(1);
+        });
+
+        it('... should resolve DebugElement target to native element and trigger click', async () => {
+            const button = document.createElement('button');
+            const onClick = vi.fn();
+            button.addEventListener('click', onClick);
+
+            const debugElement = {
+                nativeElement: button,
             } as unknown as DebugElement;
             const fixture = {
                 detectChanges: vi.fn(),
                 whenStable: vi.fn().mockResolvedValue(undefined),
             } as unknown as ComponentFixture<any>;
 
-            await clickAndAwaitChanges(clickDe, fixture);
+            await clickAndAwaitChanges(debugElement, fixture);
 
-            expect(clickDe.triggerEventHandler).toHaveBeenCalledTimes(1);
-            expect(clickDe.triggerEventHandler).toHaveBeenCalledWith('click', BUTTON_CLICK_EVENTS.left);
+            expect(onClick).toHaveBeenCalledTimes(1);
             expect(fixture.detectChanges).toHaveBeenCalledTimes(2);
             expect(fixture.whenStable).toHaveBeenCalledTimes(1);
         });
@@ -99,6 +78,7 @@ describe('click-helper', () => {
         it('... should return early when target element is disabled', async () => {
             const disabledButton = document.createElement('button');
             disabledButton.disabled = true;
+
             const fixture = {
                 detectChanges: vi.fn(),
                 whenStable: vi.fn().mockResolvedValue(undefined),
@@ -114,6 +94,7 @@ describe('click-helper', () => {
             const button = document.createElement('button');
             const onClick = vi.fn();
             button.addEventListener('click', onClick);
+
             const fixture = {
                 detectChanges: vi.fn(),
                 whenStable: vi.fn().mockResolvedValue(undefined),
@@ -130,6 +111,7 @@ describe('click-helper', () => {
             const button = document.createElement('button');
             const onClick = vi.fn();
             button.addEventListener('click', onClick);
+
             const debugElement = {
                 nativeElement: button,
             } as unknown as DebugElement;

--- a/src/testing/click-helper.ts
+++ b/src/testing/click-helper.ts
@@ -9,7 +9,7 @@ import { ComponentFixture } from '@angular/core/testing';
  *
  * Exposed to be called from tests.
  *
- * @param {DebugElement } clickDe The DebugElement to be clicked on.
+ * @param {DebugElement | HTMLElement } clickTarget The DebugElement or HTMLElement to click on.
  * @param {ComponentFixture<any>} fixture The component fixture on which the changes are applied.
  *
  * @returns {Promise<void>} Triggers the click event and applies the changes to the component fixture.

--- a/src/testing/click-helper.ts
+++ b/src/testing/click-helper.ts
@@ -2,38 +2,6 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 
 /**
- * Test helper object constant: BUTTON_CLICK_EVENTS.
- *
- * It provides button click events to be passed to
- * `DebugElement.triggerEventHandler` for RouterLink event handler.
- */
-export const BUTTON_CLICK_EVENTS = {
-    left: { button: 0 },
-    right: { button: 2 },
-};
-
-/**
- * Test helper function: click.
- *
- * It simulates the click on an element.
- * Defaults to mouse left-button click event.
- *
- * Exposed to be called from tests.
- *
- * @param {DebugElement | HTMLElement} el The element to be clicked on.
- * @param {any} eventObj The click event object. Defaults to mouse left-button click event.
- *
- * @returns {void} Triggers the event handler.
- */
-export function click(el: DebugElement | HTMLElement, eventObj: any = BUTTON_CLICK_EVENTS.left): void {
-    if (el instanceof HTMLElement) {
-        el.click();
-    } else {
-        el.triggerEventHandler('click', eventObj);
-    }
-}
-
-/**
  * Test helper function: clickAndAwaitChanges.
  *
  * It simulates the click on an element
@@ -46,14 +14,17 @@ export function click(el: DebugElement | HTMLElement, eventObj: any = BUTTON_CLI
  *
  * @returns {Promise<void>} Triggers the click event and applies the changes to the component fixture.
  */
-export async function clickAndAwaitChanges(clickDe: DebugElement, fixture: ComponentFixture<any>): Promise<void> {
-    // Do nothing if element is disabled
-    if (clickDe.nativeElement.disabled) {
+export async function clickAndAwaitChanges(
+    clickTarget: DebugElement | HTMLElement,
+    fixture: ComponentFixture<any>
+): Promise<void> {
+    const targetEl = clickTarget && 'nativeElement' in clickTarget ? clickTarget.nativeElement : clickTarget;
+
+    if ((targetEl as HTMLButtonElement)?.disabled) {
         return;
     }
 
-    // Trigger click with click helper
-    click(clickDe);
+    targetEl.click();
 
     fixture.detectChanges();
     await fixture.whenStable();
@@ -79,7 +50,7 @@ export async function clickDispatchAndAwaitChanges(
     const targetEl = clickTarget instanceof Element ? clickTarget : (clickTarget.nativeElement as Element);
 
     // Do nothing if the target is disabled (for native form controls).
-    if ((targetEl as HTMLButtonElement).disabled) {
+    if ((targetEl as HTMLButtonElement)?.disabled) {
         return;
     }
 

--- a/src/testing/expect-helper.ts
+++ b/src/testing/expect-helper.ts
@@ -153,6 +153,23 @@ export function expectToContain<T>(actual: T extends Function ? never : T, expec
 }
 
 /**
+ * Test helper function: expectToNotContain.
+ *
+ * It checks if a given actual value is defined and if it does not contain the expected value ('not.toContain').
+ *
+ * Exposed to be called from tests.
+ *
+ * @param {T} actual The input value to be checked (Array, String, etc. - cannot be a function).
+ * @param {any} expected The expected value that should not be contained.
+ *
+ * @returns {void} Throws the expectation statements.
+ */
+export function expectToNotContain<T>(actual: T extends Function ? never : T, expected: any): void {
+    expect(actual).toBeDefined();
+    expect(actual, `should not contain ${expected}`).not.toContain(expected);
+}
+
+/**
  * Test helper function: expectToEqual.
  *
  * It checks if a given actual value is defined and if it equals the expected value ('toEqual').

--- a/src/testing/interceptor-helper.spec.ts
+++ b/src/testing/interceptor-helper.spec.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 
 import { describe, expect, it } from 'vitest';
 
-import { expectToBe, expectToEqual } from './expect-helper';
+import { expectToBe } from './expect-helper';
 
 import { getInterceptorInstance } from './interceptor-helper';
 
@@ -28,7 +28,7 @@ describe('interceptorHelper: getInterceptorInstance', () => {
         const found = getInterceptorInstance(interceptors, SecondInterceptor);
 
         expect(found).toBeDefined();
-        expectToEqual(found, secondInterceptor);
+        expectToBe(found, secondInterceptor);
     });
 
     it('... should return null if no interceptor matches the requested type (else path)', () => {

--- a/src/testing/interceptor-helper.spec.ts
+++ b/src/testing/interceptor-helper.spec.ts
@@ -3,6 +3,8 @@ import { Observable } from 'rxjs';
 
 import { describe, expect, it } from 'vitest';
 
+import { expectToBe, expectToEqual } from './expect-helper';
+
 import { getInterceptorInstance } from './interceptor-helper';
 
 class FirstInterceptor implements HttpInterceptor {
@@ -26,7 +28,7 @@ describe('interceptorHelper: getInterceptorInstance', () => {
         const found = getInterceptorInstance(interceptors, SecondInterceptor);
 
         expect(found).toBeDefined();
-        expect(found).toBe(secondInterceptor);
+        expectToEqual(found, secondInterceptor);
     });
 
     it('... should return null if no interceptor matches the requested type (else path)', () => {
@@ -35,12 +37,12 @@ describe('interceptorHelper: getInterceptorInstance', () => {
 
         const found = getInterceptorInstance(interceptors, SecondInterceptor);
 
-        expect(found).toBeNull();
+        expectToBe(found, null);
     });
 
     it('... should return null for an empty interceptor list', () => {
         const found = getInterceptorInstance([], SecondInterceptor);
 
-        expect(found).toBeNull();
+        expectToBe(found, null);
     });
 });


### PR DESCRIPTION
This PR unifies the usage of some expect and click helpers for the tests. This improves maintainability and consistency throughout the test files.