### PR TITLE
refactor(app): use test helper for component stubs

### DIFF
--- a/src/app/core/footer/footer-poweredby/footer-poweredby.component.spec.ts
+++ b/src/app/core/footer/footer-poweredby/footer-poweredby.component.spec.ts
@@ -175,6 +175,16 @@ describe('FooterPoweredbyComponent (DONE)', () => {
                 expectToEqual(logoCmps[2].logoData(), expectedLogosData['bootstrap']);
             });
 
+            it('... should have default linkClass on logo components', () => {
+                const logoDes = getAndExpectDebugElementByDirective(compDe, LogoStubComponent, 3, 3);
+
+                logoDes.forEach(logoDe => {
+                    const logoCmp = logoDe.injector.get(LogoStubComponent) as LogoStubComponent;
+
+                    expectToBe(logoCmp.linkClass(), 'awg-logo-link');
+                });
+            });
+
             it('... should contain one anchor #dev-preview-link with faIcon', () => {
                 getAndExpectDebugElementByCss(compDe, 'a#dev-preview-link', 1, 1);
 

--- a/src/app/core/footer/footer-poweredby/footer-poweredby.component.spec.ts
+++ b/src/app/core/footer/footer-poweredby/footer-poweredby.component.spec.ts
@@ -1,10 +1,11 @@
-import { Component, DebugElement, input, isSignal } from '@angular/core';
+import { DebugElement, isSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { faScrewdriverWrench, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 
+import { LogoStubComponent } from '@testing/component-stubs';
 import {
     expectToBe,
     expectToEqual,
@@ -14,20 +15,11 @@ import {
 
 import { LogoComponent } from '@awg-shared/logos/logo.component';
 import { LOGOS_DATA } from '@awg-shared/logos/logos.data';
-import { Logo, Logos } from '@awg-shared/logos/logos.model';
+import { Logos } from '@awg-shared/logos/logos.model';
 import { META_DATA } from '@awg-shared/meta/meta.data';
 import { MetaPage, MetaSectionTypes } from '@awg-shared/meta/meta.model';
 
 import { FooterPoweredbyComponent } from './footer-poweredby.component';
-
-// Mock components
-@Component({
-    selector: 'awg-logo',
-    template: '',
-})
-class LogoStubComponent {
-    logoData = input.required<Logo>();
-}
 
 describe('FooterPoweredbyComponent (DONE)', () => {
     let component: FooterPoweredbyComponent;

--- a/src/app/core/footer/footer.component.spec.ts
+++ b/src/app/core/footer/footer.component.spec.ts
@@ -1,8 +1,14 @@
-import { Component, DebugElement, input } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+    FooterCopyrightStubComponent,
+    FooterDeclarationStubComponent,
+    FooterPoweredbyStubComponent,
+    LogoStubComponent,
+} from '@testing/component-stubs';
 import {
     expectToBe,
     expectToContain,
@@ -13,7 +19,7 @@ import {
 
 import { LogoComponent } from '@awg-shared/logos/logo.component';
 import { LOGOS_DATA } from '@awg-shared/logos/logos.data';
-import { Logo, Logos } from '@awg-shared/logos/logos.model';
+import { Logos } from '@awg-shared/logos/logos.model';
 import { META_DATA } from '@awg-shared/meta/meta.data';
 import { MetaPage, MetaSectionTypes } from '@awg-shared/meta/meta.model';
 
@@ -22,40 +28,6 @@ import { FooterDeclarationComponent } from './footer-declaration/footer-declarat
 import { FooterPoweredbyComponent } from './footer-poweredby/footer-poweredby.component';
 
 import { FooterComponent } from './footer.component';
-
-// Mock components
-@Component({
-    selector: 'awg-footer-copyright',
-    template: '',
-})
-class FooterCopyrightStubComponent {
-    pageMetaData = input.required<MetaPage>();
-}
-
-@Component({
-    selector: 'awg-footer-declaration',
-    template: '',
-})
-class FooterDeclarationStubComponent {
-    pageMetaData = input.required<MetaPage>();
-}
-
-@Component({
-    selector: 'awg-logo',
-    template: '',
-})
-class LogoStubComponent {
-    logoData = input.required<Logo>();
-}
-
-@Component({
-    selector: 'awg-footer-poweredby',
-    template: '',
-})
-class FooterPoweredbyStubComponent {
-    logosData = input.required<Logos>();
-    pageMetaData = input.required<MetaPage>();
-}
 
 describe('FooterComponent (DONE)', () => {
     let component: FooterComponent;

--- a/src/app/core/footer/footer.component.spec.ts
+++ b/src/app/core/footer/footer.component.spec.ts
@@ -213,6 +213,16 @@ describe('FooterComponent (DONE)', () => {
                     expectToEqual(logoCmps[1].logoData(), expectedLogosData['sagw']);
                     expectToEqual(logoCmps[2].logoData(), expectedLogosData['snf']);
                 });
+
+                it('... should have default linkClass on logo components', () => {
+                    const logoDes = getAndExpectDebugElementByDirective(compDe, LogoStubComponent, 3, 3);
+
+                    logoDes.forEach(logoDe => {
+                        const logoCmp = logoDe.injector.get(LogoStubComponent) as LogoStubComponent;
+
+                        expectToBe(logoCmp.linkClass(), 'awg-logo-link');
+                    });
+                });
             });
 
             describe('secondary bottom footer', () => {

--- a/src/app/core/navbar/navbar.component.spec.ts
+++ b/src/app/core/navbar/navbar.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, input, isSignal } from '@angular/core';
+import { DebugElement, isSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
 
@@ -8,6 +8,7 @@ type Spy = ReturnType<typeof vi.spyOn>;
 import { NgbCollapseConfig } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import { LogoStubComponent, NavbarDropdownLinkStubComponent, NavbarItemStubComponent } from '@testing/component-stubs';
 import { EditionStateHelper } from '@testing/edition-state-helper';
 import {
     expectSpyCall,
@@ -21,7 +22,7 @@ import {
 
 import { LogoComponent } from '@awg-shared/logos/logo.component';
 import { LOGOS_DATA } from '@awg-shared/logos/logos.data';
-import { Logo, Logos } from '@awg-shared/logos/logos.model';
+import { Logos } from '@awg-shared/logos/logos.model';
 import { LabeledRoute } from '@awg-shared/models/labeled-route.model';
 
 import { EDITION_GENERAL_LINKS } from '@awg-views/edition-view/edition-links.constants';
@@ -32,35 +33,7 @@ import { NavbarDropdownLinkComponent } from './navbar-dropdown-link/navbar-dropd
 import { NavbarItemComponent } from './navbar-item/navbar-item.component';
 import { NavbarComponent } from './navbar.component';
 import { NAVBAR_DROPDOWN_EDITION_SECTION_LINKS, NAVBAR_ITEMS } from './navbar.data';
-import { NavbarItem, NavbarItems } from './navbar.model';
-
-// Mock components
-@Component({
-    selector: 'awg-logo',
-    template: '',
-})
-class LogoStubComponent {
-    logoData = input.required<Logo>();
-}
-
-@Component({
-    selector: 'awg-navbar-dropdown-link',
-    template: '',
-})
-class NavbarDropdownLinkStubComponent {
-    label = input.required<string>();
-    route = input.required<string[]>();
-}
-
-@Component({
-    selector: 'awg-navbar-item',
-    template: '',
-})
-class NavbarItemStubComponent {
-    item = input.required<NavbarItem>();
-    id = input<string>('');
-    isDropdown = input<boolean>(false);
-}
+import { NavbarItems } from './navbar.model';
 
 describe('NavbarComponent (DONE)', () => {
     let component: NavbarComponent;

--- a/src/app/core/navbar/navbar.component.spec.ts
+++ b/src/app/core/navbar/navbar.component.spec.ts
@@ -287,6 +287,16 @@ describe('NavbarComponent (DONE)', () => {
                 });
             });
 
+            it('... should pass down expected linkClass to logo components', () => {
+                const logoDes = getAndExpectDebugElementByDirective(compDe, LogoStubComponent, 2, 2);
+
+                logoDes.forEach(logoDe => {
+                    const logoCmp = logoDe.injector.get(LogoStubComponent) as LogoStubComponent;
+
+                    expectToBe(logoCmp.linkClass(), 'navbar-brand');
+                });
+            });
+
             describe('... first nav-item link (home)', () => {
                 it('... should pass down home item to navbar item component', () => {
                     const navbarItemDes = getAndExpectDebugElementByDirective(compDe, NavbarItemStubComponent, 4, 4);

--- a/src/app/shared/table/table.component.spec.ts
+++ b/src/app/shared/table/table.component.spec.ts
@@ -12,6 +12,7 @@ import { faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons';
 import { NgbHighlight, NgbPaginationModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import { TwelveToneSpinnerStubComponent } from '@testing/component-stubs';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
@@ -42,13 +43,6 @@ class TablePaginationStubComponent {
     @Output()
     pageChangeRequest: EventEmitter<number> = new EventEmitter();
 }
-
-@Component({
-    selector: 'awg-twelve-tone-spinner',
-    template: '',
-    standalone: false,
-})
-class TwelveToneSpinnerStubComponent {}
 
 describe('TableComponent', () => {
     let component: TableComponent;

--- a/src/app/views/contact-view/contact-side-info/contact-side-info.component.spec.ts
+++ b/src/app/views/contact-view/contact-side-info/contact-side-info.component.spec.ts
@@ -1,9 +1,10 @@
-import { Component, DebugElement, input } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { ContactAddressStubComponent, ContactMapStubComponent } from '@testing/component-stubs';
 import {
     expectToBe,
     expectToEqual,
@@ -19,25 +20,6 @@ import { ContactAddressComponent } from '../contact-address/contact-address.comp
 import { ContactMapComponent } from '../contact-map/contact-map.component';
 
 import { ContactSideInfoComponent } from './contact-side-info.component';
-
-// Mock components
-@Component({
-    selector: 'awg-contact-address',
-    template: '',
-})
-class ContactAddressStubComponent {
-    pageMetaData = input.required<MetaPage>();
-    contactMetaData = input.required<MetaContact>();
-}
-
-@Component({
-    selector: 'awg-contact-map',
-    template: '',
-})
-class ContactMapStubComponent {
-    embedUrl = input.required<SafeResourceUrl>();
-    linkUrl = input.required<string>();
-}
 
 describe('ContactSideInfoComponent (DONE)', () => {
     let component: ContactSideInfoComponent;

--- a/src/app/views/contact-view/contact-view.component.spec.ts
+++ b/src/app/views/contact-view/contact-view.component.spec.ts
@@ -1,10 +1,15 @@
 import { DatePipe, registerLocaleData } from '@angular/common';
 import localeDeDE from '@angular/common/locales/de';
-import { Component, DebugElement, input, isSignal, LOCALE_ID } from '@angular/core';
+import { DebugElement, isSignal, LOCALE_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+    HeadingStubComponent,
+    MetaIdentifierBadgesStubComponent,
+    ScrollToTopButtonStubComponent,
+} from '@testing/component-stubs';
 import {
     expectToBe,
     expectToContain,
@@ -16,36 +21,12 @@ import {
 import { HeadingComponent } from '@awg-shared/heading/heading.component';
 import { MetaIdentifierBadgesComponent } from '@awg-shared/meta/meta-identifier-badges/meta-identifier-badges.component';
 import { META_DATA } from '@awg-shared/meta/meta.data';
-import { MetaContact, MetaIdentifiers, MetaPage, MetaSectionTypes } from '@awg-shared/meta/meta.model';
+import { MetaContact, MetaPage, MetaSectionTypes } from '@awg-shared/meta/meta.model';
 import { ScrollToTopButtonComponent } from '@awg-shared/scroll-to-top-button/scroll-to-top-button.component';
 
 import { ContactViewComponent } from './contact-view.component';
 
 registerLocaleData(localeDeDE);
-
-// Mock components
-@Component({
-    selector: 'awg-heading',
-    template: '',
-})
-class HeadingStubComponent {
-    readonly id = input.required<string>();
-    readonly title = input.required<string>();
-}
-
-@Component({
-    selector: 'awg-meta-identifier-badges',
-    template: '',
-})
-class MetaIdentifierBadgesStubComponent {
-    readonly identifiers = input.required<MetaIdentifiers>();
-}
-
-@Component({
-    selector: 'awg-scroll-to-top-button',
-    template: '',
-})
-class ScrollToTopButtonStubComponent {}
 
 describe('ContactViewComponent (DONE)', () => {
     let component: ContactViewComponent;

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
@@ -1,14 +1,4 @@
-import {
-    Component,
-    DebugElement,
-    DOCUMENT,
-    input,
-    Input,
-    isSignal,
-    output,
-    signal,
-    WritableSignal,
-} from '@angular/core';
+import { Component, DebugElement, DOCUMENT, input, Input, isSignal, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -42,6 +32,11 @@ import {
 import { EditionStateService } from '@awg-views/edition-view/services';
 import { EditionViewService } from '@awg-views/edition-view/services/edition-view.service';
 
+import {
+    AlertErrorStubComponent,
+    FullscreenToggleStubComponent,
+    TwelveToneSpinnerStubComponent,
+} from '@testing/component-stubs';
 import { EditionGraphComponent } from './edition-graph.component';
 
 // Mock components
@@ -55,31 +50,6 @@ class ModalStubComponent {
     open(modalContentSnippetKey: string): void {
         this.modalContent = modalContentSnippetKey;
     }
-}
-
-@Component({
-    selector: 'awg-alert-error',
-    template: '',
-})
-class AlertErrorStubComponent {
-    errorObject = input.required<any>();
-}
-
-@Component({
-    selector: 'awg-twelve-tone-spinner',
-    template: '',
-    standalone: false,
-})
-class TwelveToneSpinnerStubComponent {}
-
-@Component({
-    selector: 'awg-fullscreen-toggle',
-    template: '',
-    standalone: false,
-})
-class FullscreenToggleStubComponent {
-    readonly fsElement = input.required<HTMLElement>();
-    readonly toggleFullscreenRequest = output<boolean>();
 }
 
 @Component({
@@ -123,12 +93,10 @@ describe('EditionGraphComponent (DONE)', () => {
         };
 
         await TestBed.configureTestingModule({
-            imports: [AlertErrorStubComponent, FontAwesomeTestingModule],
+            imports: [AlertErrorStubComponent, FullscreenToggleStubComponent, FontAwesomeTestingModule],
             declarations: [
                 EditionGraphComponent,
-
                 CompileHtmlComponent,
-                FullscreenToggleStubComponent,
                 GraphVisualizerStubComponent,
                 ModalStubComponent,
                 TwelveToneSpinnerStubComponent,

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
@@ -7,6 +7,11 @@ type Spy = ReturnType<typeof vi.spyOn>;
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import {
+    AlertErrorStubComponent,
+    FullscreenToggleStubComponent,
+    TwelveToneSpinnerStubComponent,
+} from '@testing/component-stubs';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import { createMockViewData } from '@testing/edition-data-helper';
 import { EditionStateHelper } from '@testing/edition-state-helper';
@@ -32,11 +37,6 @@ import {
 import { EditionStateService } from '@awg-views/edition-view/services';
 import { EditionViewService } from '@awg-views/edition-view/services/edition-view.service';
 
-import {
-    AlertErrorStubComponent,
-    FullscreenToggleStubComponent,
-    TwelveToneSpinnerStubComponent,
-} from '@testing/component-stubs';
 import { EditionGraphComponent } from './edition-graph.component';
 
 // Mock components

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/construct-results/construct-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/construct-results/construct-results.component.spec.ts
@@ -9,8 +9,8 @@ import { EMPTY, Observable, of as observableOf } from 'rxjs';
 import { NgbAccordionDirective, NgbAccordionModule, NgbConfig } from '@ng-bootstrap/ng-bootstrap';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import { TwelveToneSpinnerStubComponent } from '@testing/component-stubs';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
-
 import {
     expectSpyCall,
     expectToBe,
@@ -21,6 +21,7 @@ import {
 } from '@testing/expect-helper';
 
 import { D3SimulationNode, D3SimulationNodeType, Triple } from '../models';
+
 import { ConstructResultsComponent } from './construct-results.component';
 
 // Mock components
@@ -44,13 +45,6 @@ class ForceGraphStubComponent {
     standalone: false,
 })
 class SparqlNoResultsStubComponent {}
-
-@Component({
-    selector: 'awg-twelve-tone-spinner',
-    template: '',
-    standalone: false,
-})
-class TwelveToneSpinnerStubComponent {}
 
 describe('ConstructResultsComponent (DONE)', () => {
     let component: ConstructResultsComponent;

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/select-results/select-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/select-results/select-results.component.spec.ts
@@ -9,6 +9,7 @@ import { EMPTY, Observable, lastValueFrom, of as observableOf } from 'rxjs';
 import { NgbAccordionDirective, NgbAccordionModule, NgbConfig } from '@ng-bootstrap/ng-bootstrap';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import { TwelveToneSpinnerStubComponent } from '@testing/component-stubs';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
@@ -43,13 +44,6 @@ class SparqlTableStubComponent {
     @Output()
     clickedTableRequest: EventEmitter<string> = new EventEmitter();
 }
-
-@Component({
-    selector: 'awg-twelve-tone-spinner',
-    template: '',
-    standalone: false,
-})
-class TwelveToneSpinnerStubComponent {}
 
 describe('SelectResultsComponent (DONE)', () => {
     let component: SelectResultsComponent;

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-no-results/sparql-no-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-no-results/sparql-no-results.component.spec.ts
@@ -109,6 +109,13 @@ describe('SparqlNoResultsComponent (DONE)', () => {
                 expectToBe(logoCmps.length, 1);
                 expectToEqual(logoCmps[0].logoData(), expectedLogosData['sparql']);
             });
+
+            it('... should have default linkClass on logo component', () => {
+                const logoDes = getAndExpectDebugElementByDirective(compDe, LogoStubComponent, 3, 3);
+                const logoCmp = logoDes[0].injector.get(LogoStubComponent) as LogoStubComponent;
+
+                expectToBe(logoCmp.linkClass(), 'awg-logo-link');
+            });
         });
     });
 });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-no-results/sparql-no-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-no-results/sparql-no-results.component.spec.ts
@@ -1,8 +1,9 @@
-import { Component, DebugElement, input } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { LogoStubComponent } from '@testing/component-stubs';
 import {
     expectToBe,
     expectToEqual,
@@ -12,18 +13,9 @@ import {
 
 import { LogoComponent } from '@awg-shared/logos/logo.component';
 import { LOGOS_DATA } from '@awg-shared/logos/logos.data';
-import { Logo, Logos } from '@awg-shared/logos/logos.model';
+import { Logos } from '@awg-shared/logos/logos.model';
 
 import { SparqlNoResultsComponent } from './sparql-no-results.component';
-
-// Mock components
-@Component({
-    selector: 'awg-logo',
-    template: '',
-})
-class LogoStubComponent {
-    logoData = input.required<Logo>();
-}
 
 describe('SparqlNoResultsComponent (DONE)', () => {
     let component: SparqlNoResultsComponent;

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-no-results/sparql-no-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/sparql-no-results/sparql-no-results.component.spec.ts
@@ -111,7 +111,7 @@ describe('SparqlNoResultsComponent (DONE)', () => {
             });
 
             it('... should have default linkClass on logo component', () => {
-                const logoDes = getAndExpectDebugElementByDirective(compDe, LogoStubComponent, 3, 3);
+                const logoDes = getAndExpectDebugElementByDirective(compDe, LogoStubComponent, 1, 1);
                 const logoCmp = logoDes[0].injector.get(LogoStubComponent) as LogoStubComponent;
 
                 expectToBe(logoCmp.linkClass(), 'awg-logo-link');

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.spec.ts
@@ -1,10 +1,11 @@
-import { Component, DebugElement, EventEmitter, Input, Output } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.spyOn>;
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import { LanguageSwitcherStubComponent } from '@testing/component-stubs';
 import {
     expectSpyCall,
     expectToBe,
@@ -18,19 +19,6 @@ import { RouterLinkStubDirective } from '@testing/router-stubs';
 import { IntroBlock } from '@awg-views/edition-view/models';
 
 import { EditionIntroNavComponent } from './edition-intro-nav.component';
-
-// Mock components
-@Component({
-    selector: 'awg-language-switcher',
-    template: '',
-    standalone: false,
-})
-class LanguageSwitcherStubComponent {
-    @Input()
-    currentLanguage: number;
-    @Output()
-    languageChangeRequest = new EventEmitter<number>();
-}
 
 describe('EditionIntroNavComponent (DONE)', () => {
     let component: EditionIntroNavComponent;

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
@@ -3,7 +3,6 @@ import {
     DebugElement,
     DOCUMENT,
     EventEmitter,
-    input,
     Input,
     isSignal,
     Output,
@@ -21,6 +20,7 @@ import { of as observableOf } from 'rxjs';
 
 import { NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 
+import { AlertErrorStubComponent, TwelveToneSpinnerStubComponent } from '@testing/component-stubs';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import { createMockViewData } from '@testing/edition-data-helper';
 import { EditionStateHelper } from '@testing/edition-state-helper';
@@ -60,21 +60,6 @@ import { EditionIntroComponent } from './edition-intro.component';
 class ModalStubComponent {
     open(): void {}
 }
-
-@Component({
-    selector: 'awg-alert-error',
-    template: '',
-})
-class AlertErrorStubComponent {
-    errorObject = input.required<any>();
-}
-
-@Component({
-    selector: 'awg-twelve-tone-spinner',
-    template: '',
-    standalone: false,
-})
-class TwelveToneSpinnerStubComponent {}
 
 @Component({
     selector: 'awg-edition-intro-content',

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/edition-report.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/edition-report.component.spec.ts
@@ -3,7 +3,6 @@ import {
     DebugElement,
     EventEmitter,
     inject as inject_1,
-    input,
     Input,
     isSignal,
     NgModule,
@@ -20,6 +19,7 @@ type Spy = ReturnType<typeof vi.spyOn>;
 
 import { NgbAccordionModule, NgbConfig, NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 
+import { AlertErrorStubComponent, TwelveToneSpinnerStubComponent } from '@testing/component-stubs';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import { createMockViewData } from '@testing/edition-data-helper';
 import { EditionStateHelper } from '@testing/edition-state-helper';
@@ -62,21 +62,6 @@ import { EditionReportComponent } from './edition-report.component';
 class ModalStubComponent {
     open(): void {}
 }
-
-@Component({
-    selector: 'awg-alert-error',
-    template: '',
-})
-class AlertErrorStubComponent {
-    errorObject = input.required<any>();
-}
-
-@Component({
-    selector: 'awg-twelve-tone-spinner',
-    template: '',
-    standalone: false,
-})
-class TwelveToneSpinnerStubComponent {}
 
 @Component({
     selector: 'awg-source-list',

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-accolade.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-accolade.component.spec.ts
@@ -3,7 +3,6 @@ import {
     DebugElement,
     EventEmitter,
     inject,
-    input,
     Input,
     isSignal,
     NgModule,
@@ -19,6 +18,7 @@ type Spy = ReturnType<typeof vi.spyOn>;
 import { NgbAccordionModule, NgbConfig } from '@ng-bootstrap/ng-bootstrap';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import { FullscreenToggleStubComponent } from '@testing/component-stubs';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
     expectSpyCall,
@@ -112,14 +112,6 @@ class EditionSvgSheetFooterStubComponent {
         complexId: string;
         sheetId: string;
     }> = new EventEmitter();
-}
-
-@Component({
-    selector: 'awg-fullscreen-toggle',
-    template: '',
-})
-class FullscreenToggleStubComponent {
-    readonly fsElement = input.required<HTMLElement>();
 }
 
 describe('EditionAccoladeComponent (DONE)', () => {

--- a/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.spec.ts
@@ -1,19 +1,14 @@
-import {
-    Component,
-    DebugElement,
-    EventEmitter,
-    input,
-    Input,
-    isSignal,
-    Output,
-    signal,
-    WritableSignal,
-} from '@angular/core';
+import { DebugElement, isSignal, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.spyOn>;
 
+import {
+    AlertErrorStubComponent,
+    LanguageSwitcherStubComponent,
+    TwelveToneSpinnerStubComponent,
+} from '@testing/component-stubs';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import { createMockViewData } from '@testing/edition-data-helper';
 import {
@@ -36,34 +31,6 @@ import { EditionGlyphService } from '@awg-views/edition-view/services';
 import { EditionViewService } from '@awg-views/edition-view/services/edition-view.service';
 
 import { EditionPrefaceComponent } from './edition-preface.component';
-
-// Mock components
-@Component({
-    selector: 'awg-alert-error',
-    template: '',
-})
-class AlertErrorStubComponent {
-    errorObject = input.required<any>();
-}
-
-@Component({
-    selector: 'awg-language-switcher',
-    template: '',
-    standalone: false,
-})
-class LanguageSwitcherStubComponent {
-    @Input()
-    currentLanguage: number;
-    @Output()
-    languageChangeRequest = new EventEmitter<number>();
-}
-
-@Component({
-    selector: 'awg-twelve-tone-spinner',
-    template: '',
-    standalone: false,
-})
-class TwelveToneSpinnerStubComponent {}
 
 describe('EditionPrefaceComponent (DONE)', () => {
     let component: EditionPrefaceComponent;

--- a/src/app/views/edition-view/edition-outlets/edition-rowtables/edition-rowtables.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-rowtables/edition-rowtables.component.spec.ts
@@ -1,9 +1,10 @@
-import { Component, DebugElement, input, isSignal, signal, WritableSignal } from '@angular/core';
+import { DebugElement, isSignal, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import { AlertErrorStubComponent, TwelveToneSpinnerStubComponent } from '@testing/component-stubs';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import { createMockViewData } from '@testing/edition-data-helper';
 import {
@@ -26,22 +27,6 @@ import {
 import { EditionViewService } from '@awg-views/edition-view/services/edition-view.service';
 
 import { EditionRowtablesComponent } from './edition-rowtables.component';
-
-// Mock components
-@Component({
-    selector: 'awg-alert-error',
-    template: '',
-})
-class AlertErrorStubComponent {
-    errorObject = input.required<any>();
-}
-
-@Component({
-    selector: 'awg-twelve-tone-spinner',
-    template: '',
-    standalone: false,
-})
-class TwelveToneSpinnerStubComponent {}
 
 describe('EditionRowTablesComponent (DONE)', () => {
     let component: EditionRowtablesComponent;

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail-disclaimer/edition-section-detail-disclaimer.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail-disclaimer/edition-section-detail-disclaimer.component.spec.ts
@@ -1,21 +1,12 @@
-import { Component, DebugElement, input, model } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { expectToBe, expectToEqual, getAndExpectDebugElementByDirective } from '@testing/expect-helper';
+import { AlertInfoStubComponent } from '@testing/component-stubs';
+import { expectToEqual, getAndExpectDebugElementByDirective } from '@testing/expect-helper';
 
 import { EditionSectionDetailDisclaimerComponent } from './edition-section-detail-disclaimer.component';
-
-// Mock components
-@Component({
-    selector: 'awg-alert-info',
-    template: '',
-})
-class AlertInfoStubComponent {
-    infoMessage = input<string>('');
-    isOpen = model<boolean>(true);
-}
 
 describe('EditionSectionDetailDisclaimerComponent (DONE)', () => {
     let component: EditionSectionDetailDisclaimerComponent;
@@ -51,11 +42,11 @@ describe('EditionSectionDetailDisclaimerComponent (DONE)', () => {
                 getAndExpectDebugElementByDirective(compDe, AlertInfoStubComponent, 1, 1);
             });
 
-            it('... should pass down empty default values to AlertInfoComponent (`infoMessage`)', () => {
+            it('... should throw when accessing AlertInfoComponent inputs (`infoMessage`) due to missing initial data binding', () => {
                 const alertInfoDes = getAndExpectDebugElementByDirective(compDe, AlertInfoStubComponent, 1, 1);
                 const alertInfoCmp = alertInfoDes[0].injector.get(AlertInfoStubComponent) as AlertInfoStubComponent;
 
-                expectToBe(alertInfoCmp.infoMessage(), '');
+                expect(() => alertInfoCmp.infoMessage()).toThrow();
             });
         });
     });

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail-overview/edition-section-detail-overview.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail-overview/edition-section-detail-overview.component.spec.ts
@@ -1,8 +1,14 @@
-import { Component, DebugElement, Input, isSignal } from '@angular/core';
+import { DebugElement, isSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import {
+    EditionSectionDetailComplexCardStubComponent,
+    EditionSectionDetailDisclaimerStubComponent,
+    EditionSectionDetailIntroCardStubComponent,
+    EditionSectionDetailPlaceholderStubComponent,
+} from '@testing/component-stubs';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import { EditionStateHelper } from '@testing/edition-state-helper';
 import {
@@ -13,52 +19,10 @@ import {
 } from '@testing/expect-helper';
 import { RouterLinkStubDirective } from '@testing/router-stubs';
 
-import { EditionOutlineComplexItem, EditionOutlineSection, EditionOutlineSeries } from '@awg-views/edition-view/models';
+import { EditionOutlineSection, EditionOutlineSeries } from '@awg-views/edition-view/models';
 import { EditionStateService } from '@awg-views/edition-view/services';
 
 import { EditionSectionDetailOverviewComponent } from './edition-section-detail-overview.component';
-
-// Mock components
-@Component({
-    selector: 'awg-edition-section-detail-complex-card',
-    template: '',
-    standalone: false,
-})
-class EditionSectionDetailComplexCardStubComponent {
-    @Input()
-    complexes: EditionOutlineComplexItem[];
-}
-
-@Component({
-    selector: 'awg-edition-section-detail-disclaimer',
-    template: '',
-    standalone: false,
-})
-class EditionSectionDetailDisclaimerStubComponent {}
-
-@Component({
-    selector: 'awg-edition-section-detail-intro-card',
-    template: '',
-    standalone: false,
-})
-class EditionSectionDetailIntroCardStubComponent {
-    @Input()
-    selectedSeries: EditionOutlineSeries;
-    @Input()
-    selectedSection: EditionOutlineSection;
-}
-
-@Component({
-    selector: 'awg-edition-section-detail-placeholder',
-    template: '',
-    standalone: false,
-})
-class EditionSectionDetailPlaceholderStubComponent {
-    @Input()
-    selectedSeries: EditionOutlineSeries;
-    @Input()
-    selectedSection: EditionOutlineSection;
-}
 
 describe('EditionSectionDetailOverviewComponent', () => {
     let component: EditionSectionDetailOverviewComponent;

--- a/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail-placeholder/edition-section-detail-placeholder.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-series-detail/edition-section-detail/edition-section-detail-placeholder/edition-section-detail-placeholder.component.spec.ts
@@ -1,24 +1,15 @@
-import { Component, DebugElement, input, model } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { AlertInfoStubComponent } from '@testing/component-stubs';
 import { EditionStateHelper } from '@testing/edition-state-helper';
-import { expectToBe, expectToEqual, getAndExpectDebugElementByDirective } from '@testing/expect-helper';
+import { expectToEqual, getAndExpectDebugElementByDirective } from '@testing/expect-helper';
 
 import { EditionOutlineSection, EditionOutlineSeries } from '@awg-views/edition-view/models';
 
 import { EditionSectionDetailPlaceholderComponent } from './edition-section-detail-placeholder.component';
-
-// Mock components
-@Component({
-    selector: 'awg-alert-info',
-    template: '',
-})
-class AlertInfoStubComponent {
-    infoMessage = input<string>('');
-    isOpen = model<boolean>(true);
-}
 
 describe('EditionSectionDetailPlaceholderComponent', () => {
     let component: EditionSectionDetailPlaceholderComponent;
@@ -69,11 +60,11 @@ describe('EditionSectionDetailPlaceholderComponent', () => {
                 getAndExpectDebugElementByDirective(compDe, AlertInfoStubComponent, 1, 1);
             });
 
-            it('... should pass down empty default values to AlertInfoComponent (`infoMessage`)', () => {
+            it('... should throw when accessing AlertInfoComponent inputs (`infoMessage`) due to missing initial data binding', () => {
                 const alertInfoDes = getAndExpectDebugElementByDirective(compDe, AlertInfoStubComponent, 1, 1);
                 const alertInfoCmp = alertInfoDes[0].injector.get(AlertInfoStubComponent) as AlertInfoStubComponent;
 
-                expectToBe(alertInfoCmp.infoMessage(), '');
+                expect(() => alertInfoCmp.infoMessage()).toThrow();
             });
         });
     });

--- a/src/app/views/edition-view/edition-view.component.spec.ts
+++ b/src/app/views/edition-view/edition-view.component.spec.ts
@@ -1,12 +1,18 @@
 import { DatePipe, registerLocaleData } from '@angular/common';
 import localeDeDE from '@angular/common/locales/de';
-import { Component, DebugElement, input, isSignal, LOCALE_ID, signal, WritableSignal } from '@angular/core';
+import { DebugElement, isSignal, LOCALE_ID, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, RouterOutlet } from '@angular/router';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.spyOn>;
 
+import {
+    EditionBreadcrumbStubComponent,
+    EditionJumbotronStubComponent,
+    MetaIdentifierBadgesStubComponent,
+    ScrollToTopButtonStubComponent,
+} from '@testing/component-stubs';
 import { EditionStateHelper } from '@testing/edition-state-helper';
 import {
     expectSpyCall,
@@ -17,7 +23,6 @@ import {
 } from '@testing/expect-helper';
 
 import { MetaIdentifierBadgesComponent } from '@awg-shared/meta/meta-identifier-badges/meta-identifier-badges.component';
-import { MetaIdentifiers } from '@awg-shared/meta/meta.model';
 import { LabeledRoute } from '@awg-shared/models/labeled-route.model';
 import { ScrollToTopButtonComponent } from '@awg-shared/scroll-to-top-button/scroll-to-top-button.component';
 
@@ -35,38 +40,6 @@ import { EditionViewService } from './services/edition-view.service';
 import { EditionViewComponent } from './edition-view.component';
 
 registerLocaleData(localeDeDE);
-
-// Mock components
-@Component({
-    selector: 'awg-scroll-to-top-button',
-    template: '',
-})
-class ScrollToTopButtonStubComponent {}
-
-@Component({
-    selector: 'awg-edition-breadcrumb',
-    template: '',
-})
-class EditionBreadcrumbStubComponent {
-    readonly items = input.required<LabeledRoute[]>();
-}
-
-@Component({
-    selector: 'awg-edition-jumbotron',
-    template: '',
-})
-class EditionJumbotronStubComponent {
-    readonly id = input.required<string>();
-    readonly title = input.required<string>();
-}
-
-@Component({
-    selector: 'awg-meta-identifier-badges',
-    template: '',
-})
-class MetaIdentifierBadgesStubComponent {
-    readonly identifiers = input.required<MetaIdentifiers | null | undefined>();
-}
 
 describe('EditionViewComponent (DONE)', () => {
     let component: EditionViewComponent;

--- a/src/app/views/home-view/home-view.component.spec.ts
+++ b/src/app/views/home-view/home-view.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, input, isSignal, model } from '@angular/core';
+import { DebugElement, isSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router, RouterLink } from '@angular/router';
 
@@ -6,6 +6,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.spyOn>;
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import {
+    AlertInfoStubComponent,
+    HeadingStubComponent,
+    HomeViewCardStubComponent,
+    ScrollToTopButtonStubComponent,
+} from '@testing/component-stubs';
 import { EditionStateHelper } from '@testing/edition-state-helper';
 import {
     expectToBe,
@@ -30,39 +36,6 @@ import { HOME_VIEW_CARD_DATA } from './home-view-card/home-view-card.data';
 import { HomeViewCard } from './home-view-card/home-view-card.model';
 
 import { HomeViewComponent } from './home-view.component';
-
-// Mock components
-@Component({
-    selector: 'awg-alert-info',
-    template: '',
-})
-class AlertInfoStubComponent {
-    infoMessage = input.required<string>();
-    isOpen = model<boolean>(true);
-}
-
-@Component({
-    selector: 'awg-heading',
-    template: '',
-})
-class HeadingStubComponent {
-    title = input.required<string>();
-    id = input.required<string>();
-}
-
-@Component({
-    selector: 'awg-home-view-card',
-    template: '',
-})
-class HomeViewCardStubComponent {
-    cardData = input.required<HomeViewCard>();
-}
-
-@Component({
-    selector: 'awg-scroll-to-top-button',
-    template: '',
-})
-class ScrollToTopButtonStubComponent {}
 
 /** Helper function */
 function getRouterlinks(sections: EditionOutlineSection[]): string[][] {

--- a/src/app/views/page-not-found-view/page-not-found-view.component.spec.ts
+++ b/src/app/views/page-not-found-view/page-not-found-view.component.spec.ts
@@ -1,10 +1,11 @@
-import { Component, DebugElement, input } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router, RouterLink } from '@angular/router';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import { HeadingStubComponent } from '@testing/component-stubs';
 import {
     expectToBe,
     expectToContain,
@@ -16,16 +17,6 @@ import { AppConfig } from '@awg-app/app.config';
 import { HeadingComponent } from '@awg-shared/heading/heading.component';
 
 import { PageNotFoundViewComponent } from './page-not-found-view.component';
-
-// Mock components
-@Component({
-    selector: 'awg-heading',
-    template: '',
-})
-class HeadingStubComponent {
-    title = input.required<string>();
-    id = input.required<string>();
-}
 
 describe('PageNotFoundViewComponent (DONE)', () => {
     let component: PageNotFoundViewComponent;

--- a/src/app/views/statistics-view/statistics-complex-breakdown/statistics-complex-breakdown.component.spec.ts
+++ b/src/app/views/statistics-view/statistics-complex-breakdown/statistics-complex-breakdown.component.spec.ts
@@ -1,8 +1,9 @@
-import { Component, DebugElement, input, isSignal } from '@angular/core';
+import { DebugElement, isSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { StatisticsProgressBarStubComponent } from '@testing/component-stubs';
 import {
     expectToBe,
     expectToContain,
@@ -20,21 +21,6 @@ import {
 import { StatisticsProgressBarComponent } from '../statistics-progress-bar/statistics-progress-bar.component';
 
 import { StatisticsComplexBreakdownComponent } from './statistics-complex-breakdown.component';
-
-// Mock components
-@Component({
-    selector: 'awg-statistics-progress-bar',
-    template: '',
-})
-class StatisticsProgressBarStubComponent {
-    config = input.required<StatisticsProgressBarConfig>();
-    headerLabel = input<string>();
-    height = input<string>('15px');
-    showPercentageLabel = input<boolean>(true);
-    boldPercentageLabel = input<boolean>(false);
-    customType = input<string>('');
-    useCustomTypeOnly = input<boolean>(false);
-}
 
 describe('StatisticsComplexBreakdownComponent', () => {
     let component: StatisticsComplexBreakdownComponent;

--- a/src/app/views/statistics-view/statistics-overall-progress/statistics-overall-progress.component.spec.ts
+++ b/src/app/views/statistics-view/statistics-overall-progress/statistics-overall-progress.component.spec.ts
@@ -1,8 +1,9 @@
-import { Component, DebugElement, input, isSignal } from '@angular/core';
+import { DebugElement, isSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { StatisticsProgressBarStubComponent } from '@testing/component-stubs';
 import {
     expectToBe,
     expectToContain,
@@ -11,25 +12,10 @@ import {
     getAndExpectDebugElementByDirective,
 } from '@testing/expect-helper';
 
-import { StatisticsOverallProgressData, StatisticsProgressBarConfig } from '../models/statistics.model';
+import { StatisticsOverallProgressData } from '../models/statistics.model';
 import { StatisticsProgressBarComponent } from '../statistics-progress-bar/statistics-progress-bar.component';
 
 import { StatisticsOverallProgressComponent } from './statistics-overall-progress.component';
-
-// Mock components
-@Component({
-    selector: 'awg-statistics-progress-bar',
-    template: '',
-})
-class StatisticsProgressBarStubComponent {
-    config = input.required<StatisticsProgressBarConfig>();
-    headerLabel = input<string>();
-    height = input<string>('15px');
-    showPercentageLabel = input<boolean>(true);
-    boldPercentageLabel = input<boolean>(false);
-    customType = input<string>('');
-    useCustomTypeOnly = input<boolean>(false);
-}
 
 describe('StatisticsOverallProgressComponent', () => {
     let component: StatisticsOverallProgressComponent;

--- a/src/app/views/statistics-view/statistics-series-breakdown/statistics-series-breakdown.component.spec.ts
+++ b/src/app/views/statistics-view/statistics-series-breakdown/statistics-series-breakdown.component.spec.ts
@@ -1,10 +1,11 @@
-import { Component, DebugElement, input, isSignal } from '@angular/core';
+import { DebugElement, isSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router, RouterLink } from '@angular/router';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import { StatisticsBreakdownBadgeStubComponent, StatisticsProgressBarStubComponent } from '@testing/component-stubs';
 import {
     expectSpyCall,
     expectToBe,
@@ -19,7 +20,6 @@ import { mockStatisticsData } from '@testing/mock-data';
 import { EDITION_ROUTE_CONSTANTS } from '@awg-views/edition-view/edition-routes.constants';
 
 import {
-    StatisticsComplexBreakdown,
     StatisticsProgressBarConfig,
     StatisticsSectionBreakdown,
     StatisticsSeriesBreakdown,
@@ -28,32 +28,6 @@ import { StatisticsBreakdownBadgeComponent } from '../statistics-breakdown-badge
 import { StatisticsProgressBarComponent } from '../statistics-progress-bar/statistics-progress-bar.component';
 
 import { StatisticsSeriesBreakdownComponent } from './statistics-series-breakdown.component';
-
-// Mock components
-
-@Component({
-    selector: 'awg-statistics-breakdown-badge',
-    template: '',
-})
-class StatisticsBreakdownBadgeStubComponent {
-    breakdown = input.required<StatisticsComplexBreakdown>();
-    containerClasses = input<string>('small text-muted');
-    showEmptyBadges = input<boolean>(false);
-}
-
-@Component({
-    selector: 'awg-statistics-progress-bar',
-    template: '',
-})
-class StatisticsProgressBarStubComponent {
-    config = input.required<StatisticsProgressBarConfig>();
-    headerLabel = input<string>();
-    height = input<string>('15px');
-    showPercentageLabel = input<boolean>(true);
-    boldPercentageLabel = input<boolean>(false);
-    customType = input<string>('');
-    useCustomTypeOnly = input<boolean>(false);
-}
 
 describe('StatisticsSeriesBreakdownComponent', () => {
     let component: StatisticsSeriesBreakdownComponent;

--- a/src/app/views/statistics-view/statistics-summary/statistics-summary.component.spec.ts
+++ b/src/app/views/statistics-view/statistics-summary/statistics-summary.component.spec.ts
@@ -1,10 +1,11 @@
-import { Component, DebugElement, input, isSignal } from '@angular/core';
+import { DebugElement, isSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { faCheckCircle, faFolder, faList, faMusic, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { faCheckCircle, faFolder, faList, faMusic } from '@fortawesome/free-solid-svg-icons';
 
+import { StatisticsSummaryCardStubComponent } from '@testing/component-stubs';
 import {
     expectToBe,
     expectToContain,
@@ -17,18 +18,6 @@ import { StatisticsSummaryCardData, StatisticsSummaryData } from '../models/stat
 import { StatisticsSummaryCardComponent } from '../statistics-summary-card/statistics-summary-card.component';
 
 import { StatisticsSummaryComponent } from './statistics-summary.component';
-
-// Mock components
-@Component({
-    selector: 'awg-statistics-summary-card',
-    template: '',
-})
-class StatisticsSummaryCardStubComponent {
-    title = input.required<string>();
-    value = input.required<number | string>();
-    icon = input.required<IconDefinition>();
-    bgClass = input.required<string>();
-}
 
 describe('StatisticsSummaryComponent', () => {
     let component: StatisticsSummaryComponent;

--- a/src/app/views/statistics-view/statistics-view.component.spec.ts
+++ b/src/app/views/statistics-view/statistics-view.component.spec.ts
@@ -1,8 +1,15 @@
-import { Component, DebugElement, input, isSignal, signal, WritableSignal } from '@angular/core';
+import { DebugElement, isSignal, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
 
+import {
+    ScrollToTopButtonStubComponent,
+    StatisticsComplexBreakdownStubComponent,
+    StatisticsOverallProgressStubComponent,
+    StatisticsSeriesBreakdownStubComponent,
+    StatisticsSummaryStubComponent,
+} from '@testing/component-stubs';
 import {
     expectSpyCall,
     expectToBe,
@@ -20,7 +27,6 @@ import {
     Statistics,
     StatisticsComplexBreakdownData,
     StatisticsOverallProgressData,
-    StatisticsSeriesBreakdown,
     StatisticsSummaryData,
 } from './models/statistics.model';
 import { StatisticsService } from './services/statistics.service';
@@ -30,45 +36,6 @@ import { StatisticsSeriesBreakdownComponent } from './statistics-series-breakdow
 import { StatisticsSummaryComponent } from './statistics-summary/statistics-summary.component';
 
 import { StatisticsViewComponent } from './statistics-view.component';
-
-// Mock components
-@Component({
-    selector: 'awg-statistics-complex-breakdown',
-    template: '',
-})
-class StatisticsComplexBreakdownStubComponent {
-    complexBreakdownData = input.required<StatisticsComplexBreakdownData>();
-}
-
-@Component({
-    selector: 'awg-statistics-series-breakdown',
-    template: '',
-})
-class StatisticsSeriesBreakdownStubComponent {
-    seriesBreakdownData = input.required<StatisticsSeriesBreakdown[]>();
-}
-
-@Component({
-    selector: 'awg-statistics-overall-progress',
-    template: '',
-})
-class StatisticsOverallProgressStubComponent {
-    overallProgressData = input.required<StatisticsOverallProgressData>();
-}
-
-@Component({
-    selector: 'awg-statistics-summary',
-    template: '',
-})
-class StatisticsSummaryStubComponent {
-    summaryData = input.required<StatisticsSummaryData>();
-}
-
-@Component({
-    selector: 'awg-scroll-to-top-button',
-    template: '',
-})
-class ScrollToTopButtonStubComponent {}
 
 describe('StatisticsViewComponent', () => {
     let component: StatisticsViewComponent;

--- a/src/app/views/structure-view/structure-side-info/structure-side-info.component.spec.ts
+++ b/src/app/views/structure-view/structure-side-info/structure-side-info.component.spec.ts
@@ -1,10 +1,11 @@
 import { DatePipe, registerLocaleData } from '@angular/common';
 import localeDeDE from '@angular/common/locales/de';
-import { Component, DebugElement, input, LOCALE_ID } from '@angular/core';
+import { DebugElement, LOCALE_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { MetaIdentifierBadgesStubComponent } from '@testing/component-stubs';
 import {
     expectToBe,
     expectToContain,
@@ -15,20 +16,11 @@ import {
 
 import { MetaIdentifierBadgesComponent } from '@awg-shared/meta/meta-identifier-badges/meta-identifier-badges.component';
 import { META_DATA } from '@awg-shared/meta/meta.data';
-import { MetaIdentifiers, MetaSectionTypes, MetaStructure } from '@awg-shared/meta/meta.model';
+import { MetaSectionTypes, MetaStructure } from '@awg-shared/meta/meta.model';
 
 import { StructureSideInfoComponent } from './structure-side-info.component';
 
 registerLocaleData(localeDeDE);
-
-// Mock components
-@Component({
-    selector: 'awg-meta-identifier-badges',
-    template: '',
-})
-class MetaIdentifierBadgesStubComponent {
-    readonly identifiers = input.required<MetaIdentifiers>();
-}
 
 describe('StructureSideInfoComponent (DONE)', () => {
     let component: StructureSideInfoComponent;

--- a/src/app/views/structure-view/structure-view.component.spec.ts
+++ b/src/app/views/structure-view/structure-view.component.spec.ts
@@ -1,30 +1,15 @@
-import { Component, DebugElement, input } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { HeadingStubComponent, ScrollToTopButtonStubComponent } from '@testing/component-stubs';
 import { expectToBe, getAndExpectDebugElementByCss, getAndExpectDebugElementByDirective } from '@testing/expect-helper';
 
 import { HeadingComponent } from '@awg-shared/heading/heading.component';
 import { ScrollToTopButtonComponent } from '@awg-shared/scroll-to-top-button/scroll-to-top-button.component';
 
 import { StructureViewComponent } from './structure-view.component';
-
-// Mock components
-@Component({
-    selector: 'awg-heading',
-    template: '',
-})
-class HeadingStubComponent {
-    title = input.required<string>();
-    id = input.required<string>();
-}
-
-@Component({
-    selector: 'awg-scroll-to-top-button',
-    template: '',
-})
-class ScrollToTopButtonStubComponent {}
 
 describe('StructureViewComponent (DONE)', () => {
     let component: StructureViewComponent;
@@ -38,7 +23,7 @@ describe('StructureViewComponent (DONE)', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [StructureViewComponent, HeadingStubComponent],
+            imports: [StructureViewComponent],
             declarations: [],
         })
             .overrideComponent(StructureViewComponent, {

--- a/src/testing/component-stubs.ts
+++ b/src/testing/component-stubs.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, input, model, output, Output } from '@angular/core';
+import { Component, EventEmitter, Input, input, model, Output } from '@angular/core';
 
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 
@@ -90,7 +90,7 @@ export class AlertErrorStubComponent {
 })
 export class AlertInfoStubComponent {
     readonly infoMessage = input.required<string>();
-    readonly isOpen = model<boolean>(true);
+    isOpen = model<boolean>(true);
 }
 
 @Component({
@@ -99,7 +99,6 @@ export class AlertInfoStubComponent {
 })
 export class FullscreenToggleStubComponent {
     readonly fsElement = input.required<HTMLElement>();
-    readonly toggleFullscreenRequest = output<boolean>();
 }
 
 @Component({
@@ -107,8 +106,8 @@ export class FullscreenToggleStubComponent {
     template: '',
 })
 export class HeadingStubComponent {
-    readonly title = input.required<string>();
     readonly id = input.required<string>();
+    readonly title = input.required<string>();
 }
 
 @Component({
@@ -129,6 +128,7 @@ export class LanguageSwitcherStubComponent {
 })
 export class LogoStubComponent {
     readonly logoData = input.required<Logo>();
+    readonly linkClass = input<string>('awg-logo-link');
 }
 
 @Component({

--- a/src/testing/component-stubs.ts
+++ b/src/testing/component-stubs.ts
@@ -1,0 +1,316 @@
+import { Component, EventEmitter, Input, input, model, output, Output } from '@angular/core';
+
+import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+
+import { NavbarItem } from '@awg-core/navbar/navbar.model';
+
+import { Logo, Logos } from '@awg-shared/logos/logos.model';
+import { MetaContact, MetaIdentifiers, MetaPage } from '@awg-shared/meta/meta.model';
+import { LabeledRoute } from '@awg-shared/models/labeled-route.model';
+
+import { HomeViewCard } from '@awg-views/home-view/home-view-card/home-view-card.model';
+
+import { SafeResourceUrl } from '@angular/platform-browser';
+import {
+    EditionOutlineComplexItem,
+    EditionOutlineSection,
+    EditionOutlineSeries,
+} from '@awg-app/views/edition-view/models';
+import {
+    StatisticsComplexBreakdown,
+    StatisticsComplexBreakdownData,
+    StatisticsOverallProgressData,
+    StatisticsProgressBarConfig,
+    StatisticsSeriesBreakdown,
+    StatisticsSummaryData,
+} from '@awg-views/statistics-view/models/statistics.model';
+
+// ============================================================================
+// CORE STUBS
+// ============================================================================
+@Component({
+    selector: 'awg-footer-copyright',
+    template: '',
+})
+export class FooterCopyrightStubComponent {
+    readonly pageMetaData = input.required<MetaPage>();
+}
+
+@Component({
+    selector: 'awg-footer-declaration',
+    template: '',
+})
+export class FooterDeclarationStubComponent {
+    readonly pageMetaData = input.required<MetaPage>();
+}
+
+@Component({
+    selector: 'awg-footer-poweredby',
+    template: '',
+})
+export class FooterPoweredbyStubComponent {
+    readonly logosData = input.required<Logos>();
+    readonly pageMetaData = input.required<MetaPage>();
+}
+
+@Component({
+    selector: 'awg-navbar-dropdown-link',
+    template: '',
+})
+export class NavbarDropdownLinkStubComponent {
+    readonly label = input.required<string>();
+    readonly route = input.required<string[]>();
+}
+
+@Component({
+    selector: 'awg-navbar-item',
+    template: '',
+})
+export class NavbarItemStubComponent {
+    readonly item = input.required<NavbarItem>();
+    readonly id = input<string>('');
+    readonly isDropdown = input<boolean>(false);
+}
+
+// ============================================================================
+// SHARED STUBS
+// ============================================================================
+
+@Component({
+    selector: 'awg-alert-error',
+    template: '',
+})
+export class AlertErrorStubComponent {
+    readonly errorObject = input.required<any>();
+}
+
+@Component({
+    selector: 'awg-alert-info',
+    template: '',
+})
+export class AlertInfoStubComponent {
+    readonly infoMessage = input.required<string>();
+    readonly isOpen = model<boolean>(true);
+}
+
+@Component({
+    selector: 'awg-fullscreen-toggle',
+    template: '',
+})
+export class FullscreenToggleStubComponent {
+    readonly fsElement = input.required<HTMLElement>();
+    readonly toggleFullscreenRequest = output<boolean>();
+}
+
+@Component({
+    selector: 'awg-heading',
+    template: '',
+})
+export class HeadingStubComponent {
+    readonly title = input.required<string>();
+    readonly id = input.required<string>();
+}
+
+@Component({
+    selector: 'awg-language-switcher',
+    template: '',
+    standalone: false,
+})
+export class LanguageSwitcherStubComponent {
+    @Input()
+    currentLanguage: number;
+    @Output()
+    languageChangeRequest = new EventEmitter<number>();
+}
+
+@Component({
+    selector: 'awg-logo',
+    template: '',
+})
+export class LogoStubComponent {
+    readonly logoData = input.required<Logo>();
+}
+
+@Component({
+    selector: 'awg-meta-identifier-badges',
+    template: '',
+})
+export class MetaIdentifierBadgesStubComponent {
+    readonly identifiers = input.required<MetaIdentifiers | null | undefined>();
+}
+
+@Component({
+    selector: 'awg-scroll-to-top-button',
+    template: '',
+})
+export class ScrollToTopButtonStubComponent {}
+
+@Component({
+    selector: 'awg-twelve-tone-spinner',
+    template: '',
+    standalone: false,
+})
+export class TwelveToneSpinnerStubComponent {}
+
+// ============================================================================
+// CONTACT VIEW STUBS
+// ============================================================================
+@Component({
+    selector: 'awg-contact-address',
+    template: '',
+})
+export class ContactAddressStubComponent {
+    readonly pageMetaData = input.required<MetaPage>();
+    readonly contactMetaData = input.required<MetaContact>();
+}
+
+@Component({
+    selector: 'awg-contact-map',
+    template: '',
+})
+export class ContactMapStubComponent {
+    readonly embedUrl = input.required<SafeResourceUrl>();
+    readonly linkUrl = input.required<string>();
+}
+
+// ============================================================================
+// EDITION VIEW STUBS
+// ============================================================================
+@Component({
+    selector: 'awg-edition-breadcrumb',
+    template: '',
+})
+export class EditionBreadcrumbStubComponent {
+    readonly items = input.required<LabeledRoute[]>();
+}
+
+@Component({
+    selector: 'awg-edition-jumbotron',
+    template: '',
+})
+export class EditionJumbotronStubComponent {
+    readonly id = input.required<string>();
+    readonly title = input.required<string>();
+}
+
+@Component({
+    selector: 'awg-edition-section-detail-complex-card',
+    template: '',
+    standalone: false,
+})
+export class EditionSectionDetailComplexCardStubComponent {
+    @Input()
+    complexes: EditionOutlineComplexItem[];
+}
+
+@Component({
+    selector: 'awg-edition-section-detail-disclaimer',
+    template: '',
+    standalone: false,
+})
+export class EditionSectionDetailDisclaimerStubComponent {}
+
+@Component({
+    selector: 'awg-edition-section-detail-intro-card',
+    template: '',
+    standalone: false,
+})
+export class EditionSectionDetailIntroCardStubComponent {
+    @Input()
+    selectedSeries: EditionOutlineSeries;
+    @Input()
+    selectedSection: EditionOutlineSection;
+}
+
+@Component({
+    selector: 'awg-edition-section-detail-placeholder',
+    template: '',
+    standalone: false,
+})
+export class EditionSectionDetailPlaceholderStubComponent {
+    @Input()
+    selectedSeries: EditionOutlineSeries;
+    @Input()
+    selectedSection: EditionOutlineSection;
+}
+
+// ============================================================================
+// HOME VIEW STUBS
+// ============================================================================
+@Component({
+    selector: 'awg-home-view-card',
+    template: '',
+})
+export class HomeViewCardStubComponent {
+    readonly cardData = input.required<HomeViewCard>();
+}
+
+// ============================================================================
+// STATISTICS VIEW STUBS
+// ============================================================================
+@Component({
+    selector: 'awg-statistics-breakdown-badge',
+    template: '',
+})
+export class StatisticsBreakdownBadgeStubComponent {
+    readonly breakdown = input.required<StatisticsComplexBreakdown>();
+    readonly containerClasses = input<string>('small text-muted');
+    readonly showEmptyBadges = input<boolean>(false);
+}
+
+@Component({
+    selector: 'awg-statistics-complex-breakdown',
+    template: '',
+})
+export class StatisticsComplexBreakdownStubComponent {
+    readonly complexBreakdownData = input.required<StatisticsComplexBreakdownData>();
+}
+
+@Component({
+    selector: 'awg-statistics-overall-progress',
+    template: '',
+})
+export class StatisticsOverallProgressStubComponent {
+    readonly overallProgressData = input.required<StatisticsOverallProgressData>();
+}
+
+@Component({
+    selector: 'awg-statistics-progress-bar',
+    template: '',
+})
+export class StatisticsProgressBarStubComponent {
+    readonly config = input.required<StatisticsProgressBarConfig>();
+    readonly headerLabel = input<string>();
+    readonly height = input<string>('15px');
+    readonly showPercentageLabel = input<boolean>(true);
+    readonly boldPercentageLabel = input<boolean>(false);
+    readonly customType = input<string>('');
+    readonly useCustomTypeOnly = input<boolean>(false);
+}
+
+@Component({
+    selector: 'awg-statistics-series-breakdown',
+    template: '',
+})
+export class StatisticsSeriesBreakdownStubComponent {
+    readonly seriesBreakdownData = input.required<StatisticsSeriesBreakdown[]>();
+}
+
+@Component({
+    selector: 'awg-statistics-summary',
+    template: '',
+})
+export class StatisticsSummaryStubComponent {
+    readonly summaryData = input.required<StatisticsSummaryData>();
+}
+
+@Component({
+    selector: 'awg-statistics-summary-card',
+    template: '',
+})
+export class StatisticsSummaryCardStubComponent {
+    readonly title = input.required<string>();
+    readonly value = input.required<number | string>();
+    readonly icon = input.required<IconDefinition>();
+    readonly bgClass = input.required<string>();
+}


### PR DESCRIPTION
This PR refactors the declaration of component stubs in test files by moving those into a dedicated test helper. (Some stubs are not transfered there yet, they will as soon as the corresponding test files will be migrated to modern Angular.)