### PR TITLE
refactor(shared): modernize TwelveToneSpinner

### DIFF
--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -66,6 +66,7 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
         MetaIdentifierBadgesComponent,
         ExternalLinkDirective,
         ScrollToTopButtonComponent,
+        TwelveToneSpinnerComponent,
     ],
     declarations: [
         DisclaimerWorkeditionsComponent,
@@ -76,7 +77,6 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
         TableComponent,
         TablePaginationComponent,
         ToastComponent,
-        TwelveToneSpinnerComponent,
         ViewHandleButtonGroupComponent,
         AbbrDirective,
         OrderByPipe,

--- a/src/app/shared/table/table.component.spec.ts
+++ b/src/app/shared/table/table.component.spec.ts
@@ -67,8 +67,14 @@ describe('TableComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [FontAwesomeTestingModule, FormsModule, NgbHighlight, NgbPaginationModule],
-            declarations: [TableComponent, TablePaginationStubComponent, TwelveToneSpinnerStubComponent, OrderByPipe],
+            imports: [
+                FontAwesomeTestingModule,
+                FormsModule,
+                NgbHighlight,
+                NgbPaginationModule,
+                TwelveToneSpinnerStubComponent,
+            ],
+            declarations: [TableComponent, TablePaginationStubComponent, OrderByPipe],
         }).compileComponents();
     });
 
@@ -261,6 +267,19 @@ describe('TableComponent', () => {
                 await detectChangesOnPush(fixture);
 
                 getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
+            });
+
+            it('... should have default spinnerText on TwelveToneSpinnerComponent', async () => {
+                // Mock empty observable
+                component.tableData.paginatedRows$ = EMPTY;
+                await detectChangesOnPush(fixture);
+
+                const spinnerDes = getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
+                const spinnerCmp = spinnerDes[0].injector.get(
+                    TwelveToneSpinnerStubComponent
+                ) as TwelveToneSpinnerStubComponent;
+
+                expectToBe(spinnerCmp.spinnerText(), 'loading');
             });
         });
 

--- a/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.html
+++ b/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.html
@@ -1,17 +1,9 @@
-<div class="spinner">
-    <div class="spinner-load-text">
-        <p>{{ spinnerLoadText }}</p>
+<div class="twelve-tone-spinner">
+    <div class="twelve-tone-spinner-text">
+        <p>{{ spinnerText() }}</p>
     </div>
-    <div class="spinner-note1"></div>
-    <div class="spinner-note2"></div>
-    <div class="spinner-note3"></div>
-    <div class="spinner-note4"></div>
-    <div class="spinner-note5"></div>
-    <div class="spinner-note6"></div>
-    <div class="spinner-note7"></div>
-    <div class="spinner-note8"></div>
-    <div class="spinner-note9"></div>
-    <div class="spinner-note10"></div>
-    <div class="spinner-note11"></div>
-    <div class="spinner-note12"></div>
+
+    @for (note of spinnerNotes; track note) {
+        <div class="twelve-tone-spinner-note" [style.--index]="note" [attr.data-note]="note"></div>
+    }
 </div>

