### PR TITLE
refactor(edition): handle edition views from ViewService

### DIFF
--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
@@ -167,7 +167,6 @@ describe('IntroComponent (DONE)', () => {
 
     let editionOutlineServiceGetEditionSeriesByIdSpy: Spy;
     let editionOutlineServiceGetEditionSectionByIdSpy: Spy;
-    let editionStateServiceUpdateIsIntroViewSpy: Spy;
 
     let listenToRouteChangesSpy: Spy;
     let navigateWithComplexIdSpy: Spy;
@@ -251,7 +250,6 @@ describe('IntroComponent (DONE)', () => {
         // Service spies
         editionOutlineServiceGetEditionSeriesByIdSpy = vi.spyOn(editionOutlineService, 'getEditionSeriesById');
         editionOutlineServiceGetEditionSectionByIdSpy = vi.spyOn(editionOutlineService, 'getEditionSectionById');
-        editionStateServiceUpdateIsIntroViewSpy = vi.spyOn(editionStateService, 'updateIsIntroView');
 
         // Test data
         expectedEditionIntroSectionData = structuredClone(mockEditionData.mockIntroSectionData);
@@ -415,21 +413,6 @@ describe('IntroComponent (DONE)', () => {
 
         it('... should have signal `viewData` to hold the expected view data', () => {
             expectToEqual(component.viewData(), createMockViewData(expectedViewDataContent));
-        });
-
-        it('... should have called `EditionStateService` and updated `isIntroView` to true', () => {
-            expectSpyCall(editionStateServiceUpdateIsIntroViewSpy, 1, true);
-
-            expectToBe(editionStateService.isIntroView(), true);
-        });
-
-        it('... should reset `isIntroView` to false on destroy', () => {
-            expectSpyCall(editionStateServiceUpdateIsIntroViewSpy, 1, true);
-
-            fixture.destroy();
-
-            expectSpyCall(editionStateServiceUpdateIsIntroViewSpy, 2, false);
-            expectToBe(editionStateService.isIntroView(), false);
         });
 
         it('... should have called `listenToRouteChanges()`', () => {
@@ -2263,15 +2246,6 @@ describe('IntroComponent (DONE)', () => {
 
                     expectToEqual(editionStateService.selectedEditionSeries(), null);
                     expectToEqual(editionStateService.selectedEditionSection(), null);
-                });
-
-                it('... should trigger and update `isIntroView = true` in EditionStateService', () => {
-                    const seriesNumber = '1';
-                    const sectionNumber = '5';
-
-                    (component as any)._updateEditionState(seriesNumber, sectionNumber);
-
-                    expectToBe(editionStateService.isIntroView(), true);
                 });
             });
         });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { NavigationEnd, NavigationExtras, Router } from '@angular/router';
 
 import { fromEvent, Subject } from 'rxjs';
@@ -101,17 +101,10 @@ export class EditionIntroComponent implements OnDestroy, OnInit {
     /**
      * Constructor of the EditionIntroComponent.
      *
-     * It updates the edition state to indicate if the intro view is active,
-     * and initializes the scroll listener for the window.
+     * It initializes the scroll listener for the window.
      */
     constructor() {
-        this._editionStateService.updateIsIntroView(true);
-
         this._initScrollListener();
-
-        inject(DestroyRef).onDestroy(() => {
-            this._editionStateService.updateIsIntroView(false);
-        });
     }
 
     /**

--- a/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.spec.ts
@@ -18,7 +18,7 @@ import { mockEditionData } from '@testing/mock-data';
 import { CompileHtmlComponent } from '@awg-shared/compile-html';
 import { EditionViewData, EditionViewDataContent } from '@awg-views/edition-view/models/edition-data.model';
 import { PrefaceList } from '@awg-views/edition-view/models/preface.model';
-import { EditionGlyphService, EditionStateService } from '@awg-views/edition-view/services';
+import { EditionGlyphService } from '@awg-views/edition-view/services';
 import { EditionViewService } from '@awg-views/edition-view/services/edition-view.service';
 
 import { EditionPrefaceComponent } from './edition-preface.component';
@@ -59,12 +59,10 @@ describe('EditionPrefaceComponent (DONE)', () => {
     let compDe: DebugElement;
 
     let mockEditionGlyphService: Partial<EditionGlyphService>;
-    let editionStateService: EditionStateService;
 
     let getGlyphSpy: Spy;
     let setLanguageSpy: Spy;
     let editionGlyphServiceGetGlyphSpy: Spy;
-    let editionStateServiceUpdateIsPrefaceViewSpy: Spy;
 
     let mockViewDataSignal: WritableSignal<EditionViewData<'preface'>>;
     let expectedViewDataContent: EditionViewDataContent<'preface'>;
@@ -97,12 +95,8 @@ describe('EditionPrefaceComponent (DONE)', () => {
     });
 
     beforeEach(() => {
-        // Inject services
-        editionStateService = TestBed.inject(EditionStateService);
-
         // Service spies
         editionGlyphServiceGetGlyphSpy = vi.spyOn(mockEditionGlyphService, 'getGlyph');
-        editionStateServiceUpdateIsPrefaceViewSpy = vi.spyOn(editionStateService, 'updateIsPrefaceView');
 
         // Test data
         expectedCurrentLanguage = 0;
@@ -143,21 +137,6 @@ describe('EditionPrefaceComponent (DONE)', () => {
 
         it('... should not have called EditionGlyphService', () => {
             expectSpyCall(editionGlyphServiceGetGlyphSpy, 0);
-        });
-
-        it('... should have called `EditionStateService` and updated `isPrefaceView` to true', () => {
-            expectSpyCall(editionStateServiceUpdateIsPrefaceViewSpy, 1, true);
-
-            expectToBe(editionStateService.isPrefaceView(), true);
-        });
-
-        it('... should reset `isPrefaceView` to false on destroy', () => {
-            expectSpyCall(editionStateServiceUpdateIsPrefaceViewSpy, 1, true);
-
-            fixture.destroy();
-
-            expectSpyCall(editionStateServiceUpdateIsPrefaceViewSpy, 2, false);
-            expectToBe(editionStateService.isPrefaceView(), false);
         });
 
         describe('VIEW', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
-import { EditionGlyphService, EditionStateService } from '@awg-views/edition-view/services';
+import { EditionGlyphService } from '@awg-views/edition-view/services';
 import { EditionViewService } from '@awg-views/edition-view/services/edition-view.service';
 
 /**
@@ -25,13 +25,6 @@ export class EditionPrefaceComponent {
     private readonly _editionGlyphService = inject(EditionGlyphService);
 
     /**
-     * Private readonly injection variable: _editionStateService.
-     *
-     * It keeps the instance of the injected EditionStateService.
-     */
-    private readonly _editionStateService = inject(EditionStateService);
-
-    /**
      * Public variable: currentLanguage.
      *
      * It keeps the current language of the edition preface: 0 for German, 1 for English.
@@ -53,17 +46,11 @@ export class EditionPrefaceComponent {
     /**
      * Constructor of the EditionPrefaceComponent.
      *
-     * It updates the edition state to indicate if the preface view is active
-     * and declares the self-referring ref variable needed for CompileHtml library.
+     * It declares the self-referring ref variable needed for CompileHtml library.
      *
      */
     constructor() {
-        this._editionStateService.updateIsPrefaceView(true);
         this.ref = this;
-
-        inject(DestroyRef).onDestroy(() => {
-            this._editionStateService.updateIsPrefaceView(false);
-        });
     }
 
     /**

--- a/src/app/views/edition-view/edition-outlets/edition-rowtables/edition-rowtables.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-rowtables/edition-rowtables.component.spec.ts
@@ -1,14 +1,12 @@
 import { Component, DebugElement, Input, isSignal, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-type Spy = ReturnType<typeof vi.spyOn>;
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import { createMockViewData } from '@testing/edition-data-helper';
 import {
-    expectSpyCall,
     expectToBe,
     expectToContain,
     expectToEqual,
@@ -21,7 +19,6 @@ import { RouterLinkStubDirective } from '@testing/router-stubs';
 
 import { RowtablesList } from '@awg-views/edition-view/models';
 import { EditionViewData, EditionViewDataContent } from '@awg-views/edition-view/models/edition-data.model';
-import { EditionStateService } from '@awg-views/edition-view/services/edition-state.service';
 import { EditionViewService } from '@awg-views/edition-view/services/edition-view.service';
 
 import { EditionRowtablesComponent } from './edition-rowtables.component';
@@ -48,10 +45,6 @@ describe('EditionRowTablesComponent (DONE)', () => {
     let component: EditionRowtablesComponent;
     let fixture: ComponentFixture<EditionRowtablesComponent>;
     let compDe: DebugElement;
-
-    let editionStateService: EditionStateService;
-
-    let editionStateServiceUpdateIsRowtablesViewSpy: Spy;
 
     let mockViewDataSignal: WritableSignal<EditionViewData<'rowtables'>>;
     let expectedViewDataContent: EditionViewDataContent<'rowtables'>;
@@ -80,12 +73,6 @@ describe('EditionRowTablesComponent (DONE)', () => {
     });
 
     beforeEach(() => {
-        // Inject services
-        editionStateService = TestBed.inject(EditionStateService);
-
-        // Spies
-        editionStateServiceUpdateIsRowtablesViewSpy = vi.spyOn(editionStateService, 'updateIsRowtablesView');
-
         // Test data
         expectedRowtablesData = structuredClone(mockEditionData.mockRowtablesData);
 
@@ -93,10 +80,6 @@ describe('EditionRowTablesComponent (DONE)', () => {
         fixture = TestBed.createComponent(EditionRowtablesComponent);
         component = fixture.componentInstance;
         compDe = fixture.debugElement;
-    });
-
-    afterEach(() => {
-        vi.restoreAllMocks();
     });
 
     it('... should create', () => {
@@ -108,21 +91,6 @@ describe('EditionRowTablesComponent (DONE)', () => {
             expectToBe(isSignal(component.viewData), true);
 
             expectToEqual(component.viewData(), createMockViewData(expectedDefaultViewDataContent));
-        });
-
-        it('... should have called `EditionStateService` and updated `isRowTableView` to true', () => {
-            expectSpyCall(editionStateServiceUpdateIsRowtablesViewSpy, 1, true);
-
-            expectToBe(editionStateService.isRowtablesView(), true);
-        });
-
-        it('... should reset `isRowtablesView` to false on destroy', () => {
-            expectSpyCall(editionStateServiceUpdateIsRowtablesViewSpy, 1, true);
-
-            fixture.destroy();
-
-            expectSpyCall(editionStateServiceUpdateIsRowtablesViewSpy, 2, false);
-            expectToBe(editionStateService.isRowtablesView(), false);
         });
 
         describe('VIEW', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-rowtables/edition-rowtables.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-rowtables/edition-rowtables.component.ts
@@ -1,6 +1,5 @@
-import { Component, DestroyRef, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
-import { EditionStateService } from '@awg-views/edition-view/services/edition-state.service';
 import { EditionViewService } from '@awg-views/edition-view/services/edition-view.service';
 
 /**
@@ -17,29 +16,9 @@ import { EditionViewService } from '@awg-views/edition-view/services/edition-vie
 })
 export class EditionRowtablesComponent {
     /**
-     * Private readonly injection variable: _editionStateService.
-     *
-     * It keeps the instance of the injected EditionStateService.
-     */
-    private readonly _editionStateService = inject(EditionStateService);
-
-    /**
      * Readonly signal: viewData.
      *
      * It holds the state of the rowtables view data from the EditionViewService.
      */
     readonly viewData = inject(EditionViewService).rowtablesViewData;
-
-    /**
-     * Constructor of the EditionRowtablesComponent.
-     *
-     * It updates the edition state to indicate if the rowtables view is active.
-     */
-    constructor() {
-        this._editionStateService.updateIsRowtablesView(true);
-
-        inject(DestroyRef).onDestroy(() => {
-            this._editionStateService.updateIsRowtablesView(false);
-        });
-    }
 }

--- a/src/app/views/edition-view/edition-view.component.html
+++ b/src/app/views/edition-view/edition-view.component.html
@@ -2,14 +2,12 @@
 <div class="awg-edition-view p-3 border rounded-3">
     <awg-scroll-to-top-button />
 
-    @let introView = isIntroView();
-    @let prefaceView = isPrefaceView();
-    @let rowtablesView = isRowtablesView();
+    @let activeView = viewContext();
     @let editionComplex = selectedEditionComplex();
     @let editionSection = selectedEditionSection();
     @let editionSeries = selectedEditionSeries();
 
-    @if (prefaceView) {
+    @if (activeView.isPreface) {
         <div class="awg-edition-preface para">
             <h6 class="awg-edition-info-breadcrumb">
                 <a [routerLink]="[editionRouteConstants.SERIES.route]">
@@ -25,7 +23,7 @@
         </div>
     }
 
-    @if (rowtablesView) {
+    @if (activeView.isRowtables) {
         <div class="awg-edition-rowtables para">
             <h6 class="awg-edition-info-breadcrumb">
                 <a [routerLink]="[editionRouteConstants.SERIES.route]">
@@ -89,7 +87,7 @@
         </div>
     }
 
-    @if (editionComplex === null && rowtablesView !== true && prefaceView !== true) {
+    @if (editionComplex === null && activeView.isRowtables !== true && activeView.isPreface !== true) {
         <div class="awg-edition-series para">
             <h6 class="awg-edition-info-breadcrumb">
                 <ng-template #breadCrumbEdition>
@@ -114,7 +112,7 @@
                             <ng-container *ngTemplateOutlet="breadCrumbSeries" />
                         </a>
                         /
-                        @if (introView) {
+                        @if (activeView.isIntro) {
                             <a
                                 [routerLink]="[
                                     './series',
@@ -143,7 +141,7 @@
             <!-- Jumbotron -->
             <awg-edition-jumbotron
                 [jumbotronId]="EDITION_VIEW_ID"
-                [jumbotronTitle]="introView ? editionRouteConstants.EDITION_INTRO.full : EDITION_VIEW_TITLE" />
+                [jumbotronTitle]="activeView.isIntro ? editionRouteConstants.EDITION_INTRO.full : EDITION_VIEW_TITLE" />
         </div>
     }
 

--- a/src/app/views/edition-view/edition-view.component.spec.ts
+++ b/src/app/views/edition-view/edition-view.component.spec.ts
@@ -1,6 +1,6 @@
 import { DatePipe, registerLocaleData } from '@angular/common';
 import localeDeDE from '@angular/common/locales/de';
-import { Component, DebugElement, DOCUMENT, Input, isSignal, LOCALE_ID } from '@angular/core';
+import { Component, DebugElement, DOCUMENT, Input, isSignal, LOCALE_ID, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -17,7 +17,9 @@ import { MetaIdentifiers } from '@awg-shared/meta/meta.model';
 
 import { EDITION_ROUTE_CONSTANTS } from './edition-routes.constants';
 import { EditionComplex, EditionOutlineSection, EditionOutlineSeries } from './models';
+import { EditionViewContext } from './models/edition-data.model';
 import { EditionComplexesService, EditionOutlineService, EditionStateService } from './services';
+import { EditionViewService } from './services/edition-view.service';
 
 import { EditionViewComponent } from './edition-view.component';
 
@@ -63,6 +65,9 @@ describe('EditionViewComponent (DONE)', () => {
     let editionOutlineService: EditionOutlineService;
     let editionStateService: EditionStateService;
 
+    let mockViewContextSignal: WritableSignal<EditionViewContext>;
+
+    let expectedDefaultViewContext: EditionViewContext;
     let expectedSelectedEditionComplexId: string;
     let expectedSelectedEditionComplex: EditionComplex;
     let expectedSelectedEditionSeries: EditionOutlineSeries;
@@ -73,6 +78,10 @@ describe('EditionViewComponent (DONE)', () => {
     const expectedEditionRouteConstants: typeof EDITION_ROUTE_CONSTANTS = EDITION_ROUTE_CONSTANTS;
 
     beforeEach(async () => {
+        // Mock services
+        expectedDefaultViewContext = { name: 'other-name', isIntro: false, isPreface: false, isRowtables: false };
+        mockViewContextSignal = signal(expectedDefaultViewContext);
+
         await TestBed.configureTestingModule({
             declarations: [
                 EditionViewComponent,
@@ -82,7 +91,10 @@ describe('EditionViewComponent (DONE)', () => {
                 RouterLinkStubDirective,
             ],
             imports: [DatePipe, ScrollToTopButtonStubComponent],
-            providers: [{ provide: LOCALE_ID, useValue: 'de-DE' }],
+            providers: [
+                { provide: LOCALE_ID, useValue: 'de-DE' },
+                { provide: EditionViewService, useValue: { viewContext: mockViewContextSignal.asReadonly() } },
+            ],
         }).compileComponents();
     });
 
@@ -129,28 +141,16 @@ describe('EditionViewComponent (DONE)', () => {
             expectToEqual(component.editionRouteConstants, expectedEditionRouteConstants);
         });
 
-        it('... should have signal `isIntroView` to hold false', () => {
-            expectToBe(isSignal(component.isIntroView), true);
+        it('... should have signal `viewContext` to hold the default view context', () => {
+            expectToBe(isSignal(component.viewContext), true);
 
-            expectToBe(component.isIntroView(), false);
+            expectToEqual(component.viewContext(), expectedDefaultViewContext);
         });
 
-        it('... should have signal `isPrefaceView` to hold false', () => {
-            expectToBe(isSignal(component.isPrefaceView), true);
+        it('... should have signal `selectedEditionSeries` to hold null', () => {
+            expectToBe(isSignal(component.selectedEditionSeries), true);
 
-            expectToBe(component.isPrefaceView(), false);
-        });
-
-        it('... should have signal `isRowtablesView` to hold false', () => {
-            expectToBe(isSignal(component.isRowtablesView), true);
-
-            expectToBe(component.isRowtablesView(), false);
-        });
-
-        it('... should have signal `selectedEditionComplex` to hold null', () => {
-            expectToBe(isSignal(component.selectedEditionComplex), true);
-
-            expectToBe(component.selectedEditionComplex(), null);
+            expectToBe(component.selectedEditionSeries(), null);
         });
 
         it('... should have signal `selectedEditionSection` to hold null', () => {
@@ -159,10 +159,10 @@ describe('EditionViewComponent (DONE)', () => {
             expectToBe(component.selectedEditionSection(), null);
         });
 
-        it('... should have signal `selectedEditionSeries` to hold null', () => {
-            expectToBe(isSignal(component.selectedEditionSeries), true);
+        it('... should have signal `selectedEditionComplex` to hold null', () => {
+            expectToBe(isSignal(component.selectedEditionComplex), true);
 
-            expectToBe(component.selectedEditionSeries(), null);
+            expectToBe(component.selectedEditionComplex(), null);
         });
 
         describe('VIEW', () => {
@@ -218,14 +218,19 @@ describe('EditionViewComponent (DONE)', () => {
 
             describe('... if isPrefaceView is true', () => {
                 beforeEach(() => {
-                    editionStateService.updateIsPrefaceView(true);
+                    mockViewContextSignal.set({ name: 'preface', isIntro: false, isPreface: true, isRowtables: false });
 
                     // Trigger data binding
                     fixture.detectChanges();
                 });
 
-                it('... should have signal `isPrefaceView` to hold true', () => {
-                    expectToBe(component.isPrefaceView(), true);
+                it('... should have signal `viewContext` to hold true for preface view', () => {
+                    expectToEqual(component.viewContext(), {
+                        name: 'preface',
+                        isIntro: false,
+                        isPreface: true,
+                        isRowtables: false,
+                    });
                 });
 
                 it('... should have one `div.awg-edition-preface` in `div.awg-edition-view`', () => {
@@ -270,14 +275,24 @@ describe('EditionViewComponent (DONE)', () => {
 
             describe('... if isRowtablesView is true', () => {
                 beforeEach(() => {
-                    editionStateService.updateIsRowtablesView(true);
+                    mockViewContextSignal.set({
+                        name: 'rowtables',
+                        isIntro: false,
+                        isPreface: false,
+                        isRowtables: true,
+                    });
 
                     // Trigger data binding
                     fixture.detectChanges();
                 });
 
-                it('... should have signal `isRowtablesView` to hold true', () => {
-                    expectToBe(component.isRowtablesView(), true);
+                it('... should have signal `viewContext` to hold true for rowtables view', () => {
+                    expectToEqual(component.viewContext(), {
+                        name: 'rowtables',
+                        isIntro: false,
+                        isPreface: false,
+                        isRowtables: true,
+                    });
                 });
 
                 it('... should have one `div.awg-edition-rowtables` in `div.awg-edition-view`', () => {
@@ -484,11 +499,8 @@ describe('EditionViewComponent (DONE)', () => {
 
             describe('... if selectedEditionComplex, isPrefaceView and isRowtablesView are not given', () => {
                 beforeEach(() => {
+                    mockViewContextSignal.set(expectedDefaultViewContext);
                     editionStateService.updateSelectedEditionComplex(null);
-                    editionStateService.updateIsPrefaceView(false);
-                    editionStateService.updateIsRowtablesView(false);
-
-                    editionStateService.updateIsIntroView(false);
                     editionStateService.updateSelectedEditionSeries(null);
                     editionStateService.updateSelectedEditionSection(null);
 
@@ -496,10 +508,7 @@ describe('EditionViewComponent (DONE)', () => {
                 });
 
                 it('... should have signals to hold expected values', () => {
-                    expectToBe(component.isIntroView(), false);
-                    expectToBe(component.isPrefaceView(), false);
-                    expectToBe(component.isRowtablesView(), false);
-
+                    expectToEqual(component.viewContext(), expectedDefaultViewContext);
                     expectToBe(component.selectedEditionComplex(), null);
                     expectToBe(component.selectedEditionSeries(), null);
                     expectToBe(component.selectedEditionSection(), null);
@@ -543,7 +552,7 @@ describe('EditionViewComponent (DONE)', () => {
                 });
 
                 it('... should pass down full edition intro const as title to JumbotronComponent (stubbed) if `isIntroView=true`', () => {
-                    editionStateService.updateIsIntroView(true);
+                    mockViewContextSignal.set({ name: 'intro', isIntro: true, isPreface: false, isRowtables: false });
 
                     // Trigger data binding
                     fixture.detectChanges();
@@ -706,7 +715,12 @@ describe('EditionViewComponent (DONE)', () => {
                         beforeEach(() => {
                             editionStateService.updateSelectedEditionSeries(expectedSelectedEditionSeries);
                             editionStateService.updateSelectedEditionSection(expectedSelectedEditionSection);
-                            editionStateService.updateIsIntroView(true);
+                            mockViewContextSignal.set({
+                                name: 'intro',
+                                isIntro: true,
+                                isPreface: false,
+                                isRowtables: false,
+                            });
 
                             fixture.detectChanges();
                         });

--- a/src/app/views/edition-view/edition-view.component.ts
+++ b/src/app/views/edition-view/edition-view.component.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { EDITION_ROUTE_CONSTANTS } from '@awg-views/edition-view/edition-routes.constants';
-import { EditionStateService } from '@awg-views/edition-view/services';
+import { EditionStateService } from '@awg-views/edition-view/services/edition-state.service';
+import { EditionViewService } from '@awg-views/edition-view/services/edition-view.service';
 
 /**
  * The EditionView component.
@@ -40,25 +41,11 @@ export class EditionViewComponent {
     readonly EDITION_VIEW_TITLE = 'Editionsübersicht';
 
     /**
-     * Readonly signal: isIntroView.
+     * Readonly signal: viewContext.
      *
-     * It holds the state of the intro view.
+     * It holds the state of the view context.
      */
-    readonly isIntroView = this._editionStateService.isIntroView;
-
-    /**
-     * Readonly signal: isPrefaceView.
-     *
-     * It holds the state of the preface view.
-     */
-    readonly isPrefaceView = this._editionStateService.isPrefaceView;
-
-    /**
-     * Readonly signal: isRowtablesView.
-     *
-     * It holds the state of the rowtables view.
-     */
-    readonly isRowtablesView = this._editionStateService.isRowtablesView;
+    readonly viewContext = inject(EditionViewService).viewContext;
 
     /**
      * Readonly signal: selectedEditionComplex.

--- a/src/app/views/edition-view/models/edition-data.model.ts
+++ b/src/app/views/edition-view/models/edition-data.model.ts
@@ -114,7 +114,7 @@ export interface EditionViewData<K extends EditionViewKey> {
     data: EditionViewDataContent<K>;
 
     /**
-     * Indicates whether the data is loading.
+     * A flag indicating whether the data is loading.
      */
     isLoading: boolean;
 
@@ -122,4 +122,31 @@ export interface EditionViewData<K extends EditionViewKey> {
      * An optional error object if there was an error loading the data.
      */
     error: EditionDataAssetsError | null;
+}
+
+/**
+ * The EditionViewContext type.
+ *
+ * It defines the structure of the context for the edition view.
+ */
+export interface EditionViewContext {
+    /**
+     * The name of the current edition view.
+     */
+    name: EditionViewKey | string;
+
+    /**
+     * A flag indicating whether the current view is the intro view.
+     */
+    isIntro: boolean;
+
+    /**
+     * A flag indicating whether the current view is the preface view.
+     */
+    isPreface: boolean;
+
+    /**
+     * A flag indicating whether the current view is the rowtables view.
+     */
+    isRowtables: boolean;
 }

--- a/src/app/views/edition-view/services/edition-state.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-state.service.spec.ts
@@ -44,24 +44,6 @@ describe('EditionStateService (DONE)', () => {
         expect(editionStateService).toBeTruthy();
     });
 
-    it('... should have signal `_isIntroViewSignal`', () => {
-        expectToBe(isSignal(editionStateService['_isIntroViewSignal']), true);
-
-        expectToBe(editionStateService['_isIntroViewSignal'](), false);
-    });
-
-    it('... should have signal `_isPrefaceViewSignal`', () => {
-        expectToBe(isSignal(editionStateService['_isPrefaceViewSignal']), true);
-
-        expectToBe(editionStateService['_isPrefaceViewSignal'](), false);
-    });
-
-    it('... should have signal `_isRowtablesViewSignal`', () => {
-        expectToBe(isSignal(editionStateService['_isRowtablesViewSignal']), true);
-
-        expectToBe(editionStateService['_isRowtablesViewSignal'](), false);
-    });
-
     it('... should have signal `_selectedEditionComplexSignal`', () => {
         expectToBe(isSignal(editionStateService['_selectedEditionComplexSignal']), true);
 
@@ -77,24 +59,6 @@ describe('EditionStateService (DONE)', () => {
     it('... should have signal `_selectedEditionSectionSignal`', () => {
         expectToBe(isSignal(editionStateService['_selectedEditionSectionSignal']), true);
         expectToBe(editionStateService['_selectedEditionSectionSignal'](), null);
-    });
-
-    it('... should have signal `isIntroView`', () => {
-        expectToBe(isSignal(editionStateService.isIntroView), true);
-
-        expectToBe(editionStateService.isIntroView(), false);
-    });
-
-    it('... should have signal `isPrefaceView`', () => {
-        expectToBe(isSignal(editionStateService.isPrefaceView), true);
-
-        expectToBe(editionStateService.isPrefaceView(), false);
-    });
-
-    it('... should have signal `isRowtablesView`', () => {
-        expectToBe(isSignal(editionStateService.isRowtablesView), true);
-
-        expectToBe(editionStateService.isRowtablesView(), false);
     });
 
     it('... should have signal `selectedEditionComplex`', () => {
@@ -116,84 +80,6 @@ describe('EditionStateService (DONE)', () => {
     });
 
     describe('METHODS', () => {
-        describe('#updateIsIntroView()', () => {
-            it('... should have a method `updateIsIntroView`', () => {
-                expect(editionStateService.updateIsIntroView).toBeDefined();
-            });
-
-            it('... should update isIntroView to hold true', () => {
-                editionStateService.updateIsIntroView(true);
-
-                expectToBe(editionStateService.isIntroView(), true);
-            });
-
-            it('... should update isIntroView to hold false', () => {
-                editionStateService.updateIsIntroView(false);
-
-                expectToBe(editionStateService.isIntroView(), false);
-            });
-
-            it('... should not change value when updating with the same boolean', () => {
-                editionStateService.updateIsIntroView(true);
-                expectToBe(editionStateService.isIntroView(), true);
-
-                editionStateService.updateIsIntroView(true);
-                expectToBe(editionStateService.isIntroView(), true);
-            });
-        });
-
-        describe('#updateIsPrefaceView()', () => {
-            it('... should have a method `updateIsPrefaceView`', () => {
-                expect(editionStateService.updateIsPrefaceView).toBeDefined();
-            });
-
-            it('... should update isPrefaceView to hold true', () => {
-                editionStateService.updateIsPrefaceView(true);
-
-                expectToBe(editionStateService.isPrefaceView(), true);
-            });
-
-            it('... should update isPrefaceView to hold false', () => {
-                editionStateService.updateIsPrefaceView(false);
-
-                expectToBe(editionStateService.isPrefaceView(), false);
-            });
-
-            it('... should not change value when updating with the same boolean', () => {
-                editionStateService.updateIsPrefaceView(true);
-                expectToBe(editionStateService.isPrefaceView(), true);
-
-                editionStateService.updateIsPrefaceView(true);
-                expectToBe(editionStateService.isPrefaceView(), true);
-            });
-        });
-
-        describe('#updateIsRowtablesView()', () => {
-            it('... should have a method `updateIsRowtablesView`', () => {
-                expect(editionStateService.updateIsRowtablesView).toBeDefined();
-            });
-
-            it('... should update isRowtablesView to hold true', () => {
-                editionStateService.updateIsRowtablesView(true);
-
-                expectToBe(editionStateService.isRowtablesView(), true);
-            });
-
-            it('... should update isRowtablesView to hold false', () => {
-                editionStateService.updateIsRowtablesView(false);
-
-                expectToBe(editionStateService.isRowtablesView(), false);
-            });
-
-            it('... should not change value when updating with the same boolean', () => {
-                editionStateService.updateIsRowtablesView(true);
-                expectToBe(editionStateService.isRowtablesView(), true);
-
-                editionStateService.updateIsRowtablesView(true);
-                expectToBe(editionStateService.isRowtablesView(), true);
-            });
-        });
-
         describe('#updateSelectedEditionComplex()', () => {
             it('... should have a method `updateSelectedEditionComplex`', () => {
                 expect(editionStateService.updateSelectedEditionComplex).toBeDefined();

--- a/src/app/views/edition-view/services/edition-state.service.ts
+++ b/src/app/views/edition-view/services/edition-state.service.ts
@@ -13,21 +13,6 @@ import { EditionComplex, EditionOutlineSection, EditionOutlineSeries } from '@aw
 })
 export class EditionStateService {
     /**
-     * Private readonly signal holding the intro view state.
-     */
-    private readonly _isIntroViewSignal = signal<boolean>(false);
-
-    /**
-     * Private readonly signal holding the preface view state.
-     */
-    private readonly _isPrefaceViewSignal = signal<boolean>(false);
-
-    /**
-     * Private readonly signal holding the rowtables view state.
-     */
-    private readonly _isRowtablesViewSignal = signal<boolean>(false);
-
-    /**
      * Private readonly signal holding the selected edition complex.
      */
     private readonly _selectedEditionComplexSignal = signal<EditionComplex | null>(null);
@@ -41,27 +26,6 @@ export class EditionStateService {
      * Private readonly signal holding the selected edition series.
      */
     private readonly _selectedEditionSeriesSignal = signal<EditionOutlineSeries | null>(null);
-
-    /**
-     * Readonly signal: isIntroView.
-     *
-     * It holds the state of the intro view.
-     */
-    readonly isIntroView = this._isIntroViewSignal.asReadonly();
-
-    /**
-     * Readonly signal: isPrefaceView.
-     *
-     * It holds the state of the preface view.
-     */
-    readonly isPrefaceView = this._isPrefaceViewSignal.asReadonly();
-
-    /**
-     * Readonly signal: isRowtablesView.
-     *
-     * It holds the state of the rowtables view.
-     */
-    readonly isRowtablesView = this._isRowtablesViewSignal.asReadonly();
 
     /**
      * Readonly signal: selectedEditionComplex.
@@ -83,42 +47,6 @@ export class EditionStateService {
      * It holds the state of the selected edition series.
      */
     readonly selectedEditionSeries = this._selectedEditionSeriesSignal.asReadonly();
-
-    /**
-     * Public method: updateIsIntroView.
-     *
-     * It updates the isIntroView signal with the given boolean value.
-     *
-     * @param {boolean} isView The given isIntroView flag.
-     * @returns {void} Sets the next state to the isIntroView signal.
-     */
-    updateIsIntroView(isView: boolean): void {
-        this._isIntroViewSignal.set(isView);
-    }
-
-    /**
-     * Public method: updateIsPrefaceView.
-     *
-     * It updates the isPrefaceView signal with the given boolean value.
-     *
-     * @param {boolean} isView The given isPrefaceView flag.
-     * @returns {void} Sets the next state to the isPrefaceView signal.
-     */
-    updateIsPrefaceView(isView: boolean): void {
-        this._isPrefaceViewSignal.set(isView);
-    }
-
-    /**
-     * Public method: updateIsRowtablesView.
-     *
-     * It updates the isRowtablesView signal with the given boolean value.
-     *
-     * @param {boolean} isView The given isRowtablesView flag.
-     * @returns {void} Sets the next state to the isRowtablesView signal.
-     */
-    updateIsRowtablesView(isView: boolean): void {
-        this._isRowtablesViewSignal.set(isView);
-    }
 
     /**
      * Public method: updateSelectedEditionComplex.

--- a/src/app/views/edition-view/services/edition-view.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-view.service.spec.ts
@@ -1,11 +1,10 @@
 import { isSignal, signal, WritableSignal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { NavigationEnd, Router, Event as RouterEvent } from '@angular/router';
+import { provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.spyOn>;
-
-import { Subject } from 'rxjs';
 
 import { expectSpyCall, expectToBe, expectToEqual } from '@testing/expect-helper';
 
@@ -22,7 +21,7 @@ describe('EditionViewService', () => {
 
     let mockEditionDataService: Partial<EditionDataService>;
 
-    let activeViewSpy: Spy;
+    let currentViewNameSpy: Spy;
     let buildViewDataSpy: Spy;
     let getErrorSpy: Spy;
     let getFallbackForInactiveViewSpy: Spy;
@@ -53,7 +52,7 @@ describe('EditionViewService', () => {
                 EditionViewService,
                 { provide: EditionDataService, useValue: mockEditionDataService },
                 { provide: LoadingService, useValue: { isLoading: mockIsLoadingSignal.asReadonly() } },
-                Router,
+                provideRouter([]),
             ],
         });
 
@@ -61,7 +60,7 @@ describe('EditionViewService', () => {
         service = TestBed.inject(EditionViewService);
 
         // Spies
-        activeViewSpy = vi.spyOn(service, 'activeView');
+        currentViewNameSpy = vi.spyOn(service as any, '_currentViewName');
         buildViewDataSpy = vi.spyOn(service as any, '_buildViewData');
         getFallbackForInactiveViewSpy = vi.spyOn(service as any, '_getFallbackForInactiveView');
         getUniqueAssetKeysSpy = vi.spyOn(service as any, '_getUniqueAssetKeys');
@@ -77,68 +76,115 @@ describe('EditionViewService', () => {
         expect(service).toBeTruthy();
     });
 
-    describe('#activeView()', () => {
-        let router: Router;
-        let routerEventsSubject: Subject<RouterEvent>;
+    describe('#_currentViewName()', () => {
+        let harness: RouterTestingHarness;
 
-        beforeEach(() => {
-            router = TestBed.inject(Router);
-            routerEventsSubject = new Subject<RouterEvent>();
-
-            vi.spyOn(router, 'events', 'get').mockReturnValue(routerEventsSubject as any);
-        });
-
-        const createFreshServiceWithUrl = (url: string): EditionViewService => {
+        const createFreshServiceWithUrl = async (url: string): Promise<EditionViewService> => {
             // Reset the testing module to ensure a fresh instance of the service for the router
             TestBed.resetTestingModule();
 
             TestBed.configureTestingModule({
                 providers: [
+                    provideRouter([
+                        { path: '**', children: [] },
+                        { path: '**', outlet: 'sidebar', children: [] },
+                    ]),
                     EditionViewService,
-                    { provide: Router, useValue: router },
-                    { provide: LoadingService, useValue: { isLoading: mockIsLoadingSignal.asReadonly() } },
                     { provide: EditionDataService, useValue: mockEditionDataService },
+                    { provide: LoadingService, useValue: { isLoading: mockIsLoadingSignal.asReadonly() } },
                 ],
             });
 
-            vi.spyOn(router, 'url', 'get').mockReturnValue(url);
+            // Set up the RouterTestingHarness to navigate to the desired URL
+            harness = await RouterTestingHarness.create();
+            await harness.navigateByUrl(url);
 
-            // Freshly inject the service after configuring the spies
+            // Freshly inject the service after configuring the route
             return TestBed.inject(EditionViewService);
         };
 
-        it('... should have a signal `activeView`', () => {
-            expect(service.activeView).toBeDefined();
+        it('... should have a signal `_currentViewName`', () => {
+            expect((service as any)._currentViewName).toBeDefined();
 
-            expectToBe(isSignal(service.activeView), true);
+            expectToBe(isSignal((service as any)._currentViewName), true);
         });
 
-        it('... should start with holding the parsed view name based on the current router URL', () => {
-            const freshService = createFreshServiceWithUrl('/edition/preface');
+        it('... should start with holding the parsed view name based on the current router URL', async () => {
+            const freshService = await createFreshServiceWithUrl('/edition/preface');
 
-            const result = freshService.activeView();
+            const result = (freshService as any)._currentViewName();
 
             expectToBe(result, 'preface');
         });
 
-        it('... should hold the parsed active view when a NavigationEnd event occurs', () => {
-            const freshService = createFreshServiceWithUrl('/edition/preface');
+        it('... should hold the parsed active view when a NavigationEnd event occurs', async () => {
+            const freshService = await createFreshServiceWithUrl('/edition/preface');
 
-            expectToBe(freshService.activeView(), 'preface');
+            expectToBe((freshService as any)._currentViewName(), 'preface');
 
-            routerEventsSubject.next(
-                new NavigationEnd(1, '/edition/complex/op12/sheets', '/edition/complex/op12/sheets')
-            );
+            await harness.navigateByUrl('/edition/complex/op12/sheets');
 
-            expectToBe(freshService.activeView(), 'sheets');
+            expectToBe((freshService as any)._currentViewName(), 'sheets');
         });
 
-        it('... should return an empty string if the navigation destination has no primary segments', () => {
-            createFreshServiceWithUrl('/edition/preface');
+        it('... should return an empty string if the navigation destination has no primary segments', async () => {
+            await createFreshServiceWithUrl('/edition/preface');
 
-            routerEventsSubject.next(new NavigationEnd(2, '/(sidebar:help)', '/(sidebar:help)'));
+            await harness.navigateByUrl('/(sidebar:help)');
 
-            expectToBe(service.activeView(), '');
+            expectToBe((service as any)._currentViewName(), '');
+        });
+    });
+
+    describe('#viewContext()', () => {
+        it('... should have a signal `viewContext`', () => {
+            expect(service.viewContext).toBeDefined();
+
+            expectToBe(isSignal(service.viewContext), true);
+        });
+
+        it('... should return correct context for `intro`', () => {
+            currentViewNameSpy.mockReturnValue('intro');
+
+            const context = service.viewContext();
+
+            expectToBe(context.name, 'intro');
+            expectToBe(context.isIntro, true);
+            expectToBe(context.isPreface, false);
+            expectToBe(context.isRowtables, false);
+        });
+
+        it('... should return correct context for `preface`', () => {
+            currentViewNameSpy.mockReturnValue('preface');
+
+            const context = service.viewContext();
+
+            expectToBe(context.name, 'preface');
+            expectToBe(context.isIntro, false);
+            expectToBe(context.isPreface, true);
+            expectToBe(context.isRowtables, false);
+        });
+
+        it('... should return correct context for `rowtables`', () => {
+            currentViewNameSpy.mockReturnValue('rowtables');
+
+            const context = service.viewContext();
+
+            expectToBe(context.name, 'rowtables');
+            expectToBe(context.isIntro, false);
+            expectToBe(context.isPreface, false);
+            expectToBe(context.isRowtables, true);
+        });
+
+        it('... should handle other view names gracefully', () => {
+            currentViewNameSpy.mockReturnValue('other-view');
+
+            const context = service.viewContext();
+
+            expectToBe(context.name, 'other-view');
+            expectToBe(context.isIntro, false);
+            expectToBe(context.isPreface, false);
+            expectToBe(context.isRowtables, false);
         });
     });
 
@@ -191,7 +237,7 @@ describe('EditionViewService', () => {
             });
 
             it(`... should return loading fallback for ${signalName} if view is inactive`, () => {
-                activeViewSpy.mockReturnValue('any-other-view');
+                currentViewNameSpy.mockReturnValue('any-other-view');
 
                 const result = service[signalName]();
 
@@ -201,8 +247,8 @@ describe('EditionViewService', () => {
             });
 
             it(`... should reactively update ${signalName} if ${dataKey} emits`, () => {
-                activeViewSpy.mockReturnValue(viewName);
-                (service as any)._lastActiveView.set(viewName);
+                currentViewNameSpy.mockReturnValue(viewName);
+                (service as any)._previousViewName.set(viewName);
                 mockIsLoadingSignal.set(false);
 
                 (mockEditionDataService as any)[dataKey].set(mockData);
@@ -215,8 +261,8 @@ describe('EditionViewService', () => {
             });
 
             it(`... should set \`isLoading=true\` on ${signalName} if loading is active`, () => {
-                activeViewSpy.mockReturnValue(viewName);
-                (service as any)._lastActiveView.set(viewName);
+                currentViewNameSpy.mockReturnValue(viewName);
+                (service as any)._previousViewName.set(viewName);
 
                 (mockEditionDataService as any)[dataKey].set(mockData);
                 mockIsLoadingSignal.set(true);
@@ -227,8 +273,8 @@ describe('EditionViewService', () => {
             });
 
             it(`... should propagate errors to ${signalName} from the EditionDataService`, () => {
-                activeViewSpy.mockReturnValue(viewName);
-                (service as any)._lastActiveView.set(viewName);
+                currentViewNameSpy.mockReturnValue(viewName);
+                (service as any)._previousViewName.set(viewName);
                 mockIsLoadingSignal.set(false);
 
                 (mockEditionDataService as any)[dataKey].set(mockData);
@@ -301,7 +347,7 @@ describe('EditionViewService', () => {
             });
 
             it(`... should return loading fallback for ${signalName} if view is inactive`, () => {
-                activeViewSpy.mockReturnValue('any-other-view');
+                currentViewNameSpy.mockReturnValue('any-other-view');
 
                 const result = service[signalName]();
 
@@ -313,8 +359,8 @@ describe('EditionViewService', () => {
             });
 
             it(`... should reactively update ${signalName} if all source signals emit`, () => {
-                activeViewSpy.mockReturnValue(viewName);
-                (service as any)._lastActiveView.set(viewName);
+                currentViewNameSpy.mockReturnValue(viewName);
+                (service as any)._previousViewName.set(viewName);
                 mockIsLoadingSignal.set(false);
 
                 signalsSetup.forEach(({ dataKey, mockValue }) => {
@@ -331,8 +377,8 @@ describe('EditionViewService', () => {
             });
 
             it(`... should set \`isLoading=true\` on ${signalName} if loading is active`, () => {
-                activeViewSpy.mockReturnValue(viewName);
-                (service as any)._lastActiveView.set(viewName);
+                currentViewNameSpy.mockReturnValue(viewName);
+                (service as any)._previousViewName.set(viewName);
 
                 signalsSetup.forEach(({ dataKey, mockValue }) => {
                     (mockEditionDataService as any)[dataKey].set(mockValue);
@@ -345,8 +391,8 @@ describe('EditionViewService', () => {
             });
 
             it(`... should propagate errors to ${signalName} from the EditionDataService`, () => {
-                activeViewSpy.mockReturnValue(viewName);
-                (service as any)._lastActiveView.set(viewName);
+                currentViewNameSpy.mockReturnValue(viewName);
+                (service as any)._previousViewName.set(viewName);
                 mockIsLoadingSignal.set(false);
 
                 signalsSetup.forEach(({ dataKey, mockValue }) => {
@@ -364,8 +410,8 @@ describe('EditionViewService', () => {
             if (signalName === 'sheetsViewData') {
                 describe('... `extraContentCheck` specific to sheetsViewData', () => {
                     it('... should keep `isLoading=true` if all edition arrays (work, text, sketch) are empty', () => {
-                        activeViewSpy.mockReturnValue(viewName);
-                        (service as any)._lastActiveView.set(viewName);
+                        currentViewNameSpy.mockReturnValue(viewName);
+                        (service as any)._previousViewName.set(viewName);
                         mockIsLoadingSignal.set(false);
 
                         (mockEditionDataService as any)['folioConvoluteData'].set({ convolutes: [{ id: 'fol-1' }] });
@@ -380,8 +426,8 @@ describe('EditionViewService', () => {
                     });
 
                     it('... should set `isLoading=false` if at least one edition array (e.g., sketchEditions) contains data', () => {
-                        activeViewSpy.mockReturnValue(viewName);
-                        (service as any)._lastActiveView.set(viewName);
+                        currentViewNameSpy.mockReturnValue(viewName);
+                        (service as any)._previousViewName.set(viewName);
                         mockIsLoadingSignal.set(false);
 
                         (mockEditionDataService as any)['folioConvoluteData'].set({ convolutes: [{ id: 'fol-1' }] });
@@ -747,7 +793,7 @@ describe('EditionViewService', () => {
                 const dataKeys = ['folioConvoluteData'];
                 const mockFallback = { data: {}, isLoading: true, error: null };
 
-                activeViewSpy.mockReturnValue('preface');
+                currentViewNameSpy.mockReturnValue('preface');
                 const createFallbackSpy = vi.spyOn(service as any, '_createFallback').mockReturnValue(mockFallback);
 
                 const result = (service as any)._getFallbackForInactiveView(viewKey, dataKeys);
@@ -756,36 +802,36 @@ describe('EditionViewService', () => {
                 expectSpyCall(createFallbackSpy, 1, [dataKeys]);
             });
 
-            it('... should return a fallback and update `_lastActiveView` asynchronously if the view is active but changed', () => {
+            it('... should return a fallback and update `_previousViewName` asynchronously if the view is active but changed', () => {
                 vi.useFakeTimers();
 
                 const viewKey = 'sheets';
                 const dataKeys = ['folioConvoluteData'];
                 const mockFallback = { data: {}, isLoading: true, error: null };
 
-                activeViewSpy.mockReturnValue('sheets');
-                (service as any)._lastActiveView.set('preface');
+                currentViewNameSpy.mockReturnValue('sheets');
+                (service as any)._previousViewName.set('preface');
 
                 vi.spyOn(service as any, '_createFallback').mockReturnValue(mockFallback);
 
                 const result = (service as any)._getFallbackForInactiveView(viewKey, dataKeys);
 
                 expectToEqual(result, mockFallback);
-                expectToBe((service as any)._lastActiveView(), 'preface');
+                expectToBe((service as any)._previousViewName(), 'preface');
 
                 vi.advanceTimersByTime(0);
 
-                expectToBe((service as any)._lastActiveView(), 'sheets');
+                expectToBe((service as any)._previousViewName(), 'sheets');
 
                 vi.useRealTimers();
             });
 
-            it('... should return null if the view is active and matches the `_lastActiveView` (steady state)', () => {
+            it('... should return null if the view is active and matches the `_previousViewName` (steady state)', () => {
                 const viewKey = 'sheets';
                 const dataKeys = ['folioConvoluteData'];
 
-                activeViewSpy.mockReturnValue('sheets');
-                (service as any)._lastActiveView.set('sheets');
+                currentViewNameSpy.mockReturnValue('sheets');
+                (service as any)._previousViewName.set('sheets');
 
                 const result = (service as any)._getFallbackForInactiveView(viewKey, dataKeys);
 

--- a/src/app/views/edition-view/services/edition-view.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-view.service.spec.ts
@@ -128,11 +128,11 @@ describe('EditionViewService', () => {
         });
 
         it('... should return an empty string if the navigation destination has no primary segments', async () => {
-            await createFreshServiceWithUrl('/edition/preface');
+            const freshService = await createFreshServiceWithUrl('/edition/preface');
 
             await harness.navigateByUrl('/(sidebar:help)');
 
-            expectToBe((service as any)._currentViewName(), '');
+            expectToBe((freshService as any)._currentViewName(), '');
         });
     });
 

--- a/src/app/views/edition-view/services/edition-view.service.ts
+++ b/src/app/views/edition-view/services/edition-view.service.ts
@@ -67,7 +67,7 @@ export class EditionViewService {
         merge(
             this._router.events.pipe(
                 filter(event => event instanceof NavigationEnd),
-                map((event: NavigationEnd) => event.url)
+                map((event: NavigationEnd) => event.urlAfterRedirects)
             ),
             this._route.url.pipe(map(() => this._router.url))
         ).pipe(

--- a/src/app/views/edition-view/services/edition-view.service.ts
+++ b/src/app/views/edition-view/services/edition-view.service.ts
@@ -1,8 +1,8 @@
 import { computed, inject, Injectable, Signal, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { NavigationEnd, Router } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 
-import { filter, map, startWith } from 'rxjs';
+import { distinctUntilChanged, filter, map, merge, startWith } from 'rxjs';
 
 import { LoadingService } from '@awg-shared/loading/loading.service';
 import {
@@ -45,23 +45,53 @@ export class EditionViewService {
     private readonly _router = inject(Router);
 
     /**
-     * Private readonly signal holding the last active view state.
+     * Private readonly injection variable: _route.
+     *
+     * It keeps the instance of the injected ActivatedRoute.
      */
-    private readonly _lastActiveView = signal<string>('');
+    private readonly _route = inject(ActivatedRoute);
 
     /**
-     * Readonly signal: activeView.
-     *
-     * It holds the state of the currently active view.
+     * Private readonly signal holding the last active view state.
      */
-    readonly activeView = toSignal(
-        this._router.events.pipe(
-            filter(event => event instanceof NavigationEnd),
-            map((event: NavigationEnd) => this._parseViewFromUrl(event.urlAfterRedirects)),
+    private readonly _previousViewName = signal<string>('');
+
+    /**
+     * Readonly signal: _currentViewName.
+     *
+     * It holds the name of the currently active view parsed from the current URL.
+     * It is updated on every NavigationEnd event of the Angular Router.
+     * It is also updated on every URL change of the ActivatedRoute.
+     */
+    private readonly _currentViewName = toSignal(
+        merge(
+            this._router.events.pipe(
+                filter(event => event instanceof NavigationEnd),
+                map((event: NavigationEnd) => event.url)
+            ),
+            this._route.url.pipe(map(() => this._router.url))
+        ).pipe(
+            map(url => this._parseViewFromUrl(url)),
+            distinctUntilChanged(),
             startWith(this._parseViewFromUrl(this._router.url))
         ),
         { requireSync: true }
     );
+
+    /**
+     * Readonly signal: viewContext.
+     *
+     * It holds the state of the currently active view.
+     */
+    readonly viewContext = computed(() => {
+        const viewName = this._currentViewName();
+        return {
+            name: viewName,
+            isIntro: viewName === 'intro',
+            isPreface: viewName === 'preface',
+            isRowtables: viewName === 'rowtables',
+        };
+    });
 
     /**
      * Readonly signal: prefaceViewData.
@@ -232,14 +262,15 @@ export class EditionViewService {
         viewKey: K,
         dataKeys: Array<keyof EditionViewDataTypeMapping[K]>
     ): EditionViewData<K> | null {
-        const activeView = this.activeView();
+        const current = this._currentViewName();
+        const previous = this._previousViewName();
 
-        if (!activeView.includes(viewKey)) {
+        if (!current.includes(viewKey)) {
             return this._createFallback(dataKeys);
         }
 
-        if (this._lastActiveView() !== activeView) {
-            setTimeout(() => this._lastActiveView.set(activeView), 0);
+        if (previous !== current) {
+            setTimeout(() => this._previousViewName.set(current), 0);
             return this._createFallback(dataKeys);
         }
 
@@ -261,10 +292,10 @@ export class EditionViewService {
         const nullData = Object.fromEntries(nullEntries);
 
         return {
-            data: nullData as any,
+            data: nullData,
             isLoading: true,
             error: null,
-        };
+        } as EditionViewData<K>;
     }
 
     /**
@@ -283,6 +314,6 @@ export class EditionViewService {
             return '';
         }
 
-        return segments[segments.length - 1].path;
+        return segments.at(-1).path;
     }
 }


### PR DESCRIPTION
This PR refactors the handling of the edition views, moving it from the components to the EditionViewService.