### PR TITLE
style(app): improve contrast to meet WCAG-AA standard

### DIFF
--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.html
@@ -10,7 +10,9 @@
                             class="nav-link awg-edition-intro-nav-link pt-0"
                             [routerLink]="'.'"
                             [fragment]="introBlock.blockId"
-                            [innerHTML]="introBlock.blockHeader"></a>
+                            [innerHTML]="introBlock.blockHeader"
+                            ><span class="visually-hidden">{{ introBlock.blockHeader }}</span></a
+                        >
                     </li>
                 }
             }

--- a/src/assets/themes/scss/main.scss
+++ b/src/assets/themes/scss/main.scss
@@ -52,6 +52,16 @@ a.awg-svg-sheet-facet-link.active,
 .navbar-nav > li > a:active:not(#dropdownNavEdition) {
     color: $link-color !important;
 }
+.dropdown-item.active,
+.dropdown-item:active {
+    background-color: $link-color !important;
+    color: #ffffff !important;
+}
+.dropdown-item:hover,
+.dropdown-item:focus {
+    background-color: #f1f3f3 !important;
+    color: $link-color !important;
+}
 /* no border color for svg-sheet-facet-link */
 a.awg-svg-sheet-facet-link.active,
 a.awg-svg-sheet-facet-link:active,

--- a/src/assets/themes/scss/shared.scss
+++ b/src/assets/themes/scss/shared.scss
@@ -1,5 +1,5 @@
 // Default variable overrides
-$info: #149b9e;
+$info: #0f777a;
 $link-color: $info;
 
 $form-check-input-checked-color: $info;


### PR DESCRIPTION
This PR improves accessibility by darkening the main info link color which improves color contrast to meet WCAG-AA standard. (Bringing it up to AAA would need a much darker color which then has much less contrast against the main text color.)