### PR TITLE
refactor(edition): move breadcrumb into separate component

### DIFF
--- a/src/app/views/edition-view/edition-bread-crumb/edition-bread-crumb.component.html
+++ b/src/app/views/edition-view/edition-bread-crumb/edition-bread-crumb.component.html
@@ -1,0 +1,15 @@
+<h6 class="awg-edition-info-breadcrumb">
+    @for (item of items(); track $index; let last = $last) {
+        @if (item.label) {
+            @if (item.route && item.route.length > 0) {
+                <a [routerLink]="item.route">{{ item.label }}</a>
+            } @else {
+                <span [innerHTML]="item.label"></span>
+            }
+        }
+
+        @if (!last) {
+            <span class="mx-1">/</span>
+        }
+    }
+</h6>

--- a/src/app/views/edition-view/edition-bread-crumb/edition-bread-crumb.component.spec.ts
+++ b/src/app/views/edition-view/edition-bread-crumb/edition-bread-crumb.component.spec.ts
@@ -4,6 +4,7 @@ import { provideRouter, Router, RouterLink } from '@angular/router';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import {
     expectToBe,
     expectToEqual,
@@ -16,10 +17,9 @@ import { EDITION_ROUTE_CONSTANTS } from '../edition-routes.constants';
 import { EditionComplex, EditionOutlineSection, EditionOutlineSeries, EditionRouteConstant } from '../models';
 import { EditionComplexesService, EditionOutlineService } from '../services';
 
-import { clickAndAwaitChanges } from '@testing/click-helper';
 import { EditionBreadcrumbComponent } from './edition-bread-crumb.component';
 
-describe('EditionBreadCrumbComponent', () => {
+describe('EditionBreadcrumbComponent', () => {
     let component: EditionBreadcrumbComponent;
     let fixture: ComponentFixture<EditionBreadcrumbComponent>;
     let compDe: DebugElement;
@@ -157,9 +157,9 @@ describe('EditionBreadCrumbComponent', () => {
                         const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
                         const hEl: HTMLHeadingElement = hDes[0].nativeElement;
 
-                        const expectedBreadCrumb = `${EDITION.short}/${PREFACE.short}`;
+                        const expectedBreadcrumb = `${EDITION.short}/${PREFACE.short}`;
 
-                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                        expectToBe(hEl.textContent?.trim(), expectedBreadcrumb);
                     });
 
                     it('... should have one router link (to series overview)', () => {
@@ -194,9 +194,9 @@ describe('EditionBreadCrumbComponent', () => {
                         const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
                         const hEl: HTMLHeadingElement = hDes[0].nativeElement;
 
-                        const expectedBreadCrumb = `${EDITION.short}/${ROWTABLES.full}`;
+                        const expectedBreadcrumb = `${EDITION.short}/${ROWTABLES.full}`;
 
-                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                        expectToBe(hEl.textContent?.trim(), expectedBreadcrumb);
                     });
 
                     it('... should have one router link (back to series overview)', () => {
@@ -231,9 +231,9 @@ describe('EditionBreadCrumbComponent', () => {
                         const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
                         const hEl: HTMLHeadingElement = hDes[0].nativeElement;
 
-                        const expectedBreadCrumb = `${EDITION.short}/`;
+                        const expectedBreadcrumb = `${EDITION.short}/`;
 
-                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                        expectToBe(hEl.textContent?.trim(), expectedBreadcrumb);
                     });
 
                     it('... should have no router link, but only span', () => {
@@ -257,9 +257,9 @@ describe('EditionBreadCrumbComponent', () => {
                         const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
                         const hEl: HTMLHeadingElement = hDes[0].nativeElement;
 
-                        const expectedBreadCrumb = `${EDITION.short}/${expectedSeries.series.full}/`;
+                        const expectedBreadcrumb = `${EDITION.short}/${expectedSeries.series.full}/`;
 
-                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                        expectToBe(hEl.textContent?.trim(), expectedBreadcrumb);
                     });
 
                     it('... should have one router link (to edition series overview)', () => {
@@ -298,9 +298,9 @@ describe('EditionBreadCrumbComponent', () => {
                         const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
                         const hEl: HTMLHeadingElement = hDes[0].nativeElement;
 
-                        const expectedBreadCrumb = `${EDITION.short}/${expectedSeries.series.full}/${expectedSection.section.full}/`;
+                        const expectedBreadcrumb = `${EDITION.short}/${expectedSeries.series.full}/${expectedSection.section.full}/`;
 
-                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                        expectToBe(hEl.textContent?.trim(), expectedBreadcrumb);
                     });
 
                     it('... should have two router links (to series overview and current edition series)', () => {
@@ -341,9 +341,9 @@ describe('EditionBreadCrumbComponent', () => {
                         const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
                         const hEl: HTMLHeadingElement = hDes[0].nativeElement;
 
-                        const expectedBreadCrumb = `${EDITION.short}/${expectedSeries.series.full}/${expectedSection.section.full}/${EDITION_INTRO.full}`;
+                        const expectedBreadcrumb = `${EDITION.short}/${expectedSeries.series.full}/${expectedSection.section.full}/${EDITION_INTRO.full}`;
 
-                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                        expectToBe(hEl.textContent?.trim(), expectedBreadcrumb);
                     });
 
                     it('... should have three router links (to series overview, current edition series and section overview)', async () => {
@@ -401,9 +401,9 @@ describe('EditionBreadCrumbComponent', () => {
                         const hEl: HTMLHeadingElement = hDes[0].nativeElement;
 
                         const complexShortWithSpace = expectedComplex.complexId.short.replace(/&nbsp;/g, '\u00A0');
-                        const expectedBreadCrumb = `${EDITION.short}/${series.full}/${section.full}/${complexShortWithSpace}`;
+                        const expectedBreadcrumb = `${EDITION.short}/${series.full}/${section.full}/${complexShortWithSpace}`;
 
-                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                        expectToBe(hEl.textContent?.trim(), expectedBreadcrumb);
                     });
 
                     it('... should have three router links (to series overview, current series, and current section)', () => {

--- a/src/app/views/edition-view/edition-bread-crumb/edition-bread-crumb.component.spec.ts
+++ b/src/app/views/edition-view/edition-bread-crumb/edition-bread-crumb.component.spec.ts
@@ -1,0 +1,508 @@
+import { DebugElement, isSignal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, Router, RouterLink } from '@angular/router';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    expectToBe,
+    expectToEqual,
+    getAndExpectDebugElementByCss,
+    getAndExpectDebugElementByDirective,
+} from '@testing/expect-helper';
+
+import { LabeledRoute } from '@awg-shared/models/labeled-route.model';
+import { EDITION_ROUTE_CONSTANTS } from '../edition-routes.constants';
+import { EditionComplex, EditionOutlineSection, EditionOutlineSeries, EditionRouteConstant } from '../models';
+import { EditionComplexesService, EditionOutlineService } from '../services';
+
+import { clickAndAwaitChanges } from '@testing/click-helper';
+import { EditionBreadcrumbComponent } from './edition-bread-crumb.component';
+
+describe('EditionBreadCrumbComponent', () => {
+    let component: EditionBreadcrumbComponent;
+    let fixture: ComponentFixture<EditionBreadcrumbComponent>;
+    let compDe: DebugElement;
+
+    let router: Router;
+
+    let editionComplexesService: EditionComplexesService;
+    let editionOutlineService: EditionOutlineService;
+
+    let expectedSelectedEditionComplexId: string;
+    let expectedComplex: EditionComplex;
+    let expectedSeries: EditionOutlineSeries;
+    let expectedSection: EditionOutlineSection;
+
+    const { EDITION, SERIES, EDITION_INTRO, PREFACE, ROWTABLES } = EDITION_ROUTE_CONSTANTS;
+    const expectedRootItem: LabeledRoute = {
+        label: EDITION.short,
+        route: [EDITION.route, SERIES.route],
+    };
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [EditionBreadcrumbComponent],
+            providers: [provideRouter([])],
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        // Inject services
+        router = TestBed.inject(Router);
+
+        // Init edition data
+        editionComplexesService = TestBed.inject(EditionComplexesService);
+        editionOutlineService = TestBed.inject(EditionOutlineService);
+        editionComplexesService.initializeEditionComplexesList();
+        editionOutlineService.initializeEditionOutline();
+
+        // Test data
+        expectedSelectedEditionComplexId = 'op12';
+        expectedComplex = editionComplexesService.getEditionComplexById(expectedSelectedEditionComplexId);
+        expectedSeries = editionOutlineService.editionOutline()[0]; // Series 1
+        expectedSection = expectedSeries.sections[4]; // Section 5
+
+        // Create component fixture
+        fixture = TestBed.createComponent(EditionBreadcrumbComponent);
+        component = fixture.componentInstance;
+        compDe = fixture.debugElement;
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    describe('BEFORE initial data binding', () => {
+        it('... should throw due to missing required input signal `items`', () => {
+            expectToBe(isSignal(component.items), true);
+
+            expect(() => component.items()).toThrow();
+        });
+
+        describe('VIEW', () => {
+            it('... should have a breadcrumb header', () => {
+                getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+            });
+
+            it('... should have no anchor or span in breadcrumb header yet', () => {
+                const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+
+                getAndExpectDebugElementByCss(hDes[0], 'h6.awg-edition-info-breadcrumb a', 0, 0);
+                getAndExpectDebugElementByCss(hDes[0], 'h6.awg-edition-info-breadcrumb span', 0, 0);
+            });
+        });
+    });
+
+    describe('AFTER initial data binding', () => {
+        beforeEach(() => {
+            // Set the initial values for the signal inputs
+            fixture.componentRef.setInput('items', [expectedRootItem]);
+
+            // Trigger initial data binding
+            fixture.detectChanges();
+        });
+
+        it('... should have input signal `items` to hold the provided data', () => {
+            expectToEqual(component.items(), [expectedRootItem]);
+        });
+
+        describe('VIEW', () => {
+            it('... should render an anchor tag for items with a valid route', () => {
+                const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                const anchorDes = getAndExpectDebugElementByCss(hDes[0], 'a', 1, 1);
+                const anchorEl: HTMLAnchorElement = anchorDes[0].nativeElement;
+
+                expect(anchorEl).toBeTruthy();
+                expectToBe(anchorEl.textContent.trim(), expectedRootItem.label);
+
+                getAndExpectDebugElementByCss(hDes[0], 'span:not(.mx-1)', 0, 0);
+            });
+
+            it('... should render a span with innerHTML for items without a route', () => {
+                fixture.componentRef.setInput('items', [{ label: 'op. 27', route: [] }]);
+
+                fixture.detectChanges();
+
+                const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                getAndExpectDebugElementByCss(hDes[0], 'a', 0, 0);
+
+                const spanDes = getAndExpectDebugElementByCss(hDes[0], 'span:not(.mx-1)', 1, 1);
+                const spanEl: HTMLSpanElement = spanDes[0].nativeElement;
+
+                expect(spanEl).toBeTruthy();
+                expectToBe(spanEl.innerHTML, 'op. 27');
+            });
+
+            it('... should manage separators correctly between items and omit the last one', () => {
+                fixture.componentRef.setInput('items', [
+                    expectedRootItem,
+                    { label: 'Serie I', route: [] },
+                    { label: '', route: [] },
+                ]);
+
+                fixture.detectChanges();
+
+                getAndExpectDebugElementByCss(compDe, '.mx-1', 2, 2);
+            });
+
+            describe('... with specific input items', () => {
+                describe('... if preface view is given', () => {
+                    beforeEach(() => {
+                        fixture.componentRef.setInput('items', [expectedRootItem, { label: PREFACE.short, route: [] }]);
+                        fixture.detectChanges();
+                    });
+
+                    it('... should display edition root and preface heading (without final slash)', () => {
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        const hEl: HTMLHeadingElement = hDes[0].nativeElement;
+
+                        const expectedBreadCrumb = `${EDITION.short}/${PREFACE.short}`;
+
+                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                    });
+
+                    it('... should have one router link (to series overview)', () => {
+                        const expectedLinkLength = 1;
+
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        getAndExpectDebugElementByCss(hDes[0], 'a', expectedLinkLength, expectedLinkLength);
+
+                        const linkDes = getAndExpectDebugElementByDirective(
+                            hDes[0],
+                            RouterLink,
+                            expectedLinkLength,
+                            expectedLinkLength
+                        );
+                        const routerLinks = linkDes.map(de => de.injector.get(RouterLink));
+
+                        expectToBe(routerLinks.length, expectedLinkLength);
+                        expectToEqual(routerLinks[0].urlTree.toString(), expectedRootItem.route.join('/'));
+                    });
+                });
+
+                describe('... if rowtables view is given', () => {
+                    beforeEach(() => {
+                        fixture.componentRef.setInput('items', [
+                            expectedRootItem,
+                            { label: ROWTABLES.full, route: [] },
+                        ]);
+                        fixture.detectChanges();
+                    });
+
+                    it('... should display edition root and rowtables heading (without final slash)', () => {
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        const hEl: HTMLHeadingElement = hDes[0].nativeElement;
+
+                        const expectedBreadCrumb = `${EDITION.short}/${ROWTABLES.full}`;
+
+                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                    });
+
+                    it('... should have one router link (back to series overview)', () => {
+                        const expectedLinkLength = 1;
+
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        getAndExpectDebugElementByCss(hDes[0], 'a', expectedLinkLength, expectedLinkLength);
+
+                        const linkDes = getAndExpectDebugElementByDirective(
+                            hDes[0],
+                            RouterLink,
+                            expectedLinkLength,
+                            expectedLinkLength
+                        );
+                        const routerLinks = linkDes.map(de => de.injector.get(RouterLink));
+
+                        expectToBe(routerLinks.length, expectedLinkLength);
+                        expectToEqual(routerLinks[0].urlTree.toString(), expectedRootItem.route.join('/'));
+                    });
+                });
+
+                describe('... if no series and section is given (root)', () => {
+                    beforeEach(() => {
+                        fixture.componentRef.setInput('items', [
+                            { ...expectedRootItem, route: [] },
+                            { label: '', route: [] },
+                        ]);
+                        fixture.detectChanges();
+                    });
+
+                    it('... should display edition root (with final slash)', () => {
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        const hEl: HTMLHeadingElement = hDes[0].nativeElement;
+
+                        const expectedBreadCrumb = `${EDITION.short}/`;
+
+                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                    });
+
+                    it('... should have no router link, but only span', () => {
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        getAndExpectDebugElementByCss(hDes[0], 'a', 0, 0);
+                        getAndExpectDebugElementByCss(hDes[0], 'span:not(.mx-1)', 1, 1);
+                    });
+                });
+
+                describe('... if series, but no section is given', () => {
+                    beforeEach(() => {
+                        fixture.componentRef.setInput('items', [
+                            expectedRootItem,
+                            { label: expectedSeries.series.full, route: [] },
+                            { label: '', route: [] },
+                        ]);
+                        fixture.detectChanges();
+                    });
+
+                    it('... should display edition root and series (with final slash)', () => {
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        const hEl: HTMLHeadingElement = hDes[0].nativeElement;
+
+                        const expectedBreadCrumb = `${EDITION.short}/${expectedSeries.series.full}/`;
+
+                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                    });
+
+                    it('... should have one router link (to edition series overview)', () => {
+                        const expectedLinkLength = 1;
+
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        getAndExpectDebugElementByCss(hDes[0], 'a', expectedLinkLength, expectedLinkLength);
+                        const linkDes = getAndExpectDebugElementByDirective(
+                            hDes[0],
+                            RouterLink,
+                            expectedLinkLength,
+                            expectedLinkLength
+                        );
+                        const routerLinks = linkDes.map(de => de.injector.get(RouterLink));
+
+                        expectToBe(routerLinks.length, expectedLinkLength);
+                        expectToEqual(routerLinks[0].urlTree.toString(), expectedRootItem.route.join('/'));
+                    });
+                });
+
+                describe('... if series and section are given', () => {
+                    beforeEach(() => {
+                        fixture.componentRef.setInput('items', [
+                            expectedRootItem,
+                            {
+                                label: expectedSeries.series.full,
+                                route: [...expectedRootItem.route, expectedSeries.series.route],
+                            },
+                            { label: expectedSection.section.full, route: [] },
+                            { label: '', route: [] },
+                        ]);
+                        fixture.detectChanges();
+                    });
+
+                    it('... should display edition root, series and section (with final slash)', () => {
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        const hEl: HTMLHeadingElement = hDes[0].nativeElement;
+
+                        const expectedBreadCrumb = `${EDITION.short}/${expectedSeries.series.full}/${expectedSection.section.full}/`;
+
+                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                    });
+
+                    it('... should have two router links (to series overview and current edition series)', () => {
+                        const expectedLinkLength = 2;
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+
+                        const linkDes = getAndExpectDebugElementByDirective(
+                            hDes[0],
+                            RouterLink,
+                            expectedLinkLength,
+                            expectedLinkLength
+                        );
+                        const routerLinks = linkDes.map(de => de.injector.get(RouterLink));
+
+                        expectToEqual(routerLinks[0].urlTree.toString(), expectedRootItem.route.join('/'));
+                        expectToEqual(
+                            routerLinks[1].urlTree.toString(),
+                            [...expectedRootItem.route, expectedSeries.series.route].join('/')
+                        );
+                    });
+                });
+
+                describe('... if series, section, and intro view is given', () => {
+                    beforeEach(() => {
+                        fixture.componentRef.setInput('items', [
+                            expectedRootItem,
+                            {
+                                label: expectedSeries.series.full,
+                                route: [...expectedRootItem.route, expectedSeries.series.route],
+                            },
+                            { label: expectedSection.section.full, route: expectedSection.labeledRoute.route },
+                            { label: EDITION_INTRO.full, route: [] },
+                        ]);
+                        fixture.detectChanges();
+                    });
+
+                    it('... should display edition series, section and intro heading', () => {
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        const hEl: HTMLHeadingElement = hDes[0].nativeElement;
+
+                        const expectedBreadCrumb = `${EDITION.short}/${expectedSeries.series.full}/${expectedSection.section.full}/${EDITION_INTRO.full}`;
+
+                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                    });
+
+                    it('... should have three router links (to series overview, current edition series and section overview)', async () => {
+                        const expectedLinkLength = 3;
+
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        getAndExpectDebugElementByCss(hDes[0], 'a', expectedLinkLength, expectedLinkLength);
+
+                        const linkDes = getAndExpectDebugElementByDirective(
+                            hDes[0],
+                            RouterLink,
+                            expectedLinkLength,
+                            expectedLinkLength
+                        );
+                        const routerLinks = linkDes.map(de => de.injector.get(RouterLink));
+
+                        expectToBe(routerLinks.length, expectedLinkLength);
+                        expectToEqual(routerLinks[0].urlTree.toString(), expectedRootItem.route.join('/'));
+                        expectToEqual(
+                            routerLinks[1].urlTree.toString(),
+                            [...expectedRootItem.route, expectedSeries.series.route].join('/')
+                        );
+                        expectToEqual(routerLinks[2].urlTree.toString(), expectedSection.labeledRoute.route.join('/'));
+                    });
+                });
+
+                describe('... if an edition complex is given', () => {
+                    let series: EditionRouteConstant;
+                    let section: EditionRouteConstant;
+                    let labeledSectionRoute: LabeledRoute;
+
+                    beforeEach(() => {
+                        ({ series, section, labeledSectionRoute } = expectedComplex.pubStatement);
+
+                        fixture.componentRef.setInput('items', [
+                            expectedRootItem,
+                            {
+                                label: series.full,
+                                route: [...expectedRootItem.route, series.route],
+                            },
+                            {
+                                label: section.full,
+                                route: labeledSectionRoute.route,
+                            },
+                            {
+                                label: expectedComplex.complexId.short,
+                                route: [],
+                            },
+                        ]);
+                        fixture.detectChanges();
+                    });
+
+                    it('... should display edition root, series, section and complex (without final slash)', () => {
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        const hEl: HTMLHeadingElement = hDes[0].nativeElement;
+
+                        const complexShortWithSpace = expectedComplex.complexId.short.replace(/&nbsp;/g, '\u00A0');
+                        const expectedBreadCrumb = `${EDITION.short}/${series.full}/${section.full}/${complexShortWithSpace}`;
+
+                        expectToBe(hEl.textContent?.trim(), expectedBreadCrumb);
+                    });
+
+                    it('... should have three router links (to series overview, current series, and current section)', () => {
+                        const expectedLinkLength = 3;
+
+                        const hDes = getAndExpectDebugElementByCss(compDe, 'h6.awg-edition-info-breadcrumb', 1, 1);
+                        getAndExpectDebugElementByCss(hDes[0], 'a', expectedLinkLength, expectedLinkLength);
+
+                        const linkDes = getAndExpectDebugElementByDirective(
+                            hDes[0],
+                            RouterLink,
+                            expectedLinkLength,
+                            expectedLinkLength
+                        );
+                        const routerLinks = linkDes.map(de => de.injector.get(RouterLink));
+
+                        expectToBe(routerLinks.length, expectedLinkLength);
+                        expectToEqual(routerLinks[0].urlTree.toString(), expectedRootItem.route.join('/'));
+                        expectToEqual(
+                            routerLinks[1].urlTree.toString(),
+                            [...expectedRootItem.route, series.route].join('/')
+                        );
+                        expectToEqual(routerLinks[2].urlTree.toString(), labeledSectionRoute.route.join('/'));
+                    });
+                });
+            });
+        });
+
+        describe('[routerLink]', () => {
+            let linkDes: DebugElement[];
+            let routerLinks: RouterLink[];
+
+            let series: EditionRouteConstant;
+            let section: EditionRouteConstant;
+            let labeledSectionRoute: LabeledRoute;
+
+            beforeEach(() => {
+                ({ series, section, labeledSectionRoute } = expectedComplex.pubStatement);
+
+                fixture.componentRef.setInput('items', [
+                    expectedRootItem,
+                    {
+                        label: series.full,
+                        route: [...expectedRootItem.route, series.route],
+                    },
+                    {
+                        label: section.full,
+                        route: labeledSectionRoute.route,
+                    },
+                    {
+                        label: expectedComplex.complexId.short,
+                        route: [],
+                    },
+                ]);
+                fixture.detectChanges();
+
+                linkDes = getAndExpectDebugElementByDirective(compDe, RouterLink, 3, 3);
+                routerLinks = linkDes.map(de => de.injector.get(RouterLink));
+            });
+
+            it('... can get correct number of routerLinks from template (complex given)', () => {
+                expectToBe(routerLinks.length, 3);
+            });
+
+            it('... can get correct linkParams from template', () => {
+                const urlTree0 = routerLinks[0].urlTree;
+                const urlTree1 = routerLinks[1].urlTree;
+                const urlTree2 = routerLinks[2].urlTree;
+
+                expectToBe(urlTree0.toString(), expectedRootItem.route.join('/'));
+                expectToBe(urlTree1.toString(), [...expectedRootItem.route, series.route].join('/'));
+                expectToBe(urlTree2.toString(), labeledSectionRoute.route.join('/'));
+            });
+
+            const clickTestCases = [
+                { index: 0, name: 'edition root', expectedRouterLink: () => expectedRootItem.route.join('/') },
+                {
+                    index: 1,
+                    name: 'series',
+                    expectedRouterLink: () => [...expectedRootItem.route, series.route].join('/'),
+                },
+                { index: 2, name: 'section', expectedRouterLink: () => labeledSectionRoute.route.join('/') },
+            ];
+
+            it.each(clickTestCases)('... can click $name link in template', async ({ index, expectedRouterLink }) => {
+                const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+                navigateSpy.mockClear();
+
+                const targetLinkDe = linkDes[index];
+
+                await clickAndAwaitChanges(targetLinkDe, fixture);
+
+                expect(navigateSpy).toHaveBeenCalledOnce();
+                const actualUrl = navigateSpy.mock.calls[0][0].toString();
+
+                expectToBe(actualUrl, expectedRouterLink());
+
+                navigateSpy.mockRestore();
+            });
+        });
+    });
+});

--- a/src/app/views/edition-view/edition-bread-crumb/edition-bread-crumb.component.ts
+++ b/src/app/views/edition-view/edition-bread-crumb/edition-bread-crumb.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import { LabeledRoute } from '@awg-shared/models/labeled-route.model';
+
+/**
+ * The EditionBreadcrumbComponent.
+ *
+ * It displays the breadcrumb of the edition view.
+ */
+@Component({
+    selector: 'awg-edition-breadcrumb',
+    templateUrl: './edition-bread-crumb.component.html',
+    styleUrl: './edition-bread-crumb.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [RouterLink],
+})
+export class EditionBreadcrumbComponent {
+    /**
+     * Readonly input signal: items.
+     *
+     * It holds the labeled route items for the breadcrumb.
+     */
+    readonly items = input.required<LabeledRoute[]>();
+}

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail.component.spec.ts
@@ -120,6 +120,12 @@ describe('EditionSectionDetailComponent (DONE)', () => {
         });
 
         describe('#updateSectionFromRoute()', () => {
+            beforeEach(() => {
+                // Reset spy calls
+                editionOutlineServiceGetEditionSectionByIdSpy.mockClear();
+                editionStateServiceUpdateSelectedEditionSectionSpy.mockClear();
+            });
+
             it('... should have a method `updateSectionFromRoute`', () => {
                 expect(component.updateSectionFromRoute).toBeDefined();
             });
@@ -152,8 +158,8 @@ describe('EditionSectionDetailComponent (DONE)', () => {
                 expectSpyCall(editionStateServiceUpdateSelectedEditionSectionSpy, 2, expectedSelectedSection);
             });
 
-            describe('... should update selected section to null if ', () => {
-                it('... `series.series.route` is missing', () => {
+            describe('... should update selected section to null', () => {
+                it('... if `series.series.route` is missing', () => {
                     const mockSeriesWithRoute = {
                         series: {
                             short: 'series-1',
@@ -170,7 +176,7 @@ describe('EditionSectionDetailComponent (DONE)', () => {
                     expectSpyCall(editionStateServiceUpdateSelectedEditionSectionSpy, 2, null);
                 });
 
-                it('... section is missing (undefined)', () => {
+                it('... if section is missing (undefined)', () => {
                     const mockSeries = { series: { route: 'series-1' }, sections: [] } as EditionOutlineSeries;
                     editionStateService.updateSelectedEditionSeries(mockSeries);
                     fixture.componentRef.setInput('sectionId', 'sec-999');
@@ -179,6 +185,14 @@ describe('EditionSectionDetailComponent (DONE)', () => {
 
                     expectSpyCall(editionOutlineServiceGetEditionSectionByIdSpy, 1, ['series-1', 'sec-999']);
                     expectSpyCall(editionStateServiceUpdateSelectedEditionSectionSpy, 2, null);
+                });
+
+                it('... on cleanup', () => {
+                    editionStateService.updateSelectedEditionSeries(expectedSelectedSeries);
+
+                    fixture.destroy();
+
+                    expectSpyCall(editionStateServiceUpdateSelectedEditionSectionSpy, 1, null);
                 });
             });
         });

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail.component.ts
@@ -55,24 +55,23 @@ export class EditionSectionDetailComponent {
      * @returns {void} Updates the edition section from the route.
      */
     updateSectionFromRoute(): void {
-        effect(() => {
+        effect(onCleanup => {
             const series = this._editionStateService.selectedEditionSeries();
             const currentSectionId = this.sectionId();
 
-            if (!series) {
-                return;
-            }
-
-            const seriesId = series.series?.route;
-            if (!seriesId) {
+            if (!series?.series?.route) {
                 this._editionStateService.updateSelectedEditionSection(null);
                 return;
             }
 
             const selectedSection =
-                this._editionOutlineService.getEditionSectionById(seriesId, currentSectionId) ?? null;
+                this._editionOutlineService.getEditionSectionById(series.series.route, currentSectionId) ?? null;
 
             this._editionStateService.updateSelectedEditionSection(selectedSection);
+
+            onCleanup(() => {
+                this._editionStateService.updateSelectedEditionSection(null);
+            });
         });
     }
 }

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-series-detail.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-series-detail.component.spec.ts
@@ -103,55 +103,58 @@ describe('EditionSeriesDetailComponent (DONE)', () => {
         });
 
         describe('#updateSeriesFromRoute()', () => {
+            beforeEach(() => {
+                // Reset spy calls
+                editionOutlineServiceGetEditionSeriesByIdSpy.mockClear();
+                editionStateServiceUpdateSelectedEditionSeriesSpy.mockClear();
+            });
+
             it('... should have a method `updateSeriesFromRoute`', () => {
                 expect(component.updateSeriesFromRoute).toBeDefined();
             });
 
             it('... should call EditionOutlineService.getEditionSeriesById', () => {
-                expectSpyCall(editionOutlineServiceGetEditionSeriesByIdSpy, 1, expectedSeriesId);
-
                 const newSeriesId = 'another-series-id';
                 fixture.componentRef.setInput('seriesId', newSeriesId);
 
                 fixture.detectChanges();
 
-                expectSpyCall(editionOutlineServiceGetEditionSeriesByIdSpy, 2, newSeriesId);
+                expectSpyCall(editionOutlineServiceGetEditionSeriesByIdSpy, 1, newSeriesId);
             });
 
             it('... should update the selected edition series in the state service', () => {
-                expectSpyCall(editionStateServiceUpdateSelectedEditionSeriesSpy, 1, expectedSelectedSeries);
-
                 const newSeries = editionOutlineService.editionOutline()[1];
                 const newSeriesId = newSeries.series.route;
                 fixture.componentRef.setInput('seriesId', newSeriesId);
 
                 fixture.detectChanges();
 
+                // 2 calls because of onCleanup
                 expectSpyCall(editionStateServiceUpdateSelectedEditionSeriesSpy, 2, newSeries);
             });
 
-            describe('... should update selected series to null if ', () => {
-                beforeEach(() => {
-                    // Reset spies
-                    editionOutlineServiceGetEditionSeriesByIdSpy.mockClear();
-                    editionStateServiceUpdateSelectedEditionSeriesSpy.mockClear();
-                });
-
-                it('... param `id` is missing', () => {
+            describe('... should update selected series to null', () => {
+                it('... if param `id` is missing', () => {
                     fixture.componentRef.setInput('seriesId', null);
 
                     fixture.detectChanges();
 
                     expectSpyCall(editionOutlineServiceGetEditionSeriesByIdSpy, 0);
-                    expectSpyCall(editionStateServiceUpdateSelectedEditionSeriesSpy, 1, null);
+                    expectSpyCall(editionStateServiceUpdateSelectedEditionSeriesSpy, 2, null);
                 });
 
-                it('... series is missing (undefined)', () => {
+                it('... if series is missing (undefined)', () => {
                     fixture.componentRef.setInput('seriesId', 'invalid-id');
 
                     fixture.detectChanges();
 
                     expectSpyCall(editionOutlineServiceGetEditionSeriesByIdSpy, 1, 'invalid-id');
+                    expectSpyCall(editionStateServiceUpdateSelectedEditionSeriesSpy, 2, null);
+                });
+
+                it('... on cleanup', () => {
+                    fixture.destroy();
+
                     expectSpyCall(editionStateServiceUpdateSelectedEditionSeriesSpy, 1, null);
                 });
             });

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-series-detail.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-series-detail.component.ts
@@ -55,7 +55,7 @@ export class EditionSeriesDetailComponent {
      * @returns {void} Updates the edition series.
      */
     updateSeriesFromRoute(): void {
-        effect(() => {
+        effect(onCleanup => {
             const currentSeriesId = this.seriesId();
 
             if (!currentSeriesId) {
@@ -65,6 +65,10 @@ export class EditionSeriesDetailComponent {
 
             const selectedSeries = this._editionOutlineService.getEditionSeriesById(currentSeriesId) ?? null;
             this._editionStateService.updateSelectedEditionSeries(selectedSeries);
+
+            onCleanup(() => {
+                this._editionStateService.updateSelectedEditionSeries(null);
+            });
         });
     }
 }

--- a/src/app/views/edition-view/edition-view.component.html
+++ b/src/app/views/edition-view/edition-view.component.html
@@ -2,65 +2,27 @@
 <div class="awg-edition-view p-3 border rounded-3">
     <awg-scroll-to-top-button />
 
-    @let activeView = viewContext();
+    @let context = viewContext();
     @let editionComplex = selectedEditionComplex();
-    @let editionSection = selectedEditionSection();
-    @let editionSeries = selectedEditionSeries();
 
-    @if (activeView.isPreface) {
+    @if (context.isPreface) {
         <div class="awg-edition-preface para">
-            <h6 class="awg-edition-info-breadcrumb">
-                <a [routerLink]="[editionRouteConstants.SERIES.route]">
-                    {{ editionRouteConstants.EDITION?.short }}
-                </a>
-                /
-                <span>{{ editionRouteConstants.PREFACE.short }}</span>
-            </h6>
-            <!-- Jumbotron -->
-            <awg-edition-jumbotron
-                [jumbotronId]="EDITION_VIEW_ID"
-                [jumbotronTitle]="editionRouteConstants.PREFACE.full" />
+            <awg-edition-breadcrumb [items]="breadcrumbItems()" />
+            <awg-edition-jumbotron [jumbotronId]="EDITION_VIEW_ID" [jumbotronTitle]="jumbotronTitle()" />
         </div>
     }
 
-    @if (activeView.isRowtables) {
+    @if (context.isRowtables) {
         <div class="awg-edition-rowtables para">
-            <h6 class="awg-edition-info-breadcrumb">
-                <a [routerLink]="[editionRouteConstants.SERIES.route]">
-                    {{ editionRouteConstants.EDITION?.short }}
-                </a>
-                /
-                <span>{{ editionRouteConstants.ROWTABLES.full }}</span>
-            </h6>
-            <!-- Jumbotron -->
-            <awg-edition-jumbotron [jumbotronId]="EDITION_VIEW_ID" [jumbotronTitle]="'Übersicht'" />
+            <awg-edition-breadcrumb [items]="breadcrumbItems()" />
+            <awg-edition-jumbotron [jumbotronId]="EDITION_VIEW_ID" [jumbotronTitle]="jumbotronTitle()" />
         </div>
     }
 
     @if (editionComplex) {
         <div class="awg-edition-complex">
-            <h6 class="awg-edition-info-breadcrumb">
-                <a [routerLink]="[editionRouteConstants.SERIES.route]">
-                    {{ editionRouteConstants.EDITION?.short }}
-                </a>
-                /
-                <a [routerLink]="[editionRouteConstants.SERIES.route, editionComplex.pubStatement.series.route]">
-                    {{ editionComplex.pubStatement.series.full }}
-                </a>
-                /
-                <a
-                    [routerLink]="[
-                        editionRouteConstants.SERIES.route,
-                        editionComplex.pubStatement.series.route,
-                        'section',
-                        editionComplex.pubStatement.section.route,
-                    ]">
-                    {{ editionComplex.pubStatement.section.full }}
-                </a>
-                /
-                <span [innerHTML]="editionComplex.complexId.short"></span>
-            </h6>
-            <awg-edition-jumbotron [jumbotronId]="EDITION_VIEW_ID" [jumbotronTitle]="editionComplex.complexId.full" />
+            <awg-edition-breadcrumb [items]="breadcrumbItems()" />
+            <awg-edition-jumbotron [jumbotronId]="EDITION_VIEW_ID" [jumbotronTitle]="jumbotronTitle()" />
 
             <!-- declamation -->
             <div class="awg-edition-responsibility mt-3 mb-5">
@@ -87,61 +49,10 @@
         </div>
     }
 
-    @if (editionComplex === null && activeView.isRowtables !== true && activeView.isPreface !== true) {
+    @if (editionComplex === null && !context.isRowtables && !context.isPreface) {
         <div class="awg-edition-series para">
-            <h6 class="awg-edition-info-breadcrumb">
-                <ng-template #breadCrumbEdition>
-                    {{ editionRouteConstants.EDITION?.short }}
-                </ng-template>
-
-                @if (editionSeries) {
-                    <ng-template #breadCrumbSeries>
-                        {{ editionSeries?.series.full }}
-                    </ng-template>
-
-                    <a [routerLink]="[editionRouteConstants.SERIES.route]">
-                        <ng-container *ngTemplateOutlet="breadCrumbEdition" />
-                    </a>
-                    /
-                    @if (editionSection) {
-                        <ng-template #breadCrumbSection>
-                            {{ editionSection?.section.full }}
-                        </ng-template>
-
-                        <a [routerLink]="['./series', editionSeries.series.route]">
-                            <ng-container *ngTemplateOutlet="breadCrumbSeries" />
-                        </a>
-                        /
-                        @if (activeView.isIntro) {
-                            <a
-                                [routerLink]="[
-                                    './series',
-                                    editionSeries.series.route,
-                                    'section',
-                                    editionSection.section.route,
-                                ]">
-                                <ng-container *ngTemplateOutlet="breadCrumbSection" />
-                            </a>
-                            /
-                            <span>{{ editionRouteConstants.EDITION_INTRO.full }}</span>
-                        } @else {
-                            <span>
-                                <ng-container *ngTemplateOutlet="breadCrumbSection" />
-                            </span>
-                        }
-                    } @else {
-                        <ng-container *ngTemplateOutlet="breadCrumbSeries" />
-                        /
-                    }
-                } @else {
-                    <ng-container *ngTemplateOutlet="breadCrumbEdition" />
-                    /
-                }
-            </h6>
-            <!-- Jumbotron -->
-            <awg-edition-jumbotron
-                [jumbotronId]="EDITION_VIEW_ID"
-                [jumbotronTitle]="activeView.isIntro ? editionRouteConstants.EDITION_INTRO.full : EDITION_VIEW_TITLE" />
+            <awg-edition-breadcrumb [items]="breadcrumbItems()" />
+            <awg-edition-jumbotron [jumbotronId]="EDITION_VIEW_ID" [jumbotronTitle]="jumbotronTitle()" />
         </div>
     }
 

--- a/src/app/views/edition-view/edition-view.component.spec.ts
+++ b/src/app/views/edition-view/edition-view.component.spec.ts
@@ -21,12 +21,12 @@ import { LabeledRoute } from '@awg-shared/models/labeled-route.model';
 import { EDITION_ROUTE_CONSTANTS } from './edition-routes.constants';
 import { EditionComplex } from './models/edition-complex.model';
 import { EditionViewContext } from './models/edition-data.model';
+import { EditionBreadcrumbService } from './services/edition-breadcrumb.service';
 import { EditionComplexesService } from './services/edition-complexes.service';
 import { EditionStateService } from './services/edition-state.service';
 import { EditionViewService } from './services/edition-view.service';
 
 import { EditionViewComponent } from './edition-view.component';
-import { EditionBreadcrumbService } from './services/edition-breadcrumb.service';
 
 registerLocaleData(localeDeDE);
 
@@ -330,25 +330,25 @@ describe('EditionViewComponent (DONE)', () => {
                     getPrefaceDes();
                 });
 
-                it('... should have a BreadCrumbComponent (stubbed) and a JumbotronComponent (stubbed) in `div.awg-edition-preface`', () => {
+                it('... should have a BreadcrumbComponent (stubbed) and a JumbotronComponent (stubbed) in `div.awg-edition-preface`', () => {
                     const prefaceDes = getPrefaceDes();
 
                     getAndExpectDebugElementByDirective(prefaceDes[0], EditionBreadcrumbStubComponent, 1, 1);
                     getAndExpectDebugElementByDirective(prefaceDes[0], EditionJumbotronStubComponent, 1, 1);
                 });
 
-                it('... should pass down `breadCrumbItems` to BreadCrumbComponent (stubbed)', () => {
-                    const breadCrumbDes = getAndExpectDebugElementByDirective(
+                it('... should pass down `breadcrumbItems` to BreadcrumbComponent (stubbed)', () => {
+                    const breadcrumbDes = getAndExpectDebugElementByDirective(
                         getPrefaceDes()[0],
                         EditionBreadcrumbStubComponent,
                         1,
                         1
                     );
-                    const breadCrumbCmp = breadCrumbDes[0].injector.get(
+                    const breadcrumbCmp = breadcrumbDes[0].injector.get(
                         EditionBreadcrumbStubComponent
                     ) as EditionBreadcrumbStubComponent;
 
-                    expectToEqual(breadCrumbCmp.items(), component.breadcrumbItems());
+                    expectToEqual(breadcrumbCmp.items(), component.breadcrumbItems());
                 });
 
                 it('... should pass down `editionViewId` and `title` to JumbotronComponent (stubbed)', () => {
@@ -387,25 +387,25 @@ describe('EditionViewComponent (DONE)', () => {
                     getRowtableDes();
                 });
 
-                it('... should have BreadCrumbComponent (stubbed) and a JumbotronComponent (stubbed) in `div.awg-edition-rowtables`', () => {
+                it('... should have BreadcrumbComponent (stubbed) and a JumbotronComponent (stubbed) in `div.awg-edition-rowtables`', () => {
                     const rowtableDes = getRowtableDes();
 
                     getAndExpectDebugElementByDirective(rowtableDes[0], EditionBreadcrumbStubComponent, 1, 1);
                     getAndExpectDebugElementByDirective(rowtableDes[0], EditionJumbotronStubComponent, 1, 1);
                 });
 
-                it('... should pass down `breadCrumbItems` to BreadCrumbComponent (stubbed)', () => {
-                    const breadCrumbDes = getAndExpectDebugElementByDirective(
+                it('... should pass down `breadcrumbItems` to BreadcrumbComponent (stubbed)', () => {
+                    const breadcrumbDes = getAndExpectDebugElementByDirective(
                         getRowtableDes()[0],
                         EditionBreadcrumbStubComponent,
                         1,
                         1
                     );
-                    const breadCrumbCmp = breadCrumbDes[0].injector.get(
+                    const breadcrumbCmp = breadcrumbDes[0].injector.get(
                         EditionBreadcrumbStubComponent
                     ) as EditionBreadcrumbStubComponent;
 
-                    expectToEqual(breadCrumbCmp.items(), component.breadcrumbItems());
+                    expectToEqual(breadcrumbCmp.items(), component.breadcrumbItems());
                 });
 
                 it('... should pass down `editionViewId` and `title` to JumbotronComponent (stubbed)', () => {
@@ -460,7 +460,7 @@ describe('EditionViewComponent (DONE)', () => {
                     getComplexDes();
                 });
 
-                it('... should have a BreadCrumbComponent (stubbed), a JumbotronComponent (stubbed) and a responsibility div in `div.awg-edition-complex`', () => {
+                it('... should have a BreadcrumbComponent (stubbed), a JumbotronComponent (stubbed) and a responsibility div in `div.awg-edition-complex`', () => {
                     const complexDes = getComplexDes();
 
                     getAndExpectDebugElementByDirective(complexDes[0], EditionBreadcrumbStubComponent, 1, 1);
@@ -468,18 +468,18 @@ describe('EditionViewComponent (DONE)', () => {
                     getAndExpectDebugElementByCss(complexDes[0], 'div.awg-edition-responsibility', 1, 1);
                 });
 
-                it('... should pass down `breadCrumbItems` to BreadCrumbComponent (stubbed)', () => {
-                    const breadCrumbDes = getAndExpectDebugElementByDirective(
+                it('... should pass down `breadcrumbItems` to BreadcrumbComponent (stubbed)', () => {
+                    const breadcrumbDes = getAndExpectDebugElementByDirective(
                         getComplexDes()[0],
                         EditionBreadcrumbStubComponent,
                         1,
                         1
                     );
-                    const breadCrumbCmp = breadCrumbDes[0].injector.get(
+                    const breadcrumbCmp = breadcrumbDes[0].injector.get(
                         EditionBreadcrumbStubComponent
                     ) as EditionBreadcrumbStubComponent;
 
-                    expectToEqual(breadCrumbCmp.items(), component.breadcrumbItems());
+                    expectToEqual(breadcrumbCmp.items(), component.breadcrumbItems());
                 });
 
                 it('... should pass down `editionViewId` and `title` to JumbotronComponent (stubbed)', () => {
@@ -612,25 +612,25 @@ describe('EditionViewComponent (DONE)', () => {
                     getSeriesDes();
                 });
 
-                it('... should have a BreadCrumbComponent (stubbed) and a JumbotronComponent (stubbed) in `div.awg-edition-series`', () => {
+                it('... should have a BreadcrumbComponent (stubbed) and a JumbotronComponent (stubbed) in `div.awg-edition-series`', () => {
                     const seriesDes = getSeriesDes();
 
                     getAndExpectDebugElementByDirective(seriesDes[0], EditionBreadcrumbStubComponent, 1, 1);
                     getAndExpectDebugElementByDirective(seriesDes[0], EditionJumbotronStubComponent, 1, 1);
                 });
 
-                it('... should pass down `breadCrumbItems` to BreadCrumbComponent (stubbed)', () => {
-                    const breadCrumbDes = getAndExpectDebugElementByDirective(
+                it('... should pass down `breadcrumbItems` to BreadcrumbComponent (stubbed)', () => {
+                    const breadcrumbDes = getAndExpectDebugElementByDirective(
                         getSeriesDes()[0],
                         EditionBreadcrumbStubComponent,
                         1,
                         1
                     );
-                    const breadCrumbCmp = breadCrumbDes[0].injector.get(
+                    const breadcrumbCmp = breadcrumbDes[0].injector.get(
                         EditionBreadcrumbStubComponent
                     ) as EditionBreadcrumbStubComponent;
 
-                    expectToEqual(breadCrumbCmp.items(), component.breadcrumbItems());
+                    expectToEqual(breadcrumbCmp.items(), component.breadcrumbItems());
                 });
 
                 it('... should pass down `editionViewId` and `editionViewTitle` to JumbotronComponent (stubbed)', () => {

--- a/src/app/views/edition-view/edition-view.component.spec.ts
+++ b/src/app/views/edition-view/edition-view.component.spec.ts
@@ -1,11 +1,13 @@
 import { DatePipe, registerLocaleData } from '@angular/common';
 import localeDeDE from '@angular/common/locales/de';
-import { Component, DebugElement, DOCUMENT, Input, isSignal, LOCALE_ID, signal, WritableSignal } from '@angular/core';
+import { Component, DebugElement, input, Input, isSignal, LOCALE_ID, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+type Spy = ReturnType<typeof vi.spyOn>;
 
 import {
+    expectSpyCall,
     expectToBe,
     expectToEqual,
     getAndExpectDebugElementByCss,
@@ -14,18 +16,35 @@ import {
 import { RouterLinkStubDirective, RouterOutletStubComponent } from '@testing/router-stubs';
 
 import { MetaIdentifiers } from '@awg-shared/meta/meta.model';
+import { LabeledRoute } from '@awg-shared/models/labeled-route.model';
 
 import { EDITION_ROUTE_CONSTANTS } from './edition-routes.constants';
-import { EditionComplex, EditionOutlineSection, EditionOutlineSeries } from './models';
+import { EditionComplex } from './models/edition-complex.model';
 import { EditionViewContext } from './models/edition-data.model';
-import { EditionComplexesService, EditionOutlineService, EditionStateService } from './services';
+import { EditionComplexesService } from './services/edition-complexes.service';
+import { EditionStateService } from './services/edition-state.service';
 import { EditionViewService } from './services/edition-view.service';
 
 import { EditionViewComponent } from './edition-view.component';
+import { EditionBreadcrumbService } from './services/edition-breadcrumb.service';
 
 registerLocaleData(localeDeDE);
 
 // Mock components
+@Component({
+    selector: 'awg-scroll-to-top-button',
+    template: '',
+})
+class ScrollToTopButtonStubComponent {}
+
+@Component({
+    selector: 'awg-edition-breadcrumb',
+    template: '',
+})
+class EditionBreadcrumbStubComponent {
+    readonly items = input.required<LabeledRoute[]>();
+}
+
 @Component({
     selector: 'awg-edition-jumbotron',
     template: '',
@@ -37,12 +56,6 @@ class EditionJumbotronStubComponent {
     @Input()
     jumbotronTitle: string;
 }
-
-@Component({
-    selector: 'awg-scroll-to-top-button',
-    template: '',
-})
-class ScrollToTopButtonStubComponent {}
 
 @Component({
     selector: 'awg-meta-identifier-badges',
@@ -59,30 +72,33 @@ describe('EditionViewComponent (DONE)', () => {
     let fixture: ComponentFixture<EditionViewComponent>;
     let compDe: DebugElement;
 
-    let mockDocument: Document;
-
     let editionComplexesService: EditionComplexesService;
-    let editionOutlineService: EditionOutlineService;
     let editionStateService: EditionStateService;
 
+    let getBreadcrumbItemsSpy: Spy;
+
     let mockViewContextSignal: WritableSignal<EditionViewContext>;
+    let mockBreadcrumbItemsSignal: WritableSignal<LabeledRoute[]>;
 
     let expectedDefaultViewContext: EditionViewContext;
+    let expectedIntroViewContext: EditionViewContext;
+    let expectedPrefaceViewContext: EditionViewContext;
+    let expectedRowtablesViewContext: EditionViewContext;
     let expectedSelectedEditionComplexId: string;
     let expectedSelectedEditionComplex: EditionComplex;
-    let expectedSelectedEditionSeries: EditionOutlineSeries;
-    let expectedSelectedEditionSection: EditionOutlineSection;
 
     const expectedTitle = 'Editionsübersicht';
     const expectedId = 'awg-edition-view';
-    const expectedEditionRouteConstants: typeof EDITION_ROUTE_CONSTANTS = EDITION_ROUTE_CONSTANTS;
 
     beforeEach(async () => {
         // Mock services
         expectedDefaultViewContext = { name: 'other-name', isIntro: false, isPreface: false, isRowtables: false };
         mockViewContextSignal = signal(expectedDefaultViewContext);
 
+        mockBreadcrumbItemsSignal = signal<LabeledRoute[]>([]);
+
         await TestBed.configureTestingModule({
+            imports: [DatePipe, EditionBreadcrumbStubComponent, ScrollToTopButtonStubComponent],
             declarations: [
                 EditionViewComponent,
                 EditionJumbotronStubComponent,
@@ -90,10 +106,13 @@ describe('EditionViewComponent (DONE)', () => {
                 RouterOutletStubComponent,
                 RouterLinkStubDirective,
             ],
-            imports: [DatePipe, ScrollToTopButtonStubComponent],
             providers: [
                 { provide: LOCALE_ID, useValue: 'de-DE' },
                 { provide: EditionViewService, useValue: { viewContext: mockViewContextSignal.asReadonly() } },
+                {
+                    provide: EditionBreadcrumbService,
+                    useValue: { getBreadcrumbItems: () => mockBreadcrumbItemsSignal.asReadonly() },
+                },
             ],
         }).compileComponents();
     });
@@ -101,21 +120,23 @@ describe('EditionViewComponent (DONE)', () => {
     beforeEach(() => {
         // Inject services
         editionComplexesService = TestBed.inject(EditionComplexesService);
-        editionOutlineService = TestBed.inject(EditionOutlineService);
         editionStateService = TestBed.inject(EditionStateService);
-        mockDocument = TestBed.inject(DOCUMENT);
+        const breadcrumbService = TestBed.inject(EditionBreadcrumbService);
 
         // Init edition data
         editionComplexesService.initializeEditionComplexesList();
-        editionOutlineService.initializeEditionOutline();
+
+        // Spies
+        getBreadcrumbItemsSpy = vi.spyOn(breadcrumbService, 'getBreadcrumbItems');
 
         // Test data
+        expectedIntroViewContext = { name: 'intro', isIntro: true, isPreface: false, isRowtables: false };
+        expectedPrefaceViewContext = { name: 'preface', isIntro: false, isPreface: true, isRowtables: false };
+        expectedRowtablesViewContext = { name: 'rowtables', isIntro: false, isPreface: false, isRowtables: true };
         expectedSelectedEditionComplexId = 'op12';
         expectedSelectedEditionComplex = editionComplexesService.getEditionComplexById(
             expectedSelectedEditionComplexId
         );
-        expectedSelectedEditionSeries = editionOutlineService.editionOutline()[0]; // Series 1
-        expectedSelectedEditionSection = expectedSelectedEditionSeries.sections[4]; // Section 5
 
         // Create component fixture
         fixture = TestBed.createComponent(EditionViewComponent);
@@ -137,16 +158,6 @@ describe('EditionViewComponent (DONE)', () => {
             expectToBe(component.EDITION_VIEW_TITLE, expectedTitle);
         });
 
-        it('... should have `editionRouteConstants`', () => {
-            expectToEqual(component.editionRouteConstants, expectedEditionRouteConstants);
-        });
-
-        it('... should have signal `viewContext` to hold the default view context', () => {
-            expectToBe(isSignal(component.viewContext), true);
-
-            expectToEqual(component.viewContext(), expectedDefaultViewContext);
-        });
-
         it('... should have signal `selectedEditionSeries` to hold null', () => {
             expectToBe(isSignal(component.selectedEditionSeries), true);
 
@@ -165,6 +176,18 @@ describe('EditionViewComponent (DONE)', () => {
             expectToBe(component.selectedEditionComplex(), null);
         });
 
+        it('... should have signal `viewContext` to hold the default view context', () => {
+            expectToBe(isSignal(component.viewContext), true);
+
+            expectToEqual(component.viewContext(), expectedDefaultViewContext);
+        });
+
+        it('... should have signal `jumbotronTitle` to hold the default title', () => {
+            expectToBe(isSignal(component.jumbotronTitle), true);
+
+            expectToBe(component.jumbotronTitle(), expectedTitle);
+        });
+
         describe('VIEW', () => {
             const getEditionViewDes = () => getAndExpectDebugElementByCss(compDe, 'div.awg-edition-view', 1, 1);
 
@@ -178,6 +201,7 @@ describe('EditionViewComponent (DONE)', () => {
 
             describe('... should contain no sub-components yet', () => {
                 it.each([
+                    { desc: '`div.awg-edition-preface`', selector: 'div.awg-edition-preface' },
                     { desc: '`div.awg-edition-rowtables`', selector: 'div.awg-edition-rowtables' },
                     { desc: '`div.awg-edition-complex`', selector: 'div.awg-edition-complex' },
                     { desc: '`div.awg-edition-series`', selector: 'div.awg-edition-series' },
@@ -194,15 +218,85 @@ describe('EditionViewComponent (DONE)', () => {
 
     describe('AFTER initial data binding', () => {
         beforeEach(() => {
-            vi.useFakeTimers();
-
             // Trigger initial data binding
             fixture.detectChanges();
         });
 
-        afterEach(() => {
-            vi.clearAllTimers();
-            vi.useRealTimers();
+        describe('#breadcrumbItems()', () => {
+            it('... should have a signal `breadcrumbItems`', () => {
+                expect(component.breadcrumbItems).toBeDefined();
+
+                expectToBe(isSignal(component.breadcrumbItems), true);
+            });
+
+            it('... should have triggered the breadcrumb service to get the items for the breadcrumb', () => {
+                component.breadcrumbItems();
+
+                expectSpyCall(getBreadcrumbItemsSpy, 1, [
+                    component.viewContext,
+                    component.selectedEditionComplex,
+                    component.selectedEditionSeries,
+                    component.selectedEditionSection,
+                ]);
+            });
+
+            it('... should return the items from the breadcrumb service', () => {
+                const expectedBreadcrumbs: LabeledRoute[] = [
+                    { label: 'Edition', route: ['/edition'] },
+                    { label: 'Serie', route: [] },
+                ];
+                mockBreadcrumbItemsSignal.set(expectedBreadcrumbs);
+
+                const actualBreadcrumbs = component.breadcrumbItems();
+
+                expectToBe(actualBreadcrumbs.length, 2);
+                expectToEqual(actualBreadcrumbs, expectedBreadcrumbs);
+            });
+        });
+
+        describe('#jumbotronTitle()', () => {
+            it('... should have a signal `jumbotronTitle`', () => {
+                expect(component.jumbotronTitle).toBeDefined();
+                expectToBe(isSignal(component.jumbotronTitle), true);
+            });
+
+            it.each([
+                {
+                    desc: 'preface title if viewContext is preface',
+                    context: () => expectedPrefaceViewContext,
+                    expected: () => EDITION_ROUTE_CONSTANTS.PREFACE.full,
+                },
+                {
+                    desc: 'rowtables title if viewContext is rowtables',
+                    context: () => expectedRowtablesViewContext,
+                    expected: () => 'Übersicht',
+                },
+                {
+                    desc: 'complex title if a complex is selected and no special view is active',
+                    context: () => expectedDefaultViewContext,
+                    expected: () => expectedSelectedEditionComplex.complexId.full,
+                    setup: () => editionStateService.updateSelectedEditionComplex(expectedSelectedEditionComplex),
+                },
+                {
+                    desc: 'intro title if viewContext is intro',
+                    context: () => expectedIntroViewContext,
+                    expected: () => EDITION_ROUTE_CONSTANTS.EDITION_INTRO.full,
+                },
+                {
+                    desc: 'EDITION_VIEW_TITLE as default',
+                    context: () => expectedDefaultViewContext,
+                    expected: () => expectedTitle,
+                    setup: () => editionStateService.updateSelectedEditionComplex(null),
+                },
+            ])('... should hold $desc', ({ context, expected, setup }) => {
+                if (setup) {
+                    setup();
+                }
+
+                mockViewContextSignal.set(context());
+
+                expectToBe(component.jumbotronTitle(), expected());
+            });
         });
 
         describe('VIEW', () => {
@@ -216,45 +310,45 @@ describe('EditionViewComponent (DONE)', () => {
             const getSeriesDes = () =>
                 getAndExpectDebugElementByCss(getEditionViewDes()[0], 'div.awg-edition-series', 1, 1);
 
-            describe('... if isPrefaceView is true', () => {
+            describe('... if `viewContext` is preface', () => {
                 beforeEach(() => {
-                    mockViewContextSignal.set({ name: 'preface', isIntro: false, isPreface: true, isRowtables: false });
+                    mockViewContextSignal.set(expectedPrefaceViewContext);
 
                     // Trigger data binding
                     fixture.detectChanges();
                 });
 
                 it('... should have signal `viewContext` to hold true for preface view', () => {
-                    expectToEqual(component.viewContext(), {
-                        name: 'preface',
-                        isIntro: false,
-                        isPreface: true,
-                        isRowtables: false,
-                    });
+                    expectToEqual(component.viewContext(), expectedPrefaceViewContext);
+                });
+
+                it('... should have signal `jumbotronTitle` to hold the preface title', () => {
+                    expectToBe(component.jumbotronTitle(), EDITION_ROUTE_CONSTANTS.PREFACE.full);
                 });
 
                 it('... should have one `div.awg-edition-preface` in `div.awg-edition-view`', () => {
                     getPrefaceDes();
                 });
 
-                it('... should have an h6 (breadcrumb) and a JumbotronComponent (stubbed) in `div.awg-edition-preface`', () => {
+                it('... should have a BreadCrumbComponent (stubbed) and a JumbotronComponent (stubbed) in `div.awg-edition-preface`', () => {
                     const prefaceDes = getPrefaceDes();
 
-                    getAndExpectDebugElementByCss(prefaceDes[0], 'h6.awg-edition-info-breadcrumb', 1, 1);
+                    getAndExpectDebugElementByDirective(prefaceDes[0], EditionBreadcrumbStubComponent, 1, 1);
                     getAndExpectDebugElementByDirective(prefaceDes[0], EditionJumbotronStubComponent, 1, 1);
                 });
 
-                it('... should display edition base root (AWG) and heading title in breadcrumb header (h6)', () => {
-                    const hDes = getAndExpectDebugElementByCss(
-                        compDe,
-                        'div.awg-edition-preface > h6.awg-edition-info-breadcrumb',
+                it('... should pass down `breadCrumbItems` to BreadCrumbComponent (stubbed)', () => {
+                    const breadCrumbDes = getAndExpectDebugElementByDirective(
+                        getPrefaceDes()[0],
+                        EditionBreadcrumbStubComponent,
                         1,
                         1
                     );
-                    const hEl: HTMLHeadingElement = hDes[0].nativeElement;
-                    const expectedBreadCrumb = `${expectedEditionRouteConstants.EDITION.short} / ${expectedEditionRouteConstants.PREFACE.short}`;
+                    const breadCrumbCmp = breadCrumbDes[0].injector.get(
+                        EditionBreadcrumbStubComponent
+                    ) as EditionBreadcrumbStubComponent;
 
-                    expectToBe(hEl.textContent?.replace(/\s+/g, ' ').trim(), expectedBreadCrumb);
+                    expectToEqual(breadCrumbCmp.items(), component.breadcrumbItems());
                 });
 
                 it('... should pass down `editionViewId` and `title` to JumbotronComponent (stubbed)', () => {
@@ -269,55 +363,49 @@ describe('EditionViewComponent (DONE)', () => {
                     ) as EditionJumbotronStubComponent;
 
                     expectToBe(jumbotronCmp.jumbotronId, expectedId);
-                    expectToBe(jumbotronCmp.jumbotronTitle, expectedEditionRouteConstants.PREFACE.full);
+                    expectToBe(jumbotronCmp.jumbotronTitle, EDITION_ROUTE_CONSTANTS.PREFACE.full);
                 });
             });
 
-            describe('... if isRowtablesView is true', () => {
+            describe('... if `viewContext` is rowtables', () => {
                 beforeEach(() => {
-                    mockViewContextSignal.set({
-                        name: 'rowtables',
-                        isIntro: false,
-                        isPreface: false,
-                        isRowtables: true,
-                    });
+                    mockViewContextSignal.set(expectedRowtablesViewContext);
 
                     // Trigger data binding
                     fixture.detectChanges();
                 });
 
                 it('... should have signal `viewContext` to hold true for rowtables view', () => {
-                    expectToEqual(component.viewContext(), {
-                        name: 'rowtables',
-                        isIntro: false,
-                        isPreface: false,
-                        isRowtables: true,
-                    });
+                    expectToEqual(component.viewContext(), expectedRowtablesViewContext);
+                });
+
+                it('... should have signal `jumbotronTitle` to hold the rowtables title', () => {
+                    expectToBe(component.jumbotronTitle(), 'Übersicht');
                 });
 
                 it('... should have one `div.awg-edition-rowtables` in `div.awg-edition-view`', () => {
                     getRowtableDes();
                 });
 
-                it('... should have an h6 (breadcrumb) and a JumbotronComponent (stubbed) in `div.awg-edition-rowtables`', () => {
+                it('... should have BreadCrumbComponent (stubbed) and a JumbotronComponent (stubbed) in `div.awg-edition-rowtables`', () => {
                     const rowtableDes = getRowtableDes();
 
-                    getAndExpectDebugElementByCss(rowtableDes[0], 'h6.awg-edition-info-breadcrumb', 1, 1);
-
+                    getAndExpectDebugElementByDirective(rowtableDes[0], EditionBreadcrumbStubComponent, 1, 1);
                     getAndExpectDebugElementByDirective(rowtableDes[0], EditionJumbotronStubComponent, 1, 1);
                 });
 
-                it('... should display edition base root (AWG) and heading title in breadcrumb header (h6)', () => {
-                    const hDes = getAndExpectDebugElementByCss(
-                        compDe,
-                        'div.awg-edition-rowtables > h6.awg-edition-info-breadcrumb',
+                it('... should pass down `breadCrumbItems` to BreadCrumbComponent (stubbed)', () => {
+                    const breadCrumbDes = getAndExpectDebugElementByDirective(
+                        getRowtableDes()[0],
+                        EditionBreadcrumbStubComponent,
                         1,
                         1
                     );
-                    const hEl: HTMLHeadingElement = hDes[0].nativeElement;
-                    const expectedBreadCrumb = `${expectedEditionRouteConstants.EDITION.short} / ${expectedEditionRouteConstants.ROWTABLES.full}`;
+                    const breadCrumbCmp = breadCrumbDes[0].injector.get(
+                        EditionBreadcrumbStubComponent
+                    ) as EditionBreadcrumbStubComponent;
 
-                    expectToBe(hEl.textContent?.replace(/\s+/g, ' ').trim(), expectedBreadCrumb);
+                    expectToEqual(breadCrumbCmp.items(), component.breadcrumbItems());
                 });
 
                 it('... should pass down `editionViewId` and `title` to JumbotronComponent (stubbed)', () => {
@@ -336,65 +424,65 @@ describe('EditionViewComponent (DONE)', () => {
                 });
             });
 
-            describe('... if selectedEditionComplex is given', () => {
+            describe('... if `selectedEditionComplex` is given', () => {
                 const renderSelectedEditionComplex = (complex: EditionComplex): void => {
                     editionStateService.updateSelectedEditionComplex(complex);
+                    mockViewContextSignal.set(expectedDefaultViewContext);
 
                     fixture.detectChanges();
                 };
 
-                it('... should have signal `selectedEditionComplex` to hold the expected complex', () => {
+                beforeEach(() => {
                     renderSelectedEditionComplex(expectedSelectedEditionComplex);
+                });
 
+                it('... should have signal `selectedEditionComplex` to hold the expected complex', () => {
                     expectToBe(component.selectedEditionComplex(), expectedSelectedEditionComplex);
                 });
 
-                it('... should have one `div.awg-edition-complex` in `div.awg-edition-view`', () => {
-                    renderSelectedEditionComplex(expectedSelectedEditionComplex);
+                it('... should have signal `viewContext` to hold the default view context', () => {
+                    expectToEqual(component.viewContext(), expectedDefaultViewContext);
+                });
 
+                it('... should have signal `jumbotronTitle` to hold the expected complex title', () => {
+                    expectToBe(component.jumbotronTitle(), expectedSelectedEditionComplex.complexId.full);
+                });
+
+                it('... should still have signal `jumbotronTitle` to hold the expected complex title if `viewContext` is intro', () => {
+                    mockViewContextSignal.set(expectedIntroViewContext);
+
+                    fixture.detectChanges();
+
+                    expectToBe(component.jumbotronTitle(), expectedSelectedEditionComplex.complexId.full);
+                });
+
+                it('... should have one `div.awg-edition-complex` in `div.awg-edition-view`', () => {
                     getComplexDes();
                 });
 
-                it('... should have an h6 (breadcrumb), a JumbotronComponent (stubbed) and a responsibility div in `div.awg-edition-complex`', () => {
-                    renderSelectedEditionComplex(expectedSelectedEditionComplex);
-
+                it('... should have a BreadCrumbComponent (stubbed), a JumbotronComponent (stubbed) and a responsibility div in `div.awg-edition-complex`', () => {
                     const complexDes = getComplexDes();
 
-                    getAndExpectDebugElementByCss(complexDes[0], 'h6.awg-edition-info-breadcrumb', 1, 1);
+                    getAndExpectDebugElementByDirective(complexDes[0], EditionBreadcrumbStubComponent, 1, 1);
                     getAndExpectDebugElementByDirective(complexDes[0], EditionJumbotronStubComponent, 1, 1);
                     getAndExpectDebugElementByCss(complexDes[0], 'div.awg-edition-responsibility', 1, 1);
                 });
 
-                it('... should display edition complex in breadcrumb header (h6)', () => {
-                    renderSelectedEditionComplex(expectedSelectedEditionComplex);
-
-                    const hDes = getAndExpectDebugElementByCss(
-                        compDe,
-                        'div.awg-edition-complex > h6.awg-edition-info-breadcrumb',
+                it('... should pass down `breadCrumbItems` to BreadCrumbComponent (stubbed)', () => {
+                    const breadCrumbDes = getAndExpectDebugElementByDirective(
+                        getComplexDes()[0],
+                        EditionBreadcrumbStubComponent,
                         1,
                         1
                     );
-                    const hEl: HTMLHeadingElement = hDes[0].nativeElement;
+                    const breadCrumbCmp = breadCrumbDes[0].injector.get(
+                        EditionBreadcrumbStubComponent
+                    ) as EditionBreadcrumbStubComponent;
 
-                    const awg = EDITION_ROUTE_CONSTANTS.EDITION.short;
-                    const series = expectedSelectedEditionComplex.pubStatement.series.full;
-                    const section = expectedSelectedEditionComplex.pubStatement.section.full;
-
-                    // Handle non-breaking space by converting HTML to text
-                    const complex = expectedSelectedEditionComplex.complexId.short;
-                    const complexHtml = mockDocument.createElement('span');
-                    complexHtml.innerHTML = complex;
-                    const complexText = complexHtml.textContent?.replace(/\s+/g, ' ').trim();
-
-                    const expectedBreadCrumb = `${awg} / ${series} / ${section} / ${complexText}`;
-
-                    expectToBe(hEl.textContent?.replace(/\s+/g, ' ').trim(), expectedBreadCrumb);
+                    expectToEqual(breadCrumbCmp.items(), component.breadcrumbItems());
                 });
 
                 it('... should pass down `editionViewId` and `title` to JumbotronComponent (stubbed)', () => {
-                    renderSelectedEditionComplex(expectedSelectedEditionComplex);
-
-                    // Get debug and native element of JumbotronComponent
                     const jumbotronDes = getAndExpectDebugElementByDirective(
                         getComplexDes()[0],
                         EditionJumbotronStubComponent,
@@ -410,8 +498,6 @@ describe('EditionViewComponent (DONE)', () => {
                 });
 
                 it('... should have one paragraph with editor and version in responsibility div', () => {
-                    renderSelectedEditionComplex(expectedSelectedEditionComplex);
-
                     const pDes = getAndExpectDebugElementByCss(compDe, 'div.awg-edition-responsibility > p', 1, 1);
 
                     const editors = expectedSelectedEditionComplex.respStatement.editors;
@@ -421,8 +507,6 @@ describe('EditionViewComponent (DONE)', () => {
                 });
 
                 it('... should display editor link and version in responsibility div', () => {
-                    renderSelectedEditionComplex(expectedSelectedEditionComplex);
-
                     const pDes = getAndExpectDebugElementByCss(compDe, 'div.awg-edition-responsibility > p', 1, 1);
 
                     const expectedEditors = expectedSelectedEditionComplex.respStatement.editors;
@@ -463,8 +547,6 @@ describe('EditionViewComponent (DONE)', () => {
                 });
 
                 it('... should have one MetaIdentifierBadgesComponent for each editor', () => {
-                    renderSelectedEditionComplex(expectedSelectedEditionComplex);
-
                     const expectedEditors = expectedSelectedEditionComplex.respStatement.editors;
 
                     const badgeDes = getAndExpectDebugElementByDirective(
@@ -479,8 +561,6 @@ describe('EditionViewComponent (DONE)', () => {
                 });
 
                 it('... should pass identifiers to MetaIdentifierBadgesComponent for each editor', () => {
-                    renderSelectedEditionComplex(expectedSelectedEditionComplex);
-
                     const expectedEditors = expectedSelectedEditionComplex.respStatement.editors;
 
                     const badgeDes = getAndExpectDebugElementByDirective(
@@ -497,7 +577,7 @@ describe('EditionViewComponent (DONE)', () => {
                 });
             });
 
-            describe('... if selectedEditionComplex, isPrefaceView and isRowtablesView are not given', () => {
+            describe('... if `selectedEditionComplex` is not given, and `viewContext` is not preface or rowtables', () => {
                 beforeEach(() => {
                     mockViewContextSignal.set(expectedDefaultViewContext);
                     editionStateService.updateSelectedEditionComplex(null);
@@ -507,11 +587,15 @@ describe('EditionViewComponent (DONE)', () => {
                     fixture.detectChanges();
                 });
 
-                it('... should have signals to hold expected values', () => {
+                it('... should have state signals to hold the expected values', () => {
                     expectToEqual(component.viewContext(), expectedDefaultViewContext);
                     expectToBe(component.selectedEditionComplex(), null);
                     expectToBe(component.selectedEditionSeries(), null);
                     expectToBe(component.selectedEditionSection(), null);
+                });
+
+                it('... should have signal `jumbotronTitle` to hold the default title', () => {
+                    expectToBe(component.jumbotronTitle(), expectedTitle);
                 });
 
                 describe('... should contain no view-specific-components', () => {
@@ -528,15 +612,28 @@ describe('EditionViewComponent (DONE)', () => {
                     getSeriesDes();
                 });
 
-                it('... should have an h6 (breadcrumb) and a JumbotronComponent (stubbed) in `div.awg-edition-series`', () => {
+                it('... should have a BreadCrumbComponent (stubbed) and a JumbotronComponent (stubbed) in `div.awg-edition-series`', () => {
                     const seriesDes = getSeriesDes();
 
-                    getAndExpectDebugElementByCss(seriesDes[0], 'h6.awg-edition-info-breadcrumb', 1, 1);
+                    getAndExpectDebugElementByDirective(seriesDes[0], EditionBreadcrumbStubComponent, 1, 1);
                     getAndExpectDebugElementByDirective(seriesDes[0], EditionJumbotronStubComponent, 1, 1);
                 });
 
+                it('... should pass down `breadCrumbItems` to BreadCrumbComponent (stubbed)', () => {
+                    const breadCrumbDes = getAndExpectDebugElementByDirective(
+                        getSeriesDes()[0],
+                        EditionBreadcrumbStubComponent,
+                        1,
+                        1
+                    );
+                    const breadCrumbCmp = breadCrumbDes[0].injector.get(
+                        EditionBreadcrumbStubComponent
+                    ) as EditionBreadcrumbStubComponent;
+
+                    expectToEqual(breadCrumbCmp.items(), component.breadcrumbItems());
+                });
+
                 it('... should pass down `editionViewId` and `editionViewTitle` to JumbotronComponent (stubbed)', () => {
-                    // Get debug and native element of JumbotronComponent
                     const jumbotronDes = getAndExpectDebugElementByDirective(
                         getSeriesDes()[0],
                         EditionJumbotronStubComponent,
@@ -551,233 +648,34 @@ describe('EditionViewComponent (DONE)', () => {
                     expectToBe(jumbotronCmp.jumbotronTitle, expectedTitle);
                 });
 
-                it('... should pass down full edition intro const as title to JumbotronComponent (stubbed) if `isIntroView=true`', () => {
-                    mockViewContextSignal.set({ name: 'intro', isIntro: true, isPreface: false, isRowtables: false });
+                describe('... if `viewContext` is intro', () => {
+                    beforeEach(() => {
+                        mockViewContextSignal.set(expectedIntroViewContext);
 
-                    // Trigger data binding
-                    fixture.detectChanges();
-
-                    // Get debug and native element of JumbotronComponent
-                    const jumbotronDes = getAndExpectDebugElementByDirective(
-                        getSeriesDes()[0],
-                        EditionJumbotronStubComponent,
-                        1,
-                        1
-                    );
-                    const jumbotronCmp = jumbotronDes[0].injector.get(
-                        EditionJumbotronStubComponent
-                    ) as EditionJumbotronStubComponent;
-
-                    expectToBe(jumbotronCmp.jumbotronId, expectedId);
-                    expectToBe(jumbotronCmp.jumbotronTitle, EDITION_ROUTE_CONSTANTS.EDITION_INTRO.full);
-                });
-
-                describe('... breadcrumb header (h6)', () => {
-                    describe('... if no series and section is given', () => {
-                        beforeEach(() => {
-                            editionStateService.updateSelectedEditionSeries(null);
-                            // Section automatically set to null if no series is given
-
-                            fixture.detectChanges();
-                        });
-
-                        it('... should display edition base root (AWG)', () => {
-                            const hDes = getAndExpectDebugElementByCss(
-                                compDe,
-                                'div.awg-edition-series > h6.awg-edition-info-breadcrumb',
-                                1,
-                                1
-                            );
-                            const hEl: HTMLHeadingElement = hDes[0].nativeElement;
-
-                            const awg = EDITION_ROUTE_CONSTANTS.EDITION.short;
-                            const expectedBreadCrumb = `${awg} /`;
-
-                            expectToBe(hEl.textContent?.replace(/\s+/g, ' ').trim(), expectedBreadCrumb);
-                        });
-
-                        it('... should have no back link to edition series overview', async () => {
-                            const expectedLinkLength = 0;
-
-                            const hDes = getAndExpectDebugElementByCss(
-                                compDe,
-                                'div.awg-edition-series > h6.awg-edition-info-breadcrumb',
-                                1,
-                                1
-                            );
-                            getAndExpectDebugElementByCss(hDes[0], 'a', expectedLinkLength, expectedLinkLength);
-                        });
+                        fixture.detectChanges();
                     });
 
-                    describe('... if series, but no section is given', () => {
-                        beforeEach(() => {
-                            editionStateService.updateSelectedEditionSeries(expectedSelectedEditionSeries);
-                            editionStateService.updateSelectedEditionSection(null);
-
-                            fixture.detectChanges();
-                        });
-
-                        it('... should display edition series', () => {
-                            const hDes = getAndExpectDebugElementByCss(
-                                compDe,
-                                'div.awg-edition-series > h6.awg-edition-info-breadcrumb',
-                                1,
-                                1
-                            );
-                            const hEl: HTMLHeadingElement = hDes[0].nativeElement;
-
-                            const awg = EDITION_ROUTE_CONSTANTS.EDITION.short;
-                            const series = expectedSelectedEditionComplex.pubStatement.series.full;
-                            const expectedBreadCrumb = `${awg} / ${series} /`;
-
-                            expectToBe(hEl.textContent?.replace(/\s+/g, ' ').trim(), expectedBreadCrumb);
-                        });
-
-                        it('... should have a back link to edition series overview', () => {
-                            const expectedLinkLength = 1;
-
-                            const hDes = getAndExpectDebugElementByCss(
-                                compDe,
-                                'div.awg-edition-series > h6.awg-edition-info-breadcrumb',
-                                1,
-                                1
-                            );
-                            getAndExpectDebugElementByCss(hDes[0], 'a', expectedLinkLength, expectedLinkLength);
-                            const linkDes = getAndExpectDebugElementByDirective(
-                                hDes[0],
-                                RouterLinkStubDirective,
-                                expectedLinkLength,
-                                expectedLinkLength
-                            );
-                            const routerLinks = linkDes.map(de => de.injector.get(RouterLinkStubDirective));
-                            const expectedRoute = EDITION_ROUTE_CONSTANTS.SERIES.route;
-
-                            expectToBe(routerLinks.length, expectedLinkLength);
-                            expectToEqual(routerLinks[0].linkParams, [expectedRoute]);
-                        });
+                    it('... should have signal `viewContext` to hold true for intro view', () => {
+                        expectToEqual(component.viewContext(), expectedIntroViewContext);
                     });
 
-                    describe('... if series and section are given', () => {
-                        beforeEach(() => {
-                            editionStateService.updateSelectedEditionSeries(expectedSelectedEditionSeries);
-                            editionStateService.updateSelectedEditionSection(expectedSelectedEditionSection);
-
-                            fixture.detectChanges();
-                        });
-
-                        it('... should display edition series and section', () => {
-                            const hDes = getAndExpectDebugElementByCss(
-                                compDe,
-                                'div.awg-edition-series > h6.awg-edition-info-breadcrumb',
-                                1,
-                                1
-                            );
-                            const hEl: HTMLHeadingElement = hDes[0].nativeElement;
-
-                            const awg = EDITION_ROUTE_CONSTANTS.EDITION.short;
-                            const series = expectedSelectedEditionComplex.pubStatement.series.full;
-                            const section = expectedSelectedEditionComplex.pubStatement.section.full;
-                            const expectedBreadCrumb = `${awg} / ${series} / ${section}`;
-
-                            expectToBe(hEl.textContent?.replace(/\s+/g, ' ').trim(), expectedBreadCrumb);
-                        });
-
-                        it('... should have two back links to series overview and current edition series', () => {
-                            const expectedLinkLength = 2;
-
-                            const hDes = getAndExpectDebugElementByCss(
-                                compDe,
-                                'div.awg-edition-series > h6.awg-edition-info-breadcrumb',
-                                1,
-                                1
-                            );
-                            getAndExpectDebugElementByCss(hDes[0], 'a', expectedLinkLength, expectedLinkLength);
-                            const linkDes = getAndExpectDebugElementByDirective(
-                                hDes[0],
-                                RouterLinkStubDirective,
-                                expectedLinkLength,
-                                expectedLinkLength
-                            );
-                            const routerLinks = linkDes.map(de => de.injector.get(RouterLinkStubDirective));
-                            const expectedSeriesRoute = EDITION_ROUTE_CONSTANTS.SERIES.route;
-                            const expectedSeriesNumberRoute = expectedSelectedEditionSeries.series.route;
-
-                            expectToBe(routerLinks.length, expectedLinkLength);
-                            expectToEqual(routerLinks[0].linkParams, [expectedSeriesRoute]);
-                            expectToEqual(routerLinks[1].linkParams, [
-                                './' + expectedSeriesRoute,
-                                expectedSeriesNumberRoute,
-                            ]);
-                        });
+                    it('... should have signal `jumbotronTitle` to hold the intro title', () => {
+                        expectToBe(component.jumbotronTitle(), EDITION_ROUTE_CONSTANTS.EDITION_INTRO.full);
                     });
 
-                    describe('... if series, section, and isIntroView is given', () => {
-                        beforeEach(() => {
-                            editionStateService.updateSelectedEditionSeries(expectedSelectedEditionSeries);
-                            editionStateService.updateSelectedEditionSection(expectedSelectedEditionSection);
-                            mockViewContextSignal.set({
-                                name: 'intro',
-                                isIntro: true,
-                                isPreface: false,
-                                isRowtables: false,
-                            });
+                    it('... should pass down correct title to JumbotronComponent (stubbed)', () => {
+                        const jumbotronDes = getAndExpectDebugElementByDirective(
+                            getSeriesDes()[0],
+                            EditionJumbotronStubComponent,
+                            1,
+                            1
+                        );
+                        const jumbotronCmp = jumbotronDes[0].injector.get(
+                            EditionJumbotronStubComponent
+                        ) as EditionJumbotronStubComponent;
 
-                            fixture.detectChanges();
-                        });
-
-                        it('... should display edition series, section and intro heading', () => {
-                            const hDes = getAndExpectDebugElementByCss(
-                                compDe,
-                                'div.awg-edition-series > h6.awg-edition-info-breadcrumb',
-                                1,
-                                1
-                            );
-                            const hEl: HTMLHeadingElement = hDes[0].nativeElement;
-
-                            const awg = EDITION_ROUTE_CONSTANTS.EDITION.short;
-                            const series = expectedSelectedEditionComplex.pubStatement.series.full;
-                            const section = expectedSelectedEditionComplex.pubStatement.section.full;
-                            const intro = EDITION_ROUTE_CONSTANTS.EDITION_INTRO.full.replace(/\u00A0/g, ' ');
-                            const expectedBreadCrumb = `${awg} / ${series} / ${section} / ${intro}`;
-
-                            expectToBe(hEl.textContent?.replace(/\s+/g, ' ').trim(), expectedBreadCrumb);
-                        });
-
-                        it('... should have three back links to series overview, current edition series and section overview', async () => {
-                            const expectedLinkLength = 3;
-
-                            const hDes = getAndExpectDebugElementByCss(
-                                compDe,
-                                'div.awg-edition-series > h6.awg-edition-info-breadcrumb',
-                                1,
-                                1
-                            );
-                            getAndExpectDebugElementByCss(hDes[0], 'a', expectedLinkLength, expectedLinkLength);
-                            const linkDes = getAndExpectDebugElementByDirective(
-                                hDes[0],
-                                RouterLinkStubDirective,
-                                expectedLinkLength,
-                                expectedLinkLength
-                            );
-                            const routerLinks = linkDes.map(de => de.injector.get(RouterLinkStubDirective));
-                            const expectedSeriesRoute = EDITION_ROUTE_CONSTANTS.SERIES.route;
-                            const expectedSeriesNumberRoute = expectedSelectedEditionSeries.series.route;
-                            const expectedSectionRoute = EDITION_ROUTE_CONSTANTS.SECTION.route;
-                            const expectedSectionNumberRoute = expectedSelectedEditionSection.section.route;
-
-                            expectToBe(routerLinks.length, expectedLinkLength);
-                            expectToEqual(routerLinks[0].linkParams, [expectedSeriesRoute]);
-                            expectToEqual(routerLinks[1].linkParams, [
-                                './' + expectedSeriesRoute,
-                                expectedSeriesNumberRoute,
-                            ]);
-                            expectToEqual(routerLinks[2].linkParams, [
-                                './' + expectedSeriesRoute,
-                                expectedSeriesNumberRoute,
-                                expectedSectionRoute,
-                                expectedSectionNumberRoute,
-                            ]);
-                        });
+                        expectToBe(jumbotronCmp.jumbotronId, expectedId);
+                        expectToBe(jumbotronCmp.jumbotronTitle, EDITION_ROUTE_CONSTANTS.EDITION_INTRO.full);
                     });
                 });
             });

--- a/src/app/views/edition-view/edition-view.component.ts
+++ b/src/app/views/edition-view/edition-view.component.ts
@@ -1,8 +1,9 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 
-import { EDITION_ROUTE_CONSTANTS } from '@awg-views/edition-view/edition-routes.constants';
-import { EditionStateService } from '@awg-views/edition-view/services/edition-state.service';
-import { EditionViewService } from '@awg-views/edition-view/services/edition-view.service';
+import { EDITION_ROUTE_CONSTANTS } from './edition-routes.constants';
+import { EditionBreadcrumbService } from './services/edition-breadcrumb.service';
+import { EditionStateService } from './services/edition-state.service';
+import { EditionViewService } from './services/edition-view.service';
 
 /**
  * The EditionView component.
@@ -69,11 +70,43 @@ export class EditionViewComponent {
     readonly selectedEditionSeries = this._editionStateService.selectedEditionSeries;
 
     /**
-     * Getter variable: editionRouteConstants.
+     * Readonly signal: breadcrumbItems.
      *
-     *  It returns the EDITION_ROUTE_CONSTANTS.
-     **/
-    get editionRouteConstants(): typeof EDITION_ROUTE_CONSTANTS {
-        return EDITION_ROUTE_CONSTANTS;
-    }
+     * It holds the labeled route items for the breadcrumb.
+     */
+    readonly breadcrumbItems = inject(EditionBreadcrumbService).getBreadcrumbItems(
+        this.viewContext,
+        this.selectedEditionComplex,
+        this.selectedEditionSeries,
+        this.selectedEditionSection
+    );
+
+    /**
+     * Readonly signal: jumbotronTitle.
+     *
+     * It computes the title of the jumbotron.
+     */
+    readonly jumbotronTitle = computed<string>(() => {
+        const context = this.viewContext();
+        const complex = this.selectedEditionComplex();
+        const { PREFACE, EDITION_INTRO } = EDITION_ROUTE_CONSTANTS;
+
+        if (context.isPreface) {
+            return PREFACE.full;
+        }
+
+        if (context.isRowtables) {
+            return 'Übersicht';
+        }
+
+        if (complex) {
+            return complex.complexId.full;
+        }
+
+        if (context.isIntro) {
+            return EDITION_INTRO.full;
+        }
+
+        return this.EDITION_VIEW_TITLE;
+    });
 }

--- a/src/app/views/edition-view/edition-view.module.ts
+++ b/src/app/views/edition-view/edition-view.module.ts
@@ -2,8 +2,9 @@ import { NgModule } from '@angular/core';
 
 import { SharedModule } from '@awg-shared/shared.module';
 
+import { EditionBreadcrumbComponent } from './edition-bread-crumb/edition-bread-crumb.component';
 import { EditionInfoComponent } from './edition-info/edition-info.component';
-import { EditionJumbotronComponent } from './edition-jumbotron';
+import { EditionJumbotronComponent } from './edition-jumbotron/edition-jumbotron.component';
 import { EditionViewRoutingModule, routedEditionViewComponents } from './edition-view-routing.module';
 
 /**
@@ -14,7 +15,7 @@ import { EditionViewRoutingModule, routedEditionViewComponents } from './edition
  * as well as the {@link SharedModule}.
  */
 @NgModule({
-    imports: [SharedModule, EditionViewRoutingModule, EditionInfoComponent],
+    imports: [SharedModule, EditionViewRoutingModule, EditionInfoComponent, EditionBreadcrumbComponent],
     declarations: [routedEditionViewComponents, EditionJumbotronComponent],
 })
 export class EditionViewModule {}

--- a/src/app/views/edition-view/models/edition-data.model.ts
+++ b/src/app/views/edition-view/models/edition-data.model.ts
@@ -125,28 +125,44 @@ export interface EditionViewData<K extends EditionViewKey> {
 }
 
 /**
- * The EditionViewContext type.
+ * The KnownViewContexts type.
  *
- * It defines the structure of the context for the edition view.
+ * It defines the structure of the known contexts for edition views.
  */
-export interface EditionViewContext {
-    /**
-     * The name of the current edition view.
-     */
-    name: EditionViewKey | string;
+type KnownViewContexts =
+    | { name: 'intro'; isIntro: true; isPreface: false; isRowtables: false }
+    | { name: 'preface'; isIntro: false; isPreface: true; isRowtables: false }
+    | { name: 'rowtables'; isIntro: false; isPreface: false; isRowtables: true };
 
+/**
+ * The DynamicViewContexts type.
+ *
+ * It defines the structure of the dynamic contexts for edition views.
+ */
+interface DynamicViewContexts {
+    /**
+     * The name of the current edition view, excluding KnownConexts, or any string.
+     */
+    name: Exclude<EditionViewKey, 'intro' | 'preface' | 'rowtables'> | (string & {});
     /**
      * A flag indicating whether the current view is the intro view.
      */
-    isIntro: boolean;
+    isIntro: false;
 
     /**
      * A flag indicating whether the current view is the preface view.
      */
-    isPreface: boolean;
+    isPreface: false;
 
     /**
      * A flag indicating whether the current view is the rowtables view.
      */
-    isRowtables: boolean;
+    isRowtables: false;
 }
+
+/**
+ * The EditionViewContext type.
+ *
+ * It defines the structure of the context for the edition view.
+ */
+export type EditionViewContext = KnownViewContexts | DynamicViewContexts;

--- a/src/app/views/edition-view/models/edition-data.model.ts
+++ b/src/app/views/edition-view/models/edition-data.model.ts
@@ -141,7 +141,7 @@ type KnownViewContexts =
  */
 interface DynamicViewContexts {
     /**
-     * The name of the current edition view, excluding KnownConexts, or any string.
+     * The name of the current edition view, excluding KnownViewContexts, or any string.
      */
     name: Exclude<EditionViewKey, 'intro' | 'preface' | 'rowtables'> | (string & {});
     /**

--- a/src/app/views/edition-view/services/edition-breadcrumb.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-breadcrumb.service.spec.ts
@@ -1,0 +1,324 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { expectToBe, expectToEqual } from '@testing/expect-helper';
+
+import { LabeledRoute } from '@awg-shared/models/labeled-route.model';
+import { EDITION_ROUTE_CONSTANTS } from '../edition-routes.constants';
+import { EditionComplex, EditionOutlineSection, EditionOutlineSeries } from '../models';
+import { EditionViewContext } from '../models/edition-data.model';
+
+import { EditionBreadcrumbService } from './edition-breadcrumb.service';
+import { EditionComplexesService } from './edition-complexes.service';
+import { EditionOutlineService } from './edition-outline.service';
+
+describe('EditionBreadcrumbService', () => {
+    let service: EditionBreadcrumbService;
+
+    let editionComplexesService: EditionComplexesService;
+    let editionOutlineService: EditionOutlineService;
+
+    let expectedSelectedEditionComplex: EditionComplex;
+    let expectedSelectedEditionSeries: EditionOutlineSeries;
+    let expectedSelectedEditionSection: EditionOutlineSection;
+
+    const mockViewContext = signal<EditionViewContext>({
+        name: 'graph',
+        isIntro: false,
+        isPreface: false,
+        isRowtables: false,
+    });
+    const mockComplex = signal<EditionComplex>(null);
+    const mockSeries = signal<EditionOutlineSeries>(null);
+    const mockSection = signal<EditionOutlineSection>(null);
+
+    const { EDITION, SERIES, EDITION_INTRO, PREFACE, ROWTABLES } = EDITION_ROUTE_CONSTANTS;
+    const mockRootItem: LabeledRoute = {
+        label: EDITION.short,
+        route: [EDITION.route, SERIES.route],
+    };
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [EditionBreadcrumbService],
+        });
+
+        // Inject services
+        service = TestBed.inject(EditionBreadcrumbService);
+
+        // Init edition data
+        editionComplexesService = TestBed.inject(EditionComplexesService);
+        editionOutlineService = TestBed.inject(EditionOutlineService);
+        editionComplexesService.initializeEditionComplexesList();
+        editionOutlineService.initializeEditionOutline();
+
+        // Test data
+        const complexId = 'op12';
+        expectedSelectedEditionComplex = editionComplexesService.getEditionComplexById(complexId);
+        expectedSelectedEditionSeries = editionOutlineService.editionOutline()[0]; // Series 1
+        expectedSelectedEditionSection = expectedSelectedEditionSeries.sections[4]; // Section 5
+
+        mockComplex.set(expectedSelectedEditionComplex);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+
+    describe('METHODS', () => {
+        describe('#getBreadcrumbItems()', () => {
+            it('... should have a method `getBreadcrumbItems`', () => {
+                expect(service.getBreadcrumbItems).toBeDefined();
+            });
+
+            it('... should return preface breadcrumb if viewContext is preface', () => {
+                mockViewContext.set({ name: 'preface', isIntro: false, isPreface: true, isRowtables: false });
+                mockComplex.set(null);
+                mockSeries.set(null);
+                mockSection.set(null);
+
+                const expectedBreadcrumbs: LabeledRoute[] = [mockRootItem, { label: PREFACE.short, route: [] }];
+                const breadcrumbSignal = service.getBreadcrumbItems(
+                    mockViewContext,
+                    mockComplex,
+                    mockSeries,
+                    mockSection
+                );
+
+                const actualBreadcrumbs = breadcrumbSignal();
+
+                expectToBe(actualBreadcrumbs.length, 2);
+                expectToEqual(actualBreadcrumbs, expectedBreadcrumbs);
+            });
+
+            it('... should return rowtables breadcrumb if viewContext is rowtables', () => {
+                mockViewContext.set({ name: 'rowtables', isIntro: false, isPreface: false, isRowtables: true });
+                mockComplex.set(null);
+                mockSeries.set(null);
+                mockSection.set(null);
+
+                const expectedBreadcrumbs: LabeledRoute[] = [mockRootItem, { label: ROWTABLES.full, route: [] }];
+                const breadcrumbSignal = service.getBreadcrumbItems(
+                    mockViewContext,
+                    mockComplex,
+                    mockSeries,
+                    mockSection
+                );
+
+                const actualBreadcrumbs = breadcrumbSignal();
+
+                expectToBe(actualBreadcrumbs.length, 2);
+                expectToEqual(actualBreadcrumbs, expectedBreadcrumbs);
+            });
+
+            it('... should return complex breadcrumbs if an editionComplex is active', () => {
+                const complex = expectedSelectedEditionComplex;
+                mockViewContext.set({ name: 'graph', isIntro: false, isPreface: false, isRowtables: false });
+                mockComplex.set(complex);
+                mockSeries.set(null);
+                mockSection.set(null);
+
+                const { series, section, labeledSectionRoute } = complex.pubStatement;
+                const expectedBreadcrumbs: LabeledRoute[] = [
+                    mockRootItem,
+                    { label: series.full, route: [...mockRootItem.route, series.route] },
+                    { label: section.full, route: labeledSectionRoute.route },
+                    { label: complex.complexId.short, route: [] },
+                ];
+
+                const breadcrumbSignal = service.getBreadcrumbItems(
+                    mockViewContext,
+                    mockComplex,
+                    mockSeries,
+                    mockSection
+                );
+                const actualBreadcrumbs = breadcrumbSignal();
+
+                expectToBe(actualBreadcrumbs.length, 4);
+                expectToEqual(actualBreadcrumbs, expectedBreadcrumbs);
+            });
+
+            it('... should return overview breadcrumbs if no special view and no complex is active', () => {
+                const series = expectedSelectedEditionSeries;
+                const section = expectedSelectedEditionSection;
+
+                mockViewContext.set({ name: 'graph', isIntro: false, isPreface: false, isRowtables: false });
+                mockComplex.set(null);
+                mockSeries.set(series);
+                mockSection.set(section);
+
+                const expectedBreadcrumbs: LabeledRoute[] = [
+                    mockRootItem,
+                    { label: series.series.full, route: [...mockRootItem.route, series.series.route] },
+                    { label: section.section.full, route: [] },
+                    { label: '', route: [] },
+                ];
+
+                const breadcrumbSignal = service.getBreadcrumbItems(
+                    mockViewContext,
+                    mockComplex,
+                    mockSeries,
+                    mockSection
+                );
+                const actualBreadcrumbs = breadcrumbSignal();
+
+                expectToBe(actualBreadcrumbs.length, 4);
+                expectToEqual(actualBreadcrumbs, expectedBreadcrumbs);
+            });
+
+            it('... should return intro breadcrumbs if intro view, but no complex is active', () => {
+                const expectedSeries = expectedSelectedEditionSeries;
+                const expectedSection = expectedSelectedEditionSection;
+
+                mockViewContext.set({ name: 'intro', isIntro: true, isPreface: false, isRowtables: false });
+                mockComplex.set(null);
+                mockSeries.set(expectedSeries);
+                mockSection.set(expectedSection);
+
+                const expectedBreadcrumbs: LabeledRoute[] = [
+                    mockRootItem,
+                    { label: expectedSeries.series.full, route: [...mockRootItem.route, expectedSeries.series.route] },
+                    { label: expectedSection.section.full, route: expectedSection.labeledRoute.route },
+                    { label: EDITION_INTRO.full, route: [] },
+                ];
+
+                const breadcrumbSignal = service.getBreadcrumbItems(
+                    mockViewContext,
+                    mockComplex,
+                    mockSeries,
+                    mockSection
+                );
+                const actualBreadcrumbs = breadcrumbSignal();
+
+                expectToBe(actualBreadcrumbs.length, 4);
+                expectToEqual(actualBreadcrumbs, expectedBreadcrumbs);
+            });
+
+            it('... should update dynamically when the underlying signals change', () => {
+                mockViewContext.set({ name: 'preface', isIntro: false, isPreface: true, isRowtables: false });
+                mockComplex.set(null);
+                mockSeries.set(null);
+                mockSection.set(null);
+
+                const breadcrumbSignal = service.getBreadcrumbItems(
+                    mockViewContext,
+                    mockComplex,
+                    mockSeries,
+                    mockSection
+                );
+
+                const prefaceBreadcrumbs = breadcrumbSignal();
+                expectToBe(prefaceBreadcrumbs.length, 2);
+                expectToBe(prefaceBreadcrumbs[1].label, PREFACE.short);
+
+                mockViewContext.set({ name: 'rowtables', isIntro: false, isPreface: false, isRowtables: true });
+
+                const rowtablesBreadcrumbs = breadcrumbSignal();
+                expectToBe(rowtablesBreadcrumbs.length, 2);
+                expectToBe(rowtablesBreadcrumbs[1].label, ROWTABLES.full);
+            });
+        });
+
+        describe('#_getComplexBreadcrumbs()', () => {
+            it('... should have a method `_getComplexBreadcrumbs`', () => {
+                expect((service as any)._getComplexBreadcrumbs).toBeDefined();
+            });
+
+            it('... should return expected breadcrumbs for complex', () => {
+                const complex = expectedSelectedEditionComplex;
+                const { series, section, labeledSectionRoute } = complex.pubStatement;
+
+                const expectedBreadcrumbs: LabeledRoute[] = [
+                    mockRootItem,
+                    { label: series.full, route: [...mockRootItem.route, series.route] },
+                    { label: section.full, route: labeledSectionRoute.route },
+                    { label: complex.complexId.short, route: [] },
+                ];
+
+                const actualBreadcrumbs = (service as any)._getComplexBreadcrumbs(mockRootItem, complex);
+
+                expectToBe(actualBreadcrumbs.length, 4);
+                expectToEqual(actualBreadcrumbs, expectedBreadcrumbs);
+            });
+        });
+
+        describe('#_getOverviewBreadcrumbs()', () => {
+            it('... should have a method _getOverviewBreadcrumbs', () => {
+                expect((service as any)._getOverviewBreadcrumbs).toBeDefined();
+            });
+
+            const testCases = [
+                {
+                    desc: ' root breadcrumbs for overview (without series and section)',
+                    context: { name: 'graph', isIntro: false, isPreface: false, isRowtables: false },
+                    series: () => null,
+                    section: () => null,
+                    expected: () => [
+                        { ...mockRootItem, route: [] },
+                        { label: '', route: [] },
+                    ],
+                },
+                {
+                    desc: 'breadcrumbs for a series only (without section)',
+                    context: { name: 'graph', isIntro: false, isPreface: false, isRowtables: false },
+                    series: () => expectedSelectedEditionSeries,
+                    section: () => null,
+                    expected: () => [
+                        mockRootItem,
+                        { label: expectedSelectedEditionSeries.series.full, route: [] },
+                        { label: '', route: [] },
+                    ],
+                },
+                {
+                    desc: 'breadcrumbs for a series and section (without intro)',
+                    context: { name: 'graph', isIntro: false, isPreface: false, isRowtables: false },
+                    series: () => expectedSelectedEditionSeries,
+                    section: () => expectedSelectedEditionSection,
+                    expected: () => [
+                        mockRootItem,
+                        {
+                            label: expectedSelectedEditionSeries.series.full,
+                            route: [...mockRootItem.route, expectedSelectedEditionSeries.series.route],
+                        },
+                        { label: expectedSelectedEditionSection.section.full, route: [] },
+                        { label: '', route: [] },
+                    ],
+                },
+                {
+                    desc: 'breadcrumbs for a series, section and active intro view',
+                    context: { name: 'intro', isIntro: true, isPreface: false, isRowtables: false },
+                    series: () => expectedSelectedEditionSeries,
+                    section: () => expectedSelectedEditionSection,
+                    expected: () => [
+                        mockRootItem,
+                        {
+                            label: expectedSelectedEditionSeries.series.full,
+                            route: [...mockRootItem.route, expectedSelectedEditionSeries.series.route],
+                        },
+                        {
+                            label: expectedSelectedEditionSection.section.full,
+                            route: expectedSelectedEditionSection.labeledRoute.route,
+                        },
+                        { label: EDITION_INTRO.full, route: [] },
+                    ],
+                },
+            ];
+
+            it.each(testCases)('... should return expected $desc', ({ context, series, section, expected }) => {
+                const expectedBreadcrumbs = expected();
+
+                const actualBreadcrumbs: LabeledRoute[] = (service as any)._getOverviewBreadcrumbs(
+                    mockRootItem,
+                    context,
+                    series(),
+                    section()
+                );
+
+                expectToBe(actualBreadcrumbs.length, expectedBreadcrumbs.length);
+                expectToEqual(actualBreadcrumbs, expectedBreadcrumbs);
+            });
+        });
+    });
+});

--- a/src/app/views/edition-view/services/edition-breadcrumb.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-breadcrumb.service.spec.ts
@@ -30,9 +30,9 @@ describe('EditionBreadcrumbService', () => {
         isPreface: false,
         isRowtables: false,
     });
-    const mockComplex = signal<EditionComplex>(null);
-    const mockSeries = signal<EditionOutlineSeries>(null);
-    const mockSection = signal<EditionOutlineSection>(null);
+    const mockComplex = signal<EditionComplex | null>(null);
+    const mockSeries = signal<EditionOutlineSeries | null>(null);
+    const mockSection = signal<EditionOutlineSection | null>(null);
 
     const { EDITION, SERIES, EDITION_INTRO, PREFACE, ROWTABLES } = EDITION_ROUTE_CONSTANTS;
     const mockRootItem: LabeledRoute = {

--- a/src/app/views/edition-view/services/edition-breadcrumb.service.ts
+++ b/src/app/views/edition-view/services/edition-breadcrumb.service.ts
@@ -1,0 +1,130 @@
+import { computed, Injectable, Signal } from '@angular/core';
+
+import { LabeledRoute } from '@awg-shared/models/labeled-route.model';
+
+import { EDITION_ROUTE_CONSTANTS } from '../edition-routes.constants';
+import { EditionComplex } from '../models/edition-complex.model';
+import { EditionViewContext } from '../models/edition-data.model';
+import { EditionOutlineSection, EditionOutlineSeries } from '../models/edition-outline.model';
+
+/**
+ * The EditionBreadcrumbService.
+ *
+ * It provides the labeled route items for the breadcrumb of the edition view.
+ */
+@Injectable({
+    providedIn: 'root',
+})
+export class EditionBreadcrumbService {
+    /**
+     * Public method: getBreadcrumbItems.
+     *
+     * It returns the labeled route items for the breadcrumb of the edition view.
+     *
+     * @param {Signal<EditionViewContext>} viewContext The current view context.
+     * @param {Signal<EditionComplex | null>} editionComplex The selected edition complex.
+     * @param {Signal<EditionOutlineSeries | null>} editionSeries The selected edition series.
+     * @param {Signal<EditionOutlineSection | null>} editionSection The selected edition section.
+     * @returns {Signal<LabeledRoute[]>} The labeled route items for the breadcrumb of the edition view.
+     */
+    getBreadcrumbItems(
+        viewContext: Signal<EditionViewContext>,
+        editionComplex: Signal<EditionComplex | null>,
+        editionSeries: Signal<EditionOutlineSeries | null>,
+        editionSection: Signal<EditionOutlineSection | null>
+    ): Signal<LabeledRoute[]> {
+        return computed<LabeledRoute[]>(() => {
+            const context = viewContext();
+            const complex = editionComplex();
+            const series = editionSeries();
+            const section = editionSection();
+
+            const { EDITION, SERIES, PREFACE, ROWTABLES } = EDITION_ROUTE_CONSTANTS;
+
+            const editionRootRoute = [EDITION.route, SERIES.route];
+            const editionRootItem: LabeledRoute = { label: EDITION.short, route: editionRootRoute };
+
+            if (context.isPreface) {
+                return [editionRootItem, { label: PREFACE.short, route: [] }];
+            }
+
+            if (context.isRowtables) {
+                return [editionRootItem, { label: ROWTABLES.full, route: [] }];
+            }
+
+            if (complex) {
+                return this._getComplexBreadcrumbs(editionRootItem, complex);
+            }
+
+            return this._getOverviewBreadcrumbs(editionRootItem, context, series, section);
+        });
+    }
+
+    /**
+     * Private method: _getComplexBreadcrumbs.
+     *
+     * It returns the labeled route items for the breadcrumb of a selected edition complex.
+     *
+     * @param {LabeledRoute} rootItem The root labeled route item.
+     * @param {EditionComplex} complex The selected edition complex.
+     * @returns {LabeledRoute[]} The labeled route items for the breadcrumb of a selected edition complex.
+     */
+    private _getComplexBreadcrumbs(rootItem: LabeledRoute, complex: EditionComplex): LabeledRoute[] {
+        const { series, section, labeledSectionRoute } = complex.pubStatement;
+
+        return [
+            rootItem,
+            { label: series.full, route: [...rootItem.route, series.route] },
+            { label: section.full, route: labeledSectionRoute.route },
+            { label: complex.complexId.short, route: [] },
+        ];
+    }
+
+    /**
+     * Private method: _getOverviewBreadcrumbs.
+     *
+     * It returns the labeled route items for the breadcrumb of the overview pages (series, section, intro).
+     *
+     * @param {LabeledRoute} rootItem The root labeled route item.
+     * @param {EditionViewContext} context The current view context.
+     * @param {EditionOutlineSeries | null} series The selected edition series.
+     * @param {EditionOutlineSection | null} section The selected edition section.
+     * @returns {LabeledRoute[]} The labeled route items for the breadcrumb of the overview page.
+     */
+    private _getOverviewBreadcrumbs(
+        rootItem: LabeledRoute,
+        context: EditionViewContext,
+        series: EditionOutlineSeries | null,
+        section: EditionOutlineSection | null
+    ): LabeledRoute[] {
+        const { EDITION_INTRO } = EDITION_ROUTE_CONSTANTS;
+
+        if (series) {
+            const seriesRouteSegment = section ? [...rootItem.route, series.series.route] : [];
+
+            const items: LabeledRoute[] = [
+                rootItem,
+                { label: series.series.full, route: seriesRouteSegment },
+                ...(section
+                    ? [
+                          {
+                              label: section.section.full,
+                              route: context.isIntro ? section.labeledRoute.route : [],
+                          },
+                      ]
+                    : []),
+                ...(section && context.isIntro ? [{ label: EDITION_INTRO.full, route: [] }] : []),
+            ];
+
+            if (!context.isIntro) {
+                items.push({ label: '', route: [] }); // Add empty item to include final slash
+            }
+            return items;
+        }
+
+        return [
+            { ...rootItem, route: [] },
+            { label: '', route: [] },
+        ];
+    }
+}

--- a/src/app/views/edition-view/services/edition-view.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-view.service.spec.ts
@@ -144,7 +144,7 @@ describe('EditionViewService', () => {
         });
 
         it('... should return correct context for `intro`', () => {
-            currentViewNameSpy.mockReturnValue('intro');
+            currentViewNameSpy.mockImplementation(() => 'intro');
 
             const context = service.viewContext();
 
@@ -155,7 +155,7 @@ describe('EditionViewService', () => {
         });
 
         it('... should return correct context for `preface`', () => {
-            currentViewNameSpy.mockReturnValue('preface');
+            currentViewNameSpy.mockImplementation(() => 'preface');
 
             const context = service.viewContext();
 
@@ -166,7 +166,7 @@ describe('EditionViewService', () => {
         });
 
         it('... should return correct context for `rowtables`', () => {
-            currentViewNameSpy.mockReturnValue('rowtables');
+            currentViewNameSpy.mockImplementation(() => 'rowtables');
 
             const context = service.viewContext();
 
@@ -177,7 +177,7 @@ describe('EditionViewService', () => {
         });
 
         it('... should handle other view names gracefully', () => {
-            currentViewNameSpy.mockReturnValue('other-view');
+            currentViewNameSpy.mockImplementation(() => 'other-view');
 
             const context = service.viewContext();
 

--- a/src/app/views/edition-view/services/edition-view.service.ts
+++ b/src/app/views/edition-view/services/edition-view.service.ts
@@ -7,6 +7,7 @@ import { distinctUntilChanged, filter, map, merge, startWith } from 'rxjs';
 import { LoadingService } from '@awg-shared/loading/loading.service';
 import {
     EditionDataAssetsKeys,
+    EditionViewContext,
     EditionViewData,
     EditionViewDataTypeMapping,
     EditionViewKey,
@@ -83,14 +84,27 @@ export class EditionViewService {
      *
      * It holds the state of the currently active view.
      */
-    readonly viewContext = computed(() => {
+    readonly viewContext = computed<EditionViewContext>(() => {
         const viewName = this._currentViewName();
-        return {
-            name: viewName,
-            isIntro: viewName === 'intro',
-            isPreface: viewName === 'preface',
-            isRowtables: viewName === 'rowtables',
-        };
+
+        switch (viewName) {
+            case 'intro':
+                return { name: 'intro', isIntro: true, isPreface: false, isRowtables: false };
+
+            case 'preface':
+                return { name: 'preface', isIntro: false, isPreface: true, isRowtables: false };
+
+            case 'rowtables':
+                return { name: 'rowtables', isIntro: false, isPreface: false, isRowtables: true };
+
+            default:
+                return {
+                    name: viewName,
+                    isIntro: false,
+                    isPreface: false,
+                    isRowtables: false,
+                };
+        }
     });
 
     /**


### PR DESCRIPTION
This PR refactors the handling of breadcrums in the edition view and moves related logic into separate component and service.