--- a/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.scss
+++ b/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.scss
@@ -1,72 +1,86 @@
-.spinner {
+.twelve-tone-spinner {
     height: 140px;
     width: 140px;
     position: relative;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
     margin: auto;
 
     > div {
         width: 100%;
         height: 100%;
         position: absolute;
-        left: 0;
         top: 0;
+        left: 0;
     }
 
-    > div:before {
-        content: '\2669';
-        margin: 0 auto;
-        display: block;
-        width: 15%;
-        height: 15%;
-        border-radius: 100%;
-        animation: spinner-circleBounceDelay 1.2s infinite ease-in-out both;
+    > .twelve-tone-spinner-text {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+
+        > p {
+            margin: 0;
+            text-align: center;
+        }
     }
 
-    > .spinner-note6:before,
-    > .spinner-note12:before {
-        /* UNICODE FLAT SIGN */
-        content: '\266D';
-    }
+    > .twelve-tone-spinner-note {
+        &:before {
+            margin: 0 auto;
+            display: block;
+            width: 15%;
+            height: 15%;
+            border-radius: 100%;
+            animation: spinner-circleBounceDelay 1.2s infinite cubic-bezier(0.16, 1, 0.3, 1) both;
+        }
 
-    > .spinner-note3:before,
-    > .spinner-note9:before {
-        /* UNICODE SHARP SIGN */
-        content: '\266F';
-    }
+        &:not([data-note='0']) {
+            transform: rotate(calc(30deg * (var(--index))));
 
-    > .spinner-load-text > p {
-        margin: 30% auto;
-        text-align: center;
-    }
-}
+            &:before {
+                animation-delay: calc(-1.2s + (var(--index)) * 0.1s);
+            }
+        }
 
-/* Calculate rotation */
-@for $i from 2 through 12 {
-    .spinner-note#{$i} {
-        $rotation: 30deg * ($i - 1);
-        transform: rotate($rotation);
-    }
-}
-
-/* Calculate delay */
-@for $i from 2 through 12 {
-    .spinner .spinner-note#{$i}:before {
-        $delay: -1.2 + ($i - 1) * 0.1;
-        animation-delay: #{$delay}s;
+        @for $i from 0 through 11 {
+            &[data-note='#{$i}'] {
+                &:before {
+                    @if $i == 0 or $i == 6 {
+                        content: '\266F'; // Sharp Sign ♯
+                    } @else if $i == 3 or $i == 9 {
+                        content: '\266D'; // Flat Sign ♭
+                    } @else {
+                        content: '\2669'; // Quarter Note ♩
+                    }
+                }
+            }
+        }
     }
 }
 
 @keyframes spinner-circleBounceDelay {
-    0%,
-    80%,
-    100% {
-        transform: scale(0);
+    0% {
+        transform: scale(0.4);
+        opacity: 0;
+        filter: blur(1px);
     }
-    40% {
+    8% {
         transform: scale(1);
+        opacity: 1;
+        filter: blur(0);
+    }
+    45% {
+        transform: scale(1);
+        opacity: 1;
+    }
+    65%,
+    100% {
+        transform: scale(0.4);
+        opacity: 0;
     }
 }

--- a/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.spec.ts
+++ b/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.spec.ts
@@ -25,23 +25,27 @@ function _assertPseudoContentFromStyles(index: number, expectedContent: string):
         .map(style => style.textContent ?? '')
         .join('\n');
 
+    let hexCode = '2669'; // Standard: Quarter Note
+    if (expectedContent === '♭') {
+        hexCode = '266d'; // Flat Sign
+    } else if (expectedContent === '♯') {
+        hexCode = '266f'; // Sharp Sign
+    }
+
+    const noteContentRegex = new RegExp(
+        `data-note=["']${index}["'].*:before\\s*\\{\\s*content:\\s*["']\\\\${hexCode}["']`,
+        'i'
+    );
+
+    expect(styles).toMatch(noteContentRegex);
+
     if (index === 0 || index === 6) {
-        expect(styles).toMatch(/data-note="0"/);
-        expect(styles).toMatch(/data-note="6"/);
-        expect(styles).toMatch(/content:\s*"\\266f"/i);
-        return;
+        expectToBe(expectedContent, '♯');
+    } else if (index === 3 || index === 9) {
+        expectToBe(expectedContent, '♭');
+    } else {
+        expectToBe(expectedContent, '♩');
     }
-
-    if (index === 3 || index === 9) {
-        expect(styles).toMatch(/data-note="3"/);
-        expect(styles).toMatch(/data-note="9"/);
-        expect(styles).toMatch(/content:\s*"\\266d"/i);
-        return;
-    }
-
-    expect(styles).toMatch(/data-note="\d+"[^]*:before/i);
-    expect(styles).toMatch(/content:\s*"\\2669"/i);
-    expectToBe(expectedContent, '\u2669');
 }
 
 describe('TwelveToneSpinnerComponent', () => {

--- a/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.spec.ts
+++ b/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.spec.ts
@@ -53,7 +53,7 @@ describe('TwelveToneSpinnerComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [TwelveToneSpinnerComponent],
+            imports: [TwelveToneSpinnerComponent],
         }).compileComponents();
     });
 

--- a/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.spec.ts
+++ b/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.spec.ts
@@ -1,20 +1,20 @@
-import { DebugElement } from '@angular/core';
+import { DebugElement, isSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { expectToBe, getAndExpectDebugElementByCss } from '@testing/expect-helper';
+import { expectToBe, expectToEqual, getAndExpectDebugElementByCss } from '@testing/expect-helper';
 
 import { TwelveToneSpinnerComponent } from './twelve-tone-spinner.component';
 
 // Helper functions for testing pseudo-element content
 function _getExpectedNoteSymbol(index: number): string {
-    if (index === 6 || index === 12) {
-        return '\u266D'; // UNICODE FLAT SIGN
+    if (index === 0 || index === 6) {
+        return '\u266F'; // UNICODE SHARP SIGN
     }
 
     if (index === 3 || index === 9) {
-        return '\u266F'; // UNICODE SHARP SIGN
+        return '\u266D'; // UNICODE FLAT SIGN
     }
 
     return '\u2669'; // UNICODE QUARTER NOTE
@@ -25,21 +25,21 @@ function _assertPseudoContentFromStyles(index: number, expectedContent: string):
         .map(style => style.textContent ?? '')
         .join('\n');
 
-    if (index === 6 || index === 12) {
-        expect(styles).toMatch(/spinner-note6/);
-        expect(styles).toMatch(/spinner-note12/);
-        expect(styles).toMatch(/content:\s*"\\266d"/i);
-        return;
-    }
-
-    if (index === 3 || index === 9) {
-        expect(styles).toMatch(/spinner-note3/);
-        expect(styles).toMatch(/spinner-note9/);
+    if (index === 0 || index === 6) {
+        expect(styles).toMatch(/data-note="0"/);
+        expect(styles).toMatch(/data-note="6"/);
         expect(styles).toMatch(/content:\s*"\\266f"/i);
         return;
     }
 
-    expect(styles).toMatch(/>\s*div[^\n]*:before/i);
+    if (index === 3 || index === 9) {
+        expect(styles).toMatch(/data-note="3"/);
+        expect(styles).toMatch(/data-note="9"/);
+        expect(styles).toMatch(/content:\s*"\\266d"/i);
+        return;
+    }
+
+    expect(styles).toMatch(/data-note="\d+"[^]*:before/i);
     expect(styles).toMatch(/content:\s*"\\2669"/i);
     expectToBe(expectedContent, '\u2669');
 }
@@ -49,7 +49,7 @@ describe('TwelveToneSpinnerComponent', () => {
     let fixture: ComponentFixture<TwelveToneSpinnerComponent>;
     let compDe: DebugElement;
 
-    let expectedSpinnerLoadText: string;
+    let expectedSpinnerText: string;
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -58,18 +58,19 @@ describe('TwelveToneSpinnerComponent', () => {
     });
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(TwelveToneSpinnerComponent);
-        component = fixture.componentInstance;
-        compDe = fixture.debugElement;
-
         // Test data
-        expectedSpinnerLoadText = 'loading';
+        expectedSpinnerText = 'loading';
 
         // Mock getComputedStyle to ensure consistent test results across different environments
         const originalGetComputedStyle = window.getComputedStyle.bind(window);
         vi.spyOn(window, 'getComputedStyle').mockImplementation((element: Element) =>
             originalGetComputedStyle(element)
         );
+
+        // Create component fixture
+        fixture = TestBed.createComponent(TwelveToneSpinnerComponent);
+        component = fixture.componentInstance;
+        compDe = fixture.debugElement;
     });
 
     afterEach(() => {
@@ -81,50 +82,42 @@ describe('TwelveToneSpinnerComponent', () => {
     });
 
     describe('BEFORE initial data binding', () => {
-        it('... should have `spinnerLoadText`', () => {
-            expectToBe(component.spinnerLoadText, expectedSpinnerLoadText);
+        it('... should have signal `spinnerText` to hold the default text', () => {
+            expectToBe(isSignal(component.spinnerText), true);
+
+            expectToBe(component.spinnerText(), expectedSpinnerText);
+        });
+
+        it('... should have `spinnerNotes` with indices from 0 to 11', () => {
+            const expectedNotes = Array.from({ length: 12 }, (_, i) => i);
+
+            expectToEqual(component.spinnerNotes, expectedNotes);
         });
 
         describe('VIEW', () => {
-            it('... should contain one div.spinner', () => {
-                getAndExpectDebugElementByCss(compDe, 'div.spinner', 1, 1);
+            it('... should contain one div.twelve-tone-spinner', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.twelve-tone-spinner', 1, 1);
             });
 
-            it('... should contain one div.spinner-load-text in div.spinner', () => {
-                getAndExpectDebugElementByCss(compDe, 'div.spinner > div.spinner-load-text', 1, 1);
+            it('... should contain one div.twelve-tone-spinner-text in div.twelve-tone-spinner', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.twelve-tone-spinner > div.twelve-tone-spinner-text', 1, 1);
             });
 
-            it(`... should not display load text yet`, () => {
-                const pDes = getAndExpectDebugElementByCss(compDe, 'div.spinner > div.spinner-load-text > p', 1, 1);
+            it('... should not display `spinnerText` yet', () => {
+                const pDes = getAndExpectDebugElementByCss(
+                    compDe,
+                    'div.twelve-tone-spinner > div.twelve-tone-spinner-text > p',
+                    1,
+                    1
+                );
                 const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 
                 expectToBe(pEl.textContent, '');
             });
 
-            for (let i = 1; i <= 12; i++) {
-                it(`... should contain one div.spinner-note${i} in div.spinner`, () => {
-                    getAndExpectDebugElementByCss(compDe, `div.spinner > div.spinner-note${i}`, 1, 1);
-                });
-            }
-
-            for (let i = 1; i <= 12; i++) {
-                it(`... should contain one div.spinner-note${i} with correct :before content in div.spinner`, () => {
-                    const noteDes = getAndExpectDebugElementByCss(compDe, `div.spinner > div.spinner-note${i}`, 1, 1);
-                    const noteEl: HTMLDivElement = noteDes[0].nativeElement;
-
-                    const beforeContent = window.getComputedStyle(noteEl, ':before').getPropertyValue('content');
-
-                    // Replace is used to remove the quotes around the content string
-                    const actualContent = beforeContent.replace(/['"]+/g, '');
-                    const expectedContent = _getExpectedNoteSymbol(i);
-
-                    if (actualContent === 'normal' || actualContent === '') {
-                        _assertPseudoContentFromStyles(i, expectedContent);
-                    } else {
-                        expectToBe(actualContent, expectedContent);
-                    }
-                });
-            }
+            it(`... should contain no div.twelve-tone-spinner-note yet"`, () => {
+                getAndExpectDebugElementByCss(compDe, 'div.twelve-tone-spinner > div.twelve-tone-spinner-note', 0, 0);
+            });
         });
     });
 
@@ -135,11 +128,73 @@ describe('TwelveToneSpinnerComponent', () => {
         });
 
         describe('VIEW', () => {
-            it(`... should display load text`, () => {
-                const pDes = getAndExpectDebugElementByCss(compDe, 'div.spinner > div.spinner-load-text > p', 1, 1);
+            it('... should display `spinnerText`', () => {
+                const pDes = getAndExpectDebugElementByCss(
+                    compDe,
+                    'div.twelve-tone-spinner > div.twelve-tone-spinner-text > p',
+                    1,
+                    1
+                );
                 const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 
-                expectToBe(pEl.textContent, expectedSpinnerLoadText);
+                expectToBe(pEl.textContent, expectedSpinnerText);
+            });
+
+            it('... should change `spinnerText` when input signal changes', () => {
+                const newSpinnerText = 'running';
+
+                fixture.componentRef.setInput('spinnerText', newSpinnerText);
+                fixture.detectChanges();
+
+                const pDes = getAndExpectDebugElementByCss(
+                    compDe,
+                    'div.twelve-tone-spinner > div.twelve-tone-spinner-text > p',
+                    1,
+                    1
+                );
+                const pEl: HTMLParagraphElement = pDes[0].nativeElement;
+
+                expectToBe(pEl.textContent, newSpinnerText);
+            });
+
+            describe('... should contain twelve div.twelve-tone-spinner-note with', () => {
+                for (let i = 0; i <= 11; i++) {
+                    it(`... data-note="${i}"`, () => {
+                        getAndExpectDebugElementByCss(
+                            compDe,
+                            `div.twelve-tone-spinner > div.twelve-tone-spinner-note[data-note="${i}"]`,
+                            1,
+                            1
+                        );
+                    });
+                }
+            });
+
+            describe('... should have correct :before content in div.twelve-tone-spinner-note with', () => {
+                for (let i = 0; i <= 11; i++) {
+                    it(`... data-note="${i}"`, () => {
+                        const noteDes = getAndExpectDebugElementByCss(
+                            compDe,
+                            `div.twelve-tone-spinner > div.twelve-tone-spinner-note[data-note="${i}"]`,
+                            1,
+                            1
+                        );
+                        const noteEl: HTMLDivElement = noteDes[0].nativeElement;
+
+                        const beforeStyle = window.getComputedStyle(noteEl, ':before');
+                        const beforeContent = beforeStyle.getPropertyValue('content');
+
+                        const actualContent = beforeContent.replace(/['"]+/g, '');
+
+                        const expectedContent = _getExpectedNoteSymbol(i);
+
+                        if (actualContent === 'normal' || actualContent === '') {
+                            _assertPseudoContentFromStyles(i, expectedContent);
+                        } else {
+                            expectToBe(actualContent, expectedContent);
+                        }
+                    });
+                }
             });
         });
     });

--- a/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.ts
+++ b/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.ts
@@ -12,7 +12,6 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
     templateUrl: './twelve-tone-spinner.component.html',
     styleUrls: ['./twelve-tone-spinner.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    standalone: false,
 })
 export class TwelveToneSpinnerComponent {
     /**

--- a/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.ts
+++ b/src/app/shared/twelve-tone-spinner/twelve-tone-spinner.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 /**
  * The TwelveToneSpinner component.
@@ -16,10 +16,16 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 })
 export class TwelveToneSpinnerComponent {
     /**
-     * Public variable: spinnerLoadText.
+     * Readonly input signal: spinnerText.
      *
-     * It contains the message to be displayed
-     * while the spinner is active.
+     * It holds the text that is displayed inside the spinner.
      */
-    spinnerLoadText = 'loading';
+    readonly spinnerText = input<string>('loading');
+
+    /**
+     * Readonly variable: spinnerNotes.
+     *
+     * It contains the twelve notes of the spinner.
+     */
+    readonly spinnerNotes = Array.from({ length: 12 }, (_, i) => i);
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.spec.ts
@@ -93,13 +93,17 @@ describe('EditionGraphComponent (DONE)', () => {
         };
 
         await TestBed.configureTestingModule({
-            imports: [AlertErrorStubComponent, FullscreenToggleStubComponent, FontAwesomeTestingModule],
+            imports: [
+                AlertErrorStubComponent,
+                FullscreenToggleStubComponent,
+                TwelveToneSpinnerStubComponent,
+                FontAwesomeTestingModule,
+            ],
             declarations: [
                 EditionGraphComponent,
                 CompileHtmlComponent,
                 GraphVisualizerStubComponent,
                 ModalStubComponent,
-                TwelveToneSpinnerStubComponent,
             ],
             providers: [
                 { provide: EditionViewService, useValue: { graphViewData: mockViewDataSignal.asReadonly() } },
@@ -256,18 +260,33 @@ describe('EditionGraphComponent (DONE)', () => {
             });
 
             describe('on loading', () => {
-                it('... should not contain graph view or alert, but one TwelveToneSpinnerComponent (stubbed)', async () => {
+                beforeEach(async () => {
                     // Mock loading state
                     mockViewDataSignal.set(
                         createMockViewData(expectedViewDataContent, { isLoading: true, error: null })
                     );
 
                     await detectChangesOnPush(fixture);
-
+                });
+                it('... should not contain graph view or alert, but one TwelveToneSpinnerComponent (stubbed)', () => {
                     getAndExpectDebugElementByCss(compDe, 'div.awg-edition-graph-view', 0, 0);
                     getAndExpectDebugElementByDirective(compDe, AlertErrorStubComponent, 0, 0);
 
                     getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
+                });
+
+                it('... should have default spinnerText on TwelveToneSpinnerComponent', () => {
+                    const spinnerDes = getAndExpectDebugElementByDirective(
+                        compDe,
+                        TwelveToneSpinnerStubComponent,
+                        1,
+                        1
+                    );
+                    const spinnerCmp = spinnerDes[0].injector.get(
+                        TwelveToneSpinnerStubComponent
+                    ) as TwelveToneSpinnerStubComponent;
+
+                    expectToBe(spinnerCmp.spinnerText(), 'loading');
                 });
             });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/construct-results/construct-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/construct-results/construct-results.component.spec.ts
@@ -74,13 +74,8 @@ describe('ConstructResultsComponent (DONE)', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [NgbAccordionWithConfigModule, NgbAccordionDirective],
-            declarations: [
-                ConstructResultsComponent,
-                ForceGraphStubComponent,
-                SparqlNoResultsStubComponent,
-                TwelveToneSpinnerStubComponent,
-            ],
+            imports: [NgbAccordionWithConfigModule, NgbAccordionDirective, TwelveToneSpinnerStubComponent],
+            declarations: [ConstructResultsComponent, ForceGraphStubComponent, SparqlNoResultsStubComponent],
         }).compileComponents();
     });
 
@@ -328,6 +323,24 @@ describe('ConstructResultsComponent (DONE)', () => {
                         );
 
                         getAndExpectDebugElementByDirective(bodyDes[0], TwelveToneSpinnerStubComponent, 1, 1);
+                    });
+
+                    it('... should have default spinnerText on TwelveToneSpinnerComponent', async () => {
+                        // Mock null response
+                        component.queryResult$ = observableOf(null);
+                        await detectChangesOnPush(fixture);
+
+                        const spinnerDes = getAndExpectDebugElementByDirective(
+                            compDe,
+                            TwelveToneSpinnerStubComponent,
+                            1,
+                            1
+                        );
+                        const spinnerCmp = spinnerDes[0].injector.get(
+                            TwelveToneSpinnerStubComponent
+                        ) as TwelveToneSpinnerStubComponent;
+
+                        expectToBe(spinnerCmp.spinnerText(), 'loading');
                     });
                 });
 
@@ -675,6 +688,24 @@ describe('ConstructResultsComponent (DONE)', () => {
                         );
 
                         getAndExpectDebugElementByDirective(bodyDes[0], TwelveToneSpinnerStubComponent, 1, 1);
+                    });
+
+                    it('... should have default spinnerText on TwelveToneSpinnerComponent', async () => {
+                        // Mock null response
+                        component.queryResult$ = observableOf(null);
+                        await detectChangesOnPush(fixture);
+
+                        const spinnerDes = getAndExpectDebugElementByDirective(
+                            compDe,
+                            TwelveToneSpinnerStubComponent,
+                            1,
+                            1
+                        );
+                        const spinnerCmp = spinnerDes[0].injector.get(
+                            TwelveToneSpinnerStubComponent
+                        ) as TwelveToneSpinnerStubComponent;
+
+                        expectToBe(spinnerCmp.spinnerText(), 'loading');
                     });
                 });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/select-results/select-results.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/graph-visualizer/select-results/select-results.component.spec.ts
@@ -73,13 +73,8 @@ describe('SelectResultsComponent (DONE)', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [NgbAccordionWithConfigModule, NgbAccordionDirective],
-            declarations: [
-                SelectResultsComponent,
-                SparqlNoResultsStubComponent,
-                SparqlTableStubComponent,
-                TwelveToneSpinnerStubComponent,
-            ],
+            imports: [NgbAccordionWithConfigModule, NgbAccordionDirective, TwelveToneSpinnerStubComponent],
+            declarations: [SelectResultsComponent, SparqlNoResultsStubComponent, SparqlTableStubComponent],
         }).compileComponents();
     });
 
@@ -315,6 +310,24 @@ describe('SelectResultsComponent (DONE)', () => {
 
                         getAndExpectDebugElementByDirective(bodyDes[0], TwelveToneSpinnerStubComponent, 1, 1);
                     });
+
+                    it('... should have default spinnerText on TwelveToneSpinnerComponent', async () => {
+                        // Mock null response
+                        component.queryResult$ = null;
+                        await detectChangesOnPush(fixture);
+
+                        const spinnerDes = getAndExpectDebugElementByDirective(
+                            compDe,
+                            TwelveToneSpinnerStubComponent,
+                            1,
+                            1
+                        );
+                        const spinnerCmp = spinnerDes[0].injector.get(
+                            TwelveToneSpinnerStubComponent
+                        ) as TwelveToneSpinnerStubComponent;
+
+                        expectToBe(spinnerCmp.spinnerText(), 'loading');
+                    });
                 });
 
                 describe('... should contain item body with SparqlNoResultsStubComponent (stubbed) if ... ', () => {
@@ -544,6 +557,24 @@ describe('SelectResultsComponent (DONE)', () => {
                         );
 
                         getAndExpectDebugElementByDirective(bodyDes[0], TwelveToneSpinnerStubComponent, 1, 1);
+                    });
+
+                    it('... should have default spinnerText on TwelveToneSpinnerComponent', async () => {
+                        // Mock null response
+                        component.queryResult$ = null;
+                        await detectChangesOnPush(fixture);
+
+                        const spinnerDes = getAndExpectDebugElementByDirective(
+                            compDe,
+                            TwelveToneSpinnerStubComponent,
+                            1,
+                            1
+                        );
+                        const spinnerCmp = spinnerDes[0].injector.get(
+                            TwelveToneSpinnerStubComponent
+                        ) as TwelveToneSpinnerStubComponent;
+
+                        expectToBe(spinnerCmp.spinnerText(), 'loading');
                     });
                 });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
@@ -202,7 +202,7 @@ describe('IntroComponent (DONE)', () => {
         mockViewDataSignal = signal(createMockViewData(expectedDefaultViewDataContent));
 
         await TestBed.configureTestingModule({
-            imports: [AlertErrorStubComponent, NgbModalModule, RouterModule],
+            imports: [AlertErrorStubComponent, TwelveToneSpinnerStubComponent, NgbModalModule, RouterModule],
             declarations: [
                 EditionIntroComponent,
                 EditionIntroContentStubComponent,
@@ -210,7 +210,6 @@ describe('IntroComponent (DONE)', () => {
                 EditionIntroPlaceholderStubComponent,
                 EditionIntroNavStubComponent,
                 ModalStubComponent,
-                TwelveToneSpinnerStubComponent,
             ],
             providers: [
                 { provide: EditionViewService, useValue: { introViewData: mockViewDataSignal.asReadonly() } },
@@ -444,18 +443,34 @@ describe('IntroComponent (DONE)', () => {
             });
 
             describe('on loading', () => {
-                it('... should not contain intro view or alert, but one TwelveToneSpinnerComponent (stubbed)', async () => {
+                beforeEach(async () => {
                     // Mock loading state
                     mockViewDataSignal.set(
                         createMockViewData(expectedViewDataContent, { isLoading: true, error: null })
                     );
 
                     await detectChangesOnPush(fixture);
+                });
 
+                it('... should not contain intro view or alert, but one TwelveToneSpinnerComponent (stubbed)', () => {
                     getAndExpectDebugElementByCss(compDe, 'div.awg-edition-intro-view', 0, 0);
                     getAndExpectDebugElementByDirective(compDe, AlertErrorStubComponent, 0, 0);
 
                     getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
+                });
+
+                it('... should have default spinnerText on TwelveToneSpinnerComponent', () => {
+                    const spinnerDes = getAndExpectDebugElementByDirective(
+                        compDe,
+                        TwelveToneSpinnerStubComponent,
+                        1,
+                        1
+                    );
+                    const spinnerCmp = spinnerDes[0].injector.get(
+                        TwelveToneSpinnerStubComponent
+                    ) as TwelveToneSpinnerStubComponent;
+
+                    expectToBe(spinnerCmp.spinnerText(), 'loading');
                 });
             });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/edition-report.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/edition-report.component.spec.ts
@@ -201,7 +201,12 @@ describe('EditionReportComponent', () => {
         mockViewDataSignal = signal(createMockViewData(expectedDefaultViewDataContent));
 
         await TestBed.configureTestingModule({
-            imports: [AlertErrorStubComponent, NgbAccordionWithConfigModule, NgbModalModule],
+            imports: [
+                AlertErrorStubComponent,
+                TwelveToneSpinnerStubComponent,
+                NgbAccordionWithConfigModule,
+                NgbModalModule,
+            ],
             declarations: [
                 CompileHtmlComponent,
                 EditionReportComponent,
@@ -211,7 +216,6 @@ describe('EditionReportComponent', () => {
                 SourceEvaluationStubComponent,
                 TextcriticsListStubComponent,
                 RouterOutletStubComponent,
-                TwelveToneSpinnerStubComponent,
             ],
             providers: [
                 { provide: EditionViewService, useValue: { reportViewData: mockViewDataSignal.asReadonly() } },
@@ -387,7 +391,7 @@ describe('EditionReportComponent', () => {
             });
 
             describe('on loading', () => {
-                it('... should not contain sheets view or alert, but one TwelveToneSpinnerComponent (stubbed)', async () => {
+                beforeEach(async () => {
                     // Mock loading state
                     mockViewDataSignal.set(
                         createMockViewData(expectedViewDataContent, {
@@ -397,11 +401,27 @@ describe('EditionReportComponent', () => {
                     );
 
                     await detectChangesOnPush(fixture);
+                });
 
+                it('... should not contain sheets view or alert, but one TwelveToneSpinnerComponent (stubbed)', () => {
                     getAndExpectDebugElementByCss(compDe, 'div.awg-edition-report-view', 0, 0);
                     getAndExpectDebugElementByDirective(compDe, AlertErrorStubComponent, 0, 0);
 
                     getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
+                });
+
+                it('... should have default spinnerText on TwelveToneSpinnerComponent', () => {
+                    const spinnerDes = getAndExpectDebugElementByDirective(
+                        compDe,
+                        TwelveToneSpinnerStubComponent,
+                        1,
+                        1
+                    );
+                    const spinnerCmp = spinnerDes[0].injector.get(
+                        TwelveToneSpinnerStubComponent
+                    ) as TwelveToneSpinnerStubComponent;
+
+                    expectToBe(spinnerCmp.spinnerText(), 'loading');
                 });
             });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-sheets.component.spec.ts
@@ -1,14 +1,4 @@
-import {
-    Component,
-    DebugElement,
-    EventEmitter,
-    input,
-    Input,
-    isSignal,
-    Output,
-    signal,
-    WritableSignal,
-} from '@angular/core';
+import { Component, DebugElement, EventEmitter, Input, isSignal, Output, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 
@@ -18,6 +8,7 @@ type Spy = ReturnType<typeof vi.spyOn>;
 
 import { of as observableOf } from 'rxjs';
 
+import { AlertErrorStubComponent, TwelveToneSpinnerStubComponent } from '@testing/component-stubs';
 import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import { createMockViewData } from '@testing/edition-data-helper';
 import { EditionStateHelper } from '@testing/edition-state-helper';
@@ -67,21 +58,6 @@ class ModalStubComponent {
         this.modalContent = modalContentSnippetKey;
     }
 }
-
-@Component({
-    selector: 'awg-alert-error',
-    template: '',
-})
-class AlertErrorStubComponent {
-    errorObject = input.required<any>();
-}
-
-@Component({
-    selector: 'awg-twelve-tone-spinner',
-    template: '',
-    standalone: false,
-})
-class TwelveToneSpinnerStubComponent {}
 
 @Component({
     selector: 'awg-edition-accolade',
@@ -227,14 +203,13 @@ describe('EditionSheetsComponent (DONE)', () => {
         };
 
         await TestBed.configureTestingModule({
-            imports: [AlertErrorStubComponent],
+            imports: [AlertErrorStubComponent, TwelveToneSpinnerStubComponent],
             declarations: [
                 CompileHtmlComponent,
                 EditionSheetsComponent,
                 EditionConvoluteStubComponent,
                 EditionAccoladeStubComponent,
                 ModalStubComponent,
-                TwelveToneSpinnerStubComponent,
             ],
             providers: [
                 { provide: EditionSheetsService, useValue: mockEditionSheetsService },
@@ -512,6 +487,30 @@ describe('EditionSheetsComponent (DONE)', () => {
                         getAndExpectDebugElementByDirective(compDe, AlertErrorStubComponent, 0, 0);
 
                         getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
+                    });
+
+                    it('... should have default spinnerText on TwelveToneSpinnerComponent', async () => {
+                        component.isFirstPageLoad.set(false);
+                        mockViewDataSignal.set(
+                            createMockViewData(expectedViewDataContent, {
+                                isLoading: true,
+                                error: null,
+                            })
+                        );
+
+                        await detectChangesOnPush(fixture);
+
+                        const spinnerDes = getAndExpectDebugElementByDirective(
+                            compDe,
+                            TwelveToneSpinnerStubComponent,
+                            1,
+                            1
+                        );
+                        const spinnerCmp = spinnerDes[0].injector.get(
+                            TwelveToneSpinnerStubComponent
+                        ) as TwelveToneSpinnerStubComponent;
+
+                        expectToBe(spinnerCmp.spinnerText(), 'loading');
                     });
                 });
             });

--- a/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.spec.ts
@@ -59,13 +59,8 @@ describe('EditionPrefaceComponent (DONE)', () => {
         };
 
         await TestBed.configureTestingModule({
-            imports: [AlertErrorStubComponent],
-            declarations: [
-                EditionPrefaceComponent,
-                CompileHtmlComponent,
-                LanguageSwitcherStubComponent,
-                TwelveToneSpinnerStubComponent,
-            ],
+            imports: [AlertErrorStubComponent, TwelveToneSpinnerStubComponent],
+            declarations: [EditionPrefaceComponent, CompileHtmlComponent, LanguageSwitcherStubComponent],
             providers: [
                 { provide: EditionViewService, useValue: { prefaceViewData: mockViewDataSignal.asReadonly() } },
                 { provide: EditionGlyphService, useValue: mockEditionGlyphService },
@@ -193,18 +188,34 @@ describe('EditionPrefaceComponent (DONE)', () => {
             });
 
             describe('on loading', () => {
-                it('... should not contain preface view or alert, but one TwelveToneSpinnerComponent (stubbed)', async () => {
+                beforeEach(async () => {
                     // Mock loading state
                     mockViewDataSignal.set(
                         createMockViewData(expectedViewDataContent, { isLoading: true, error: null })
                     );
 
                     await detectChangesOnPush(fixture);
+                });
 
+                it('... should not contain preface view or alert, but one TwelveToneSpinnerComponent (stubbed)', () => {
                     getAndExpectDebugElementByCss(compDe, 'div.awg-preface-view', 0, 0);
                     getAndExpectDebugElementByDirective(compDe, AlertErrorStubComponent, 0, 0);
 
                     getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
+                });
+
+                it('... should have default spinnerText on TwelveToneSpinnerComponent', () => {
+                    const spinnerDes = getAndExpectDebugElementByDirective(
+                        compDe,
+                        TwelveToneSpinnerStubComponent,
+                        1,
+                        1
+                    );
+                    const spinnerCmp = spinnerDes[0].injector.get(
+                        TwelveToneSpinnerStubComponent
+                    ) as TwelveToneSpinnerStubComponent;
+
+                    expectToBe(spinnerCmp.spinnerText(), 'loading');
                 });
             });
 

--- a/src/app/views/edition-view/edition-outlets/edition-rowtables/edition-rowtables.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-rowtables/edition-rowtables.component.spec.ts
@@ -44,8 +44,8 @@ describe('EditionRowTablesComponent (DONE)', () => {
         mockViewDataSignal = signal(createMockViewData(expectedDefaultViewDataContent));
 
         await TestBed.configureTestingModule({
-            imports: [AlertErrorStubComponent],
-            declarations: [EditionRowtablesComponent, TwelveToneSpinnerStubComponent, RouterLinkStubDirective],
+            imports: [AlertErrorStubComponent, TwelveToneSpinnerStubComponent],
+            declarations: [EditionRowtablesComponent, RouterLinkStubDirective],
             providers: [
                 {
                     provide: EditionViewService,
@@ -147,18 +147,34 @@ describe('EditionRowTablesComponent (DONE)', () => {
             });
 
             describe('on loading', () => {
-                it('... should not contain rowtables view or alert, but one TwelveToneSpinnerComponent (stubbed)', async () => {
+                beforeEach(async () => {
                     // Mock loading state
                     mockViewDataSignal.set(
                         createMockViewData(expectedViewDataContent, { isLoading: true, error: null })
                     );
 
                     await detectChangesOnPush(fixture);
+                });
 
+                it('... should not contain rowtables view or alert, but one TwelveToneSpinnerComponent (stubbed)', () => {
                     getAndExpectDebugElementByCss(compDe, 'div.awg-rowtables-view', 0, 0);
                     getAndExpectDebugElementByDirective(compDe, AlertErrorStubComponent, 0, 0);
 
                     getAndExpectDebugElementByDirective(compDe, TwelveToneSpinnerStubComponent, 1, 1);
+                });
+
+                it('... should have default spinnerText on TwelveToneSpinnerComponent', () => {
+                    const spinnerDes = getAndExpectDebugElementByDirective(
+                        compDe,
+                        TwelveToneSpinnerStubComponent,
+                        1,
+                        1
+                    );
+                    const spinnerCmp = spinnerDes[0].injector.get(
+                        TwelveToneSpinnerStubComponent
+                    ) as TwelveToneSpinnerStubComponent;
+
+                    expectToBe(spinnerCmp.spinnerText(), 'loading');
                 });
             });
 

--- a/src/index.html
+++ b/src/index.html
@@ -52,21 +52,19 @@
                     <p>AWG-APP is…</p>
                 </div>
                 <div class="spinner">
-                    <div class="spinner-load-text">
-                        <p>loading</p>
-                    </div>
-                    <div class="spinner-note1"></div>
-                    <div class="spinner-note2"></div>
-                    <div class="spinner-note3"></div>
-                    <div class="spinner-note4"></div>
-                    <div class="spinner-note5"></div>
-                    <div class="spinner-note6"></div>
-                    <div class="spinner-note7"></div>
-                    <div class="spinner-note8"></div>
-                    <div class="spinner-note9"></div>
-                    <div class="spinner-note10"></div>
-                    <div class="spinner-note11"></div>
-                    <div class="spinner-note12"></div>
+                    <div class="spinner-text"><p>loading</p></div>
+                    <div class="spinner-note" style="--index: 0" data-note="0"></div>
+                    <div class="spinner-note" style="--index: 1" data-note="1"></div>
+                    <div class="spinner-note" style="--index: 2" data-note="2"></div>
+                    <div class="spinner-note" style="--index: 3" data-note="3"></div>
+                    <div class="spinner-note" style="--index: 4" data-note="4"></div>
+                    <div class="spinner-note" style="--index: 5" data-note="5"></div>
+                    <div class="spinner-note" style="--index: 6" data-note="6"></div>
+                    <div class="spinner-note" style="--index: 7" data-note="7"></div>
+                    <div class="spinner-note" style="--index: 8" data-note="8"></div>
+                    <div class="spinner-note" style="--index: 9" data-note="9"></div>
+                    <div class="spinner-note" style="--index: 10" data-note="10"></div>
+                    <div class="spinner-note" style="--index: 11" data-note="11"></div>
                 </div>
             </div>
         </awg-app>

--- a/src/index.style.scss
+++ b/src/index.style.scss
@@ -26,102 +26,74 @@ html {
     left: 0;
     top: 0;
 }
-.spinner > div:before {
-    content: '\2669';
+
+.spinner .spinner-text {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.spinner .spinner-text > p {
+    margin: 0;
+    text-align: center;
+}
+
+.spinner .spinner-note:before {
     margin: 0 auto;
     display: block;
     width: 15%;
     height: 15%;
     border-radius: 100%;
-    animation: spinner-circleBounceDelay 1.2s infinite ease-in-out both;
-}
-.spinner .spinner-load-text > p {
-    margin: 30% auto;
-    text-align: center;
-}
-.spinner .spinner-note2 {
-    transform: rotate(30deg);
-}
-.spinner .spinner-note3 {
-    transform: rotate(60deg);
-}
-.spinner .spinner-note4 {
-    transform: rotate(90deg);
-}
-.spinner .spinner-note5 {
-    transform: rotate(120deg);
-}
-.spinner .spinner-note6 {
-    transform: rotate(150deg);
-}
-.spinner .spinner-note7 {
-    transform: rotate(180deg);
-}
-.spinner .spinner-note8 {
-    transform: rotate(210deg);
-}
-.spinner .spinner-note9 {
-    transform: rotate(240deg);
-}
-.spinner .spinner-note10 {
-    transform: rotate(270deg);
-}
-.spinner .spinner-note11 {
-    transform: rotate(300deg);
-}
-.spinner .spinner-note12 {
-    transform: rotate(330deg);
+    animation: spinner-circleBounceDelay 1.2s infinite cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
-.spinner .spinner-note2:before {
-    animation-delay: -1.1s;
+.spinner .spinner-note:not([data-note='0']) {
+    transform: rotate(calc(30deg * var(--index)));
 }
-.spinner .spinner-note3:before {
-    /* UNICODE SHARP SIGN */
+.spinner .spinner-note:not([data-note='0']):before {
+    animation-delay: calc(-1.2s + (var(--index) * 0.1s));
+}
+
+/* Quarter Note ♩ */
+.spinner .spinner-note:before {
+    content: '\2669';
+}
+
+/* Sharp Signs ♯*/
+.spinner .spinner-note[data-note='0']:before,
+.spinner .spinner-note[data-note='6']:before {
     content: '\266F';
-    animation-delay: -1s;
 }
-.spinner .spinner-note4:before {
-    animation-delay: -0.9s;
-}
-.spinner .spinner-note5:before {
-    animation-delay: -0.8s;
-}
-.spinner .spinner-note6:before {
-    /* UNICODE FLAT SIGN */
+
+/* Flat Signs ♭*/
+.spinner .spinner-note[data-note='3']:before,
+.spinner .spinner-note[data-note='9']:before {
     content: '\266D';
-    animation-delay: -0.7s;
-}
-.spinner .spinner-note7:before {
-    animation-delay: -0.6s;
-}
-.spinner .spinner-note8:before {
-    animation-delay: -0.5s;
-}
-.spinner .spinner-note9:before {
-    /* UNICODE SHARP SIGN */
-    content: '\266F';
-    animation-delay: -0.4s;
-}
-.spinner .spinner-note10:before {
-    animation-delay: -0.3s;
-}
-.spinner .spinner-note11:before {
-    animation-delay: -0.2s;
-}
-.spinner .spinner-note12:before {
-    /* UNICODE FLAT SIGN */
-    content: '\266D';
-    animation-delay: -0.1s;
 }
 
 @keyframes spinner-circleBounceDelay {
-    0%,
-    80%,
-    100% {
-        transform: scale(0);
+    0% {
+        transform: scale(0.4);
+        opacity: 0;
+        filter: blur(1px);
     }
-    40% {
+    8% {
         transform: scale(1);
+        opacity: 1;
+        filter: blur(0);
+    }
+    45% {
+        transform: scale(1);
+        opacity: 1;
+    }
+    65%,
+    100% {
+        transform: scale(0.4);
+        opacity: 0;
     }
 }

--- a/src/testing/component-stubs.ts
+++ b/src/testing/component-stubs.ts
@@ -148,9 +148,10 @@ export class ScrollToTopButtonStubComponent {}
 @Component({
     selector: 'awg-twelve-tone-spinner',
     template: '',
-    standalone: false,
 })
-export class TwelveToneSpinnerStubComponent {}
+export class TwelveToneSpinnerStubComponent {
+    readonly spinnerText = input<string>('loading');
+}
 
 // ============================================================================
 // CONTACT VIEW STUBS


### PR DESCRIPTION
This PR refactors the TwelveToneSpinner logic and migrates it to modern angular (signals, standalone).