### PR TITLE
refactor(shared): modernize LanguageSwitcher

### DIFF
--- a/src/app/shared/language-switcher/language-switcher.component.html
+++ b/src/app/shared/language-switcher/language-switcher.component.html
@@ -1,19 +1,11 @@
 <p class="awg-language-switcher">
-    <a
-        (click)="setLanguage(0)"
-        (keyup.enter)="setLanguage(0)"
-        role="link"
-        tabindex="0"
-        [class.active]="currentLanguage === 0"
-        >DE</a
-    >
-    |
-    <a
-        (click)="setLanguage(1)"
-        (keyup.enter)="setLanguage(1)"
-        role="link"
-        tabindex="0"
-        [class.active]="currentLanguage === 1"
-        >EN</a
-    >
+    @for (lang of languages; track lang.id) {
+        <button type="button" (click)="selectedLanguage.set(lang.id)" [class.active]="selectedLanguage() === lang.id">
+            {{ lang.label }}
+        </button>
+
+        @if (!$last) {
+            |
+        }
+    }
 </p>

--- a/src/app/shared/language-switcher/language-switcher.component.scss
+++ b/src/app/shared/language-switcher/language-switcher.component.scss
@@ -5,21 +5,34 @@
     font-size: small;
     text-align: end;
 
-    a {
-        cursor: pointer;
-        text-decoration: none;
+    button {
+        background: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        font: inherit;
         color: inherit;
-        // disable the active link style
+        cursor: pointer;
+
+        text-decoration: none;
+
         &.active,
         &.active:hover {
             cursor: default;
             color: inherit;
         }
+
         &:not(.active) {
             color: $link-color;
         }
+
         &:hover {
             border-bottom: none !important;
+        }
+
+        &:focus-visible {
+            outline: 1px solid $link-color;
+            outline-offset: 2px;
         }
     }
 }

--- a/src/app/shared/language-switcher/language-switcher.component.spec.ts
+++ b/src/app/shared/language-switcher/language-switcher.component.spec.ts
@@ -63,7 +63,7 @@ describe('LanguageSwitcherComponent (DONE)', () => {
                 getAndExpectDebugElementByCss(compDe, 'p.awg-language-switcher', 1, 1);
             });
 
-            it('... should not contain buttons yet', () => {
+            it('... should contain no buttons yet', () => {
                 const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-language-switcher', 1, 1);
                 const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 

--- a/src/app/shared/language-switcher/language-switcher.component.spec.ts
+++ b/src/app/shared/language-switcher/language-switcher.component.spec.ts
@@ -1,34 +1,32 @@
-import { DebugElement } from '@angular/core';
+import { DebugElement, isSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-type Spy = ReturnType<typeof vi.spyOn>;
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
+import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import {
-    expectSpyCall,
     expectToBe,
     expectToContain,
+    expectToEqual,
     expectToNotContain,
     getAndExpectDebugElementByCss,
 } from '@testing/expect-helper';
 
-import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
 import { LanguageSwitcherComponent } from './language-switcher.component';
+import { LanguageId } from './language.model';
 
 describe('LanguageSwitcherComponent (DONE)', () => {
     let component: LanguageSwitcherComponent;
     let fixture: ComponentFixture<LanguageSwitcherComponent>;
     let compDe: DebugElement;
 
-    let setLanguageSpy: Spy;
-    let emitLanguageChangeRequestSpy: Spy;
-
-    let expectedLanguage: number;
+    let expectedSelectedLanguage: LanguageId;
+    let expectedLanguages: { id: LanguageId; label: string }[];
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [LanguageSwitcherComponent],
+            imports: [LanguageSwitcherComponent],
         }).compileComponents();
     });
 
@@ -38,15 +36,11 @@ describe('LanguageSwitcherComponent (DONE)', () => {
         compDe = fixture.debugElement;
 
         // Test data
-        expectedLanguage = 0;
-
-        // Spies
-        setLanguageSpy = vi.spyOn(component, 'setLanguage');
-        emitLanguageChangeRequestSpy = vi.spyOn(component.languageChangeRequest, 'emit');
-    });
-
-    afterEach(() => {
-        vi.clearAllMocks();
+        expectedSelectedLanguage = LanguageId.DE;
+        expectedLanguages = [
+            { id: LanguageId.DE, label: 'DE' },
+            { id: LanguageId.EN, label: 'EN' },
+        ];
     });
 
     it('should create', () => {
@@ -54,27 +48,27 @@ describe('LanguageSwitcherComponent (DONE)', () => {
     });
 
     describe('BEFORE initial data binding', () => {
-        it('... should not have `currentLanguage`', () => {
-            expect(component.currentLanguage).toBeUndefined();
+        it('... should throw due to missing required input for model signal `selectedLanguage`', () => {
+            expectToBe(isSignal(component.selectedLanguage), true);
+
+            expect(() => component.selectedLanguage()).toThrow();
+        });
+
+        it('... should have `languages`', () => {
+            expectToEqual((component as any).languages, expectedLanguages);
         });
 
         describe('VIEW', () => {
-            it('... should contain 1 language-switcher paragraph', () => {
+            it('... should contain one language-switcher paragraph', () => {
                 getAndExpectDebugElementByCss(compDe, 'p.awg-language-switcher', 1, 1);
             });
 
-            it('... should contain 2 language-switcher anchor elements (DE | EN)', () => {
+            it('... should not contain buttons yet', () => {
                 const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-language-switcher', 1, 1);
                 const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 
-                expectToBe(pEl.textContent, 'DE | EN');
-
-                const aDes = getAndExpectDebugElementByCss(pDes[0], 'a', 2, 2);
-                const aEl1: HTMLAnchorElement = aDes[0].nativeElement;
-                const aEl2: HTMLAnchorElement = aDes[1].nativeElement;
-
-                expectToBe(aEl1.textContent, 'DE');
-                expectToBe(aEl2.textContent, 'EN');
+                expectToBe(pEl.textContent, '');
+                getAndExpectDebugElementByCss(pDes[0], 'button', 0, 0);
             });
         });
     });
@@ -82,124 +76,70 @@ describe('LanguageSwitcherComponent (DONE)', () => {
     describe('AFTER initial data binding', () => {
         beforeEach(() => {
             // Simulate the parent setting the input properties
-            component.currentLanguage = expectedLanguage;
+            fixture.componentRef.setInput('selectedLanguage', expectedSelectedLanguage);
 
             // Trigger initial data binding
             fixture.detectChanges();
         });
 
-        it('... should have `currentLanguage` = 0', () => {
-            expectToBe(component.currentLanguage, 0);
+        it('... should have signal `selectedLanguage` to hold the expected language', () => {
+            expectToBe(component.selectedLanguage(), expectedSelectedLanguage);
         });
 
         describe('VIEW', () => {
-            it('... should trigger `setLanguage` method on anchor click', async () => {
+            it('... should contain two buttons (DE | EN)', () => {
                 const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-language-switcher', 1, 1);
-                const aDes = getAndExpectDebugElementByCss(pDes[0], 'a', 2, 2);
+                const pEl: HTMLParagraphElement = pDes[0].nativeElement;
 
-                // Trigger click with click helper & wait for changes
-                await clickAndAwaitChanges(aDes[0], fixture);
+                expectToBe(pEl.textContent.trim().replace(/\s+/g, ' '), 'DE | EN');
 
-                expectSpyCall(setLanguageSpy, 1);
+                const btnDes = getAndExpectDebugElementByCss(pDes[0], 'button', 2, 2);
+                const btnEl1: HTMLButtonElement = btnDes[0].nativeElement;
+                const btnEl2: HTMLButtonElement = btnDes[1].nativeElement;
 
-                // Trigger click with click helper & wait for changes
-                await clickAndAwaitChanges(aDes[1], fixture);
-
-                expectSpyCall(setLanguageSpy, 2);
+                expectToBe(btnEl1.textContent.trim(), 'DE');
+                expectToBe(btnEl2.textContent.trim(), 'EN');
             });
 
-            it('... should trigger setLanguage method with 0 when clicking on first anchor', async () => {
+            it('... should update `selectedLanguage` on button click', async () => {
                 const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-language-switcher', 1, 1);
-                const aDes = getAndExpectDebugElementByCss(pDes[0], 'a', 2, 2);
+                const btnDes = getAndExpectDebugElementByCss(pDes[0], 'button', 2, 2);
 
-                // Click on first anchor
-                await clickAndAwaitChanges(aDes[0], fixture);
+                await clickAndAwaitChanges(btnDes[0], fixture);
 
-                expectSpyCall(setLanguageSpy, 1, 0);
+                expectToBe(component.selectedLanguage(), LanguageId.DE);
+
+                await clickAndAwaitChanges(btnDes[1], fixture);
+
+                expectToBe(component.selectedLanguage(), LanguageId.EN);
             });
 
-            it('... should trigger setLanguage method with 1 when clicking on second anchor', async () => {
-                const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-language-switcher', 1, 1);
-                const aDes = getAndExpectDebugElementByCss(pDes[0], 'a', 2, 2);
-
-                // Click on second anchor
-                await clickAndAwaitChanges(aDes[1], fixture);
-
-                expectSpyCall(setLanguageSpy, 1, 1);
-            });
-
-            it('... should have .active class on first anchor element when currentLanguage is 0', async () => {
-                component.currentLanguage = 0;
+            it('... should have .active class on first button when `selectedLanguage` is DE', async () => {
+                fixture.componentRef.setInput('selectedLanguage', LanguageId.DE);
                 await detectChangesOnPush(fixture);
 
                 const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-language-switcher', 1, 1);
-                const aDes = getAndExpectDebugElementByCss(pDes[0], 'a', 2, 2);
+                const btnDes = getAndExpectDebugElementByCss(pDes[0], 'button', 2, 2);
 
-                const aEl0: HTMLAnchorElement = aDes[0].nativeElement;
-                const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
+                const btnEl1: HTMLButtonElement = btnDes[0].nativeElement;
+                const btnEl2: HTMLButtonElement = btnDes[1].nativeElement;
 
-                expectToContain(aEl0.classList, 'active');
-                expectToNotContain(aEl1.classList, 'active');
+                expectToContain(btnEl1.classList, 'active');
+                expectToNotContain(btnEl2.classList, 'active');
             });
 
-            it('... should have .active class on second anchor element when currentLanguage is 1', async () => {
-                component.currentLanguage = 1;
+            it('... should have .active class on second button when `selectedLanguage` is EN', async () => {
+                fixture.componentRef.setInput('selectedLanguage', LanguageId.EN);
                 await detectChangesOnPush(fixture);
 
                 const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-language-switcher', 1, 1);
-                const aDes = getAndExpectDebugElementByCss(pDes[0], 'a', 2, 2);
+                const btnDes = getAndExpectDebugElementByCss(pDes[0], 'button', 2, 2);
 
-                const aEl0: HTMLAnchorElement = aDes[0].nativeElement;
-                const aEl1: HTMLAnchorElement = aDes[1].nativeElement;
+                const btnEl1: HTMLButtonElement = btnDes[0].nativeElement;
+                const btnEl2: HTMLButtonElement = btnDes[1].nativeElement;
 
-                expectToNotContain(aEl0.classList, 'active');
-                expectToContain(aEl1.classList, 'active');
-            });
-        });
-
-        describe('#setLanguage()', () => {
-            it('... should have a method `setLanguage`', () => {
-                expect(component.setLanguage).toBeDefined();
-            });
-
-            it('... should trigger on click', async () => {
-                const pDes = getAndExpectDebugElementByCss(compDe, 'p.awg-language-switcher', 1, 1);
-                const aDes = getAndExpectDebugElementByCss(pDes[0], 'a', 2, 2);
-
-                // Trigger click with click helper & wait for changes
-                await clickAndAwaitChanges(aDes[0], fixture);
-
-                expectSpyCall(setLanguageSpy, 1);
-
-                // Trigger click with click helper & wait for changes
-                await clickAndAwaitChanges(aDes[1], fixture);
-
-                expectSpyCall(setLanguageSpy, 2);
-            });
-
-            it('... should emit 0 when called with 0', () => {
-                component.setLanguage(0);
-
-                expectSpyCall(setLanguageSpy, 1);
-                expectSpyCall(emitLanguageChangeRequestSpy, 1, 0);
-            });
-
-            it('... should emit 1 when called with 1', () => {
-                component.setLanguage(1);
-
-                expectSpyCall(setLanguageSpy, 1);
-                expectSpyCall(emitLanguageChangeRequestSpy, 1, 1);
-            });
-
-            it('... should not emit when called with any other number than 0 or 1', () => {
-                const invalidLanguageNumbers = [-987654321, -2, -1, 2, 3, 987654321];
-
-                invalidLanguageNumbers.forEach((languageNumber, index) => {
-                    component.setLanguage(languageNumber);
-
-                    expectSpyCall(setLanguageSpy, index + 1);
-                    expectSpyCall(emitLanguageChangeRequestSpy, 0);
-                });
+                expectToNotContain(btnEl1.classList, 'active');
+                expectToContain(btnEl2.classList, 'active');
             });
         });
     });

--- a/src/app/shared/language-switcher/language-switcher.component.ts
+++ b/src/app/shared/language-switcher/language-switcher.component.ts
@@ -1,4 +1,6 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, model } from '@angular/core';
+
+import { LanguageId } from './language.model';
 
 /**
  * The LanguageSwitcher component.
@@ -10,35 +12,24 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
     templateUrl: './language-switcher.component.html',
     styleUrls: ['./language-switcher.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    standalone: false,
 })
 export class LanguageSwitcherComponent {
     /**
-     * Input variable: currentLanguage.
+     * Model signal: selectedLanguage.
      *
-     * It keeps the current language: 0 for German, 1 for English.
+     * It holds the selected language id.
      */
-    @Input()
-    currentLanguage: number;
+    selectedLanguage = model.required<LanguageId>();
 
     /**
-     * Output variable: languageChangeRequest.
+     * Protected readonly variable: languages.
      *
-     * It emits the current language.
+     * It holds the available languages of the app.
      */
-    @Output() languageChangeRequest = new EventEmitter<number>();
-
-    /**
-     * Public method: setLanguage.
-     *
-     * It emits the current language.
-     *
-     * @param {number} language The given language number.
-     * @returns {void} Emits the current language.
-     */
-    setLanguage(language: number): void {
-        if (language === 0 || language === 1) {
-            this.languageChangeRequest.emit(language);
-        }
-    }
+    protected readonly languages = Object.values(LanguageId)
+        .filter((value): value is LanguageId => typeof value === 'number')
+        .map(id => ({
+            id,
+            label: LanguageId[id],
+        }));
 }

--- a/src/app/shared/language-switcher/language.model.ts
+++ b/src/app/shared/language-switcher/language.model.ts
@@ -1,0 +1,9 @@
+/**
+ * The LanguageId enumeration.
+ *
+ * It defines the available language ids.
+ */
+export enum LanguageId {
+    DE = 0,
+    EN = 1,
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -61,6 +61,7 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
         AlertInfoComponent,
         FullscreenToggleComponent,
         HeadingComponent,
+        LanguageSwitcherComponent,
         LicenseComponent,
         LogoComponent,
         MetaIdentifierBadgesComponent,
@@ -71,7 +72,6 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
     declarations: [
         DisclaimerWorkeditionsComponent,
         JsonViewerComponent,
-        LanguageSwitcherComponent,
         ModalComponent,
         RouterLinkButtonGroupComponent,
         TableComponent,

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-detail-nav/edition-detail-nav.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-detail-nav/edition-detail-nav.component.spec.ts
@@ -106,7 +106,7 @@ describe('EditionDetailNavComponent (DONE)', () => {
             fixture.detectChanges();
         });
 
-        it('... should have signal `selectedEditionComplex` to hold expected complex', () => {
+        it('... should have signal `selectedEditionComplex` to hold the expected complex', () => {
             expectToEqual(component.selectedEditionComplex(), expectedComplex);
         });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.html
@@ -1,7 +1,7 @@
 @if (introBlockContent) {
     <div class="awg-edition-intro-nav">
         <ul class="nav flex-column">
-            <awg-language-switcher [currentLanguage]="currentLanguage" (languageChangeRequest)="setLanguage($event)" />
+            <awg-language-switcher [(selectedLanguage)]="selectedLanguage" />
             <hr class="mt-0 mb-2" />
             @for (introBlock of introBlockContent; track $index) {
                 @if (introBlock.blockHeader) {

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.spec.ts
@@ -1,13 +1,11 @@
-import { DebugElement } from '@angular/core';
+import { DebugElement, isSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-type Spy = ReturnType<typeof vi.spyOn>;
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
 import { LanguageSwitcherStubComponent } from '@testing/component-stubs';
 import {
-    expectSpyCall,
     expectToBe,
     expectToEqual,
     getAndExpectDebugElementByCss,
@@ -16,6 +14,7 @@ import {
 import { mockEditionData } from '@testing/mock-data';
 import { RouterLinkStubDirective } from '@testing/router-stubs';
 
+import { LanguageId } from '@awg-shared/language-switcher/language.model';
 import { IntroBlock } from '@awg-views/edition-view/models';
 
 import { EditionIntroNavComponent } from './edition-intro-nav.component';
@@ -28,19 +27,17 @@ describe('EditionIntroNavComponent (DONE)', () => {
     let linkDes: DebugElement[];
     let routerLinks;
 
-    let setLanguageSpy: Spy;
-    let emitLanguageChangeRequestSpy: Spy;
-
     let expectedIntroBlockContent: IntroBlock[];
     let expectedNotesLabel: string;
-    let expectedCurrentLanguage: number;
+    let expectedSelectedLanguage: LanguageId;
 
     let expectedLinkParam: string;
     let expectedNotesFragment: string;
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [EditionIntroNavComponent, LanguageSwitcherStubComponent, RouterLinkStubDirective],
+            imports: [LanguageSwitcherStubComponent],
+            declarations: [EditionIntroNavComponent, RouterLinkStubDirective],
         }).compileComponents();
     });
 
@@ -52,18 +49,10 @@ describe('EditionIntroNavComponent (DONE)', () => {
         // Test data
         expectedIntroBlockContent = structuredClone(mockEditionData.mockIntroSectionData.intro[0].content);
         expectedNotesLabel = 'Test notes label';
-        expectedCurrentLanguage = 0;
+        expectedSelectedLanguage = LanguageId.DE;
 
         expectedLinkParam = '.';
         expectedNotesFragment = 'notes';
-
-        // Spies
-        setLanguageSpy = vi.spyOn(component, 'setLanguage');
-        emitLanguageChangeRequestSpy = vi.spyOn(component.languageChangeRequest, 'emit');
-    });
-
-    afterEach(() => {
-        vi.clearAllMocks();
     });
 
     it('should create', () => {
@@ -79,8 +68,10 @@ describe('EditionIntroNavComponent (DONE)', () => {
             expect(component.notesLabel).toBeUndefined();
         });
 
-        it('... should not have `currentLanguage`', () => {
-            expect(component.currentLanguage).toBeUndefined();
+        it('... should throw due to missing required input for model signal `selectedLanguage`', () => {
+            expectToBe(isSignal(component.selectedLanguage), true);
+
+            expect(() => component.selectedLanguage()).toThrow();
         });
 
         describe('VIEW', () => {
@@ -88,7 +79,7 @@ describe('EditionIntroNavComponent (DONE)', () => {
                 getAndExpectDebugElementByCss(compDe, 'div.awg-edition-intro-nav', 0, 0);
             });
 
-            it('... should not contain language switcher component (stubbed)', () => {
+            it('... should contain no LanguageSwitcherComponent (stubbed)', () => {
                 getAndExpectDebugElementByDirective(compDe, LanguageSwitcherStubComponent, 0, 0);
             });
         });
@@ -99,7 +90,7 @@ describe('EditionIntroNavComponent (DONE)', () => {
             // Simulate the parent setting the input properties
             component.introBlockContent = expectedIntroBlockContent;
             component.notesLabel = expectedNotesLabel;
-            component.currentLanguage = expectedCurrentLanguage;
+            fixture.componentRef.setInput('selectedLanguage', expectedSelectedLanguage);
 
             // Trigger initial data binding
             fixture.detectChanges();
@@ -113,8 +104,8 @@ describe('EditionIntroNavComponent (DONE)', () => {
             expectToBe(component.notesLabel, expectedNotesLabel);
         });
 
-        it('... should have `currentLanguage`', () => {
-            expectToEqual(component.currentLanguage, expectedCurrentLanguage);
+        it('... should have signal `selectedLanguage` to hold the expected language', () => {
+            expectToEqual(component.selectedLanguage(), expectedSelectedLanguage);
         });
 
         describe('VIEW', () => {
@@ -127,22 +118,34 @@ describe('EditionIntroNavComponent (DONE)', () => {
                 getAndExpectDebugElementByCss(divDes[0], 'ul.nav', 1, 1);
             });
 
-            it('... should contain a language switcher component (stubbed) in ul.nav', () => {
+            it('... should contain one LanguageSwitcherComponent (stubbed) in ul.nav', () => {
                 const ulDes = getAndExpectDebugElementByCss(compDe, 'ul.nav', 1, 1);
 
                 getAndExpectDebugElementByDirective(ulDes[0], LanguageSwitcherStubComponent, 1, 1);
             });
 
-            it('... should pass down `currentLanguage` to language switcher component', () => {
+            it('... should pass down `selectedLanguage` to LanguageSwitcherComponent', () => {
                 const switcherDes = getAndExpectDebugElementByDirective(compDe, LanguageSwitcherStubComponent, 1, 1);
                 const switcherCmp = switcherDes[0].injector.get(
                     LanguageSwitcherStubComponent
                 ) as LanguageSwitcherStubComponent;
 
-                expectToEqual(switcherCmp.currentLanguage, expectedCurrentLanguage);
+                expectToEqual(switcherCmp.selectedLanguage(), expectedSelectedLanguage);
             });
 
-            it('... should contain a horizontal line after language switcher in ul.nav', () => {
+            it('... should update `selectedLanguage` when LanguageSwitcherComponent emits a change', () => {
+                const switcherDes = getAndExpectDebugElementByDirective(compDe, LanguageSwitcherStubComponent, 1, 1);
+
+                expectToBe(component.selectedLanguage(), LanguageId.DE);
+
+                switcherDes[0].triggerEventHandler('selectedLanguageChange', LanguageId.EN);
+
+                fixture.detectChanges();
+
+                expectToBe(component.selectedLanguage(), LanguageId.EN);
+            });
+
+            it('... should contain a horizontal line below LanguageSwitcherComponent in ul.nav', () => {
                 const ulDes = getAndExpectDebugElementByCss(compDe, 'ul.nav', 1, 1);
                 getAndExpectDebugElementByCss(ulDes[0], 'hr.mt-0', 1, 1);
             });
@@ -191,54 +194,6 @@ describe('EditionIntroNavComponent (DONE)', () => {
                             : expectedIntroBlockContent[index].blockHeader;
 
                     expectToBe(aEl.textContent, expectedText);
-                });
-            });
-        });
-
-        describe('#setLanguage()', () => {
-            it('... should have a method `setLanguage`', () => {
-                expect(component.setLanguage).toBeDefined();
-            });
-
-            it('... should trigger on event from LanguageSwitcherComponent', () => {
-                const switcherDes = getAndExpectDebugElementByDirective(compDe, LanguageSwitcherStubComponent, 1, 1);
-                const switcherCmp = switcherDes[0].injector.get(
-                    LanguageSwitcherStubComponent
-                ) as LanguageSwitcherStubComponent;
-
-                // Language = 0
-                switcherCmp.languageChangeRequest.emit(0);
-
-                expectSpyCall(setLanguageSpy, 1, 0);
-
-                // Language = 1
-                switcherCmp.languageChangeRequest.emit(1);
-
-                expectSpyCall(setLanguageSpy, 2, 1);
-            });
-
-            it('... should emit 0 when called with 0', () => {
-                component.setLanguage(0);
-
-                expectSpyCall(setLanguageSpy, 1);
-                expectSpyCall(emitLanguageChangeRequestSpy, 1, 0);
-            });
-
-            it('... should emit 1 when called with 1', () => {
-                component.setLanguage(1);
-
-                expectSpyCall(setLanguageSpy, 1);
-                expectSpyCall(emitLanguageChangeRequestSpy, 1, 1);
-            });
-
-            it('... should not emit when called with any other number than 0 or 1', () => {
-                const invalidLanguageNumbers = [-987654321, -2, -1, 2, 3, 987654321];
-
-                invalidLanguageNumbers.forEach((languageNumber, index) => {
-                    component.setLanguage(languageNumber);
-
-                    expectSpyCall(setLanguageSpy, index + 1);
-                    expectSpyCall(emitLanguageChangeRequestSpy, 0);
                 });
             });
         });

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-nav/edition-intro-nav.component.ts
@@ -1,4 +1,6 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, model } from '@angular/core';
+
+import { LanguageId } from '@awg-shared/language-switcher/language.model';
 
 import { IntroBlock } from '@awg-views/edition-view/models';
 
@@ -31,32 +33,11 @@ export class EditionIntroNavComponent {
      */
     @Input()
     notesLabel: string;
-    /**
-     * Input variable: currentLanguage.
-     *
-     * It keeps the current language: 0 for German, 1 for English.
-     */
-    @Input()
-    currentLanguage: number;
 
     /**
-     * Output variable: languageChangeRequest.
+     * Model signal: selectedLanguage.
      *
-     * It emits the current language.
+     * It holds the selected language id.
      */
-    @Output() languageChangeRequest = new EventEmitter<number>();
-
-    /**
-     * Public method: setLanguage.
-     *
-     * It emits the current language.
-     *
-     * @param {number} language The given language number.
-     * @returns {void} Emits the current language.
-     */
-    setLanguage(language: number): void {
-        if (language === 0 || language === 1) {
-            this.languageChangeRequest.emit(language);
-        }
-    }
+    selectedLanguage = model.required<LanguageId>();
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.html
@@ -12,10 +12,12 @@
         } @else {
             @let complex = selectedEditionComplex();
             @let intro = view.data.introData.intro;
+            @let lang = selectedLanguage();
+            @let notesLabel = notesSectionLabel();
 
             <div class="awg-edition-intro-view p-5 border rounded-3">
                 <div class="row justify-content-center">
-                    @if (UTILS.isEmptyArray(intro?.[currentLanguage]?.content)) {
+                    @if (UTILS.isEmptyArray(intro?.[lang]?.content)) {
                         <awg-edition-intro-placeholder
                             class="col-12"
                             [editionComplex]="complex"
@@ -33,8 +35,8 @@
                         }
                         <awg-edition-intro-content
                             class="col-12 col-xl-10"
-                            [introBlockContent]="intro[currentLanguage].content"
-                            [notesLabel]="notesLabels.get(currentLanguage)"
+                            [introBlockContent]="intro[lang].content"
+                            [notesLabel]="notesLabel"
                             (navigateToIntroFragmentRequest)="onIntroFragmentNavigate($event)"
                             (navigateToReportFragmentRequest)="onReportFragmentNavigate($event)"
                             (openModalRequest)="onModalOpen($event)"
@@ -42,10 +44,9 @@
 
                         <awg-edition-intro-nav
                             class="col-12 col-xl-2 d-none d-xl-block"
-                            [introBlockContent]="intro[currentLanguage].content"
-                            [notesLabel]="notesLabels.get(currentLanguage)"
-                            [currentLanguage]="currentLanguage"
-                            (languageChangeRequest)="onLanguageSet($event)" />
+                            [introBlockContent]="intro[lang].content"
+                            [notesLabel]="notesLabel"
+                            [(selectedLanguage)]="selectedLanguage" />
                     }
                 </div>
             </div>

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.spec.ts
@@ -5,6 +5,7 @@ import {
     EventEmitter,
     Input,
     isSignal,
+    model,
     Output,
     signal,
     WritableSignal,
@@ -36,6 +37,7 @@ import {
 import { mockEditionData } from '@testing/mock-data';
 import { mockConsole } from '@testing/mock-helper';
 
+import { LanguageId } from '@awg-shared/language-switcher/language.model';
 import { EDITION_ROUTE_CONSTANTS } from '@awg-views/edition-view/edition-routes.constants';
 import {
     EditionComplex,
@@ -100,10 +102,7 @@ class EditionIntroNavStubComponent {
     introBlockContent: IntroBlock[];
     @Input()
     notesLabel: string;
-    @Input()
-    currentLanguage: number;
-    @Output()
-    languageChangeRequest = new EventEmitter<number>();
+    selectedLanguage = model.required<LanguageId>();
 }
 
 @Component({
@@ -157,7 +156,6 @@ describe('IntroComponent (DONE)', () => {
     let navigationSpy: Spy;
     let openModalSpy: Spy;
     let onIntroFragmentNavigateSpy: Spy;
-    let onLanguageSetSpy: Spy;
     let onModalOpenSpy: Spy;
     let onReportFragmentNavigateSpy: Spy;
     let onSvgSheetSelectSpy: Spy;
@@ -172,8 +170,8 @@ describe('IntroComponent (DONE)', () => {
     let expectedDefaultViewDataContent: EditionViewDataContent<'intro'>;
     let expectedIntroSectionData: IntroList;
     let expectedIntroSectionFilteredData: IntroList;
-    let expectedCurrentLaguage: number;
-    let expectedNotesLabels: Map<number, string>;
+    let expectedSelectedLanguage: LanguageId;
+    let expectedDefaultNotesSectionLabel: string;
     let expectedComplex: EditionComplex;
 
     let expectedComplexBaseRoute: string;
@@ -248,11 +246,8 @@ describe('IntroComponent (DONE)', () => {
         expectedIntroSectionData = structuredClone(mockEditionData.mockIntroSectionData);
         expectedIntroSectionFilteredData = structuredClone(mockEditionData.mockIntroSectionFilteredData);
 
-        expectedCurrentLaguage = 0;
-        expectedNotesLabels = new Map([
-            [0, 'Anmerkungen'],
-            [1, 'Notes'],
-        ]);
+        expectedSelectedLanguage = LanguageId.DE;
+        expectedDefaultNotesSectionLabel = 'Anmerkungen';
 
         expectedComplexId = 'op12';
         expectedComplexBaseRoute = `/edition/complex/${expectedComplexId}`;
@@ -279,7 +274,6 @@ describe('IntroComponent (DONE)', () => {
         navigationSpy = mockRouter.navigate as Mock;
         openModalSpy = vi.spyOn(component.modal, 'open');
         onIntroFragmentNavigateSpy = vi.spyOn(component, 'onIntroFragmentNavigate');
-        onLanguageSetSpy = vi.spyOn(component, 'onLanguageSet');
         onModalOpenSpy = vi.spyOn(component, 'onModalOpen');
         onReportFragmentNavigateSpy = vi.spyOn(component, 'onReportFragmentNavigate');
         onSvgSheetSelectSpy = vi.spyOn(component, 'onSvgSheetSelect');
@@ -297,12 +291,10 @@ describe('IntroComponent (DONE)', () => {
     });
 
     describe('BEFORE initial data binding', () => {
-        it('... should have `currentLanguage`', () => {
-            expectToBe(component.currentLanguage, expectedCurrentLaguage);
-        });
+        it('... should have signal `selectedLanguage` to hold the default language (DE)', () => {
+            expectToBe(isSignal(component.selectedLanguage), true);
 
-        it('... should have `notesLabels`', () => {
-            expectToEqual(component.notesLabels, expectedNotesLabels);
+            expectToBe(component.selectedLanguage(), expectedSelectedLanguage);
         });
 
         it('... should have signal `selectedEditionComplex` to hold null', () => {
@@ -315,6 +307,12 @@ describe('IntroComponent (DONE)', () => {
             expectToBe(isSignal(component.viewData), true);
 
             expectToEqual(component.viewData(), createMockViewData(expectedDefaultViewDataContent));
+        });
+
+        it('... should have computed signal `notesSectionLabel` to hold the default label', () => {
+            expectToBe(isSignal(component.notesSectionLabel), true);
+
+            expectToEqual(component.notesSectionLabel(), expectedDefaultNotesSectionLabel);
         });
 
         it('... should have `editionRouteConstants`', () => {
@@ -393,13 +391,21 @@ describe('IntroComponent (DONE)', () => {
         });
 
         it('... should have signal `selectedEditionComplex` to hold the expected complex', () => {
-            expectToBe(isSignal(component.selectedEditionComplex), true);
-
             expectToEqual(component.selectedEditionComplex(), expectedComplex);
         });
 
         it('... should have signal `viewData` to hold the expected view data', () => {
             expectToEqual(component.viewData(), createMockViewData(expectedViewDataContent));
+        });
+
+        it('... should have re-computed signal `notesSectionLabel` to hold the expected label when `selectedLanguage` changes', () => {
+            component.selectedLanguage.set(LanguageId.EN);
+
+            expectToEqual(component.notesSectionLabel(), 'Notes');
+
+            component.selectedLanguage.set(LanguageId.DE);
+
+            expectToEqual(component.notesSectionLabel(), expectedDefaultNotesSectionLabel);
         });
 
         it('... should have called `listenToRouteChanges()`', () => {
@@ -614,12 +620,9 @@ describe('IntroComponent (DONE)', () => {
 
                             expectToEqual(
                                 editionIntroContentCmp.introBlockContent,
-                                expectedIntroSectionFilteredData.intro[expectedCurrentLaguage].content
+                                expectedIntroSectionFilteredData.intro[expectedSelectedLanguage].content
                             );
-                            expectToEqual(
-                                editionIntroContentCmp.notesLabel,
-                                expectedNotesLabels.get(expectedCurrentLaguage)
-                            );
+                            expectToEqual(editionIntroContentCmp.notesLabel, expectedDefaultNotesSectionLabel);
                         });
 
                         it('... should contain one EditionIntroNavComponent (stubbed)', () => {
@@ -627,7 +630,7 @@ describe('IntroComponent (DONE)', () => {
                             getAndExpectDebugElementByDirective(divDes[0], EditionIntroNavStubComponent, 1, 1);
                         });
 
-                        it('... should pass down filtered `introBlockContent`, `notesLabel` and `currentLanguage` to EditionIntroNavComponent', () => {
+                        it('... should pass down filtered `introBlockContent`, `notesLabel` and `selectedLanguage` to EditionIntroNavComponent', () => {
                             const editionIntroNavDes = getAndExpectDebugElementByDirective(
                                 compDe,
                                 EditionIntroNavStubComponent,
@@ -640,13 +643,10 @@ describe('IntroComponent (DONE)', () => {
 
                             expectToEqual(
                                 editionIntroNavCmp.introBlockContent,
-                                expectedIntroSectionFilteredData.intro[expectedCurrentLaguage].content
+                                expectedIntroSectionFilteredData.intro[expectedSelectedLanguage].content
                             );
-                            expectToEqual(
-                                editionIntroNavCmp.notesLabel,
-                                expectedNotesLabels.get(expectedCurrentLaguage)
-                            );
-                            expectToEqual(editionIntroNavCmp.currentLanguage, expectedCurrentLaguage);
+                            expectToEqual(editionIntroNavCmp.notesLabel, expectedDefaultNotesSectionLabel);
+                            expectToEqual(editionIntroNavCmp.selectedLanguage(), expectedSelectedLanguage);
                         });
                     });
 
@@ -688,12 +688,9 @@ describe('IntroComponent (DONE)', () => {
 
                             expectToEqual(
                                 editionIntroContentCmp.introBlockContent,
-                                expectedIntroSectionData.intro[expectedCurrentLaguage].content
+                                expectedIntroSectionData.intro[expectedSelectedLanguage].content
                             );
-                            expectToEqual(
-                                editionIntroContentCmp.notesLabel,
-                                expectedNotesLabels.get(expectedCurrentLaguage)
-                            );
+                            expectToEqual(editionIntroContentCmp.notesLabel, expectedDefaultNotesSectionLabel);
                         });
 
                         it('... should contain one EditionIntroNavComponent (stubbed)', () => {
@@ -701,7 +698,7 @@ describe('IntroComponent (DONE)', () => {
                             getAndExpectDebugElementByDirective(divDes[0], EditionIntroNavStubComponent, 1, 1);
                         });
 
-                        it('... should pass down unfiltered `introBlockContent`, `notesLabel` and `currentLanguage` to EditionIntroNavComponent', () => {
+                        it('... should pass down unfiltered `introBlockContent`, `notesLabel` and `selectedLanguage` to EditionIntroNavComponent', () => {
                             const editionIntroNavDes = getAndExpectDebugElementByDirective(
                                 compDe,
                                 EditionIntroNavStubComponent,
@@ -714,13 +711,10 @@ describe('IntroComponent (DONE)', () => {
 
                             expectToEqual(
                                 editionIntroNavCmp.introBlockContent,
-                                expectedIntroSectionData.intro[expectedCurrentLaguage].content
+                                expectedIntroSectionData.intro[expectedSelectedLanguage].content
                             );
-                            expectToEqual(
-                                editionIntroNavCmp.notesLabel,
-                                expectedNotesLabels.get(expectedCurrentLaguage)
-                            );
-                            expectToEqual(editionIntroNavCmp.currentLanguage, expectedCurrentLaguage);
+                            expectToEqual(editionIntroNavCmp.notesLabel, expectedDefaultNotesSectionLabel);
+                            expectToEqual(editionIntroNavCmp.selectedLanguage(), expectedSelectedLanguage);
                         });
                     });
                 });
@@ -915,60 +909,6 @@ describe('IntroComponent (DONE)', () => {
 
                         expectSpyCall(navigationSpy, 1, [[], expectedNavigationExtras]);
                     });
-                });
-            });
-
-            describe('#onLanguageSet()', () => {
-                it('... should have a method `onLanguageSet`', () => {
-                    expect(component.onLanguageSet).toBeDefined();
-                });
-
-                it('... should trigger on event from EditionIntroNavComponent', () => {
-                    const editionIntroNavDes = getAndExpectDebugElementByDirective(
-                        compDe,
-                        EditionIntroNavStubComponent,
-                        1,
-                        1
-                    );
-                    const editionIntroNavCmp = editionIntroNavDes[0].injector.get(
-                        EditionIntroNavStubComponent
-                    ) as EditionIntroNavStubComponent;
-
-                    editionIntroNavCmp.languageChangeRequest.emit(expectedCurrentLaguage);
-
-                    expectSpyCall(onLanguageSetSpy, 1, expectedCurrentLaguage);
-                });
-
-                it('... should set `currentLanguage` to the given language', async () => {
-                    component.onLanguageSet(expectedCurrentLaguage);
-                    await detectChangesOnPush(fixture);
-
-                    expectToBe(component.currentLanguage, expectedCurrentLaguage);
-
-                    const newLanguage = 1;
-
-                    component.onLanguageSet(newLanguage);
-
-                    expectToBe(component.currentLanguage, newLanguage);
-                });
-
-                it('... should not change `currentLanguage` if the same language is passed', () => {
-                    const initialLanguage = component.currentLanguage;
-
-                    component.onLanguageSet(initialLanguage);
-
-                    expectToBe(component.currentLanguage, initialLanguage);
-                });
-
-                it('... should change `currentLanguage` if a different language is passed', () => {
-                    const initialLanguage = component.currentLanguage;
-                    const newLanguage = initialLanguage === 0 ? 1 : 0;
-
-                    component.onLanguageSet(newLanguage);
-
-                    expect(component.currentLanguage).not.toBe(initialLanguage);
-
-                    expectToBe(component.currentLanguage, newLanguage);
                 });
             });
 

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.ts
@@ -1,11 +1,22 @@
-import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    computed,
+    inject,
+    OnDestroy,
+    OnInit,
+    signal,
+    ViewChild,
+} from '@angular/core';
 import { NavigationEnd, NavigationExtras, Router } from '@angular/router';
 
 import { fromEvent, Subject } from 'rxjs';
 import { takeUntil, throttleTime } from 'rxjs/operators';
 
+import { LanguageId } from '@awg-shared/language-switcher/language.model';
 import { ModalComponent } from '@awg-shared/modal/modal.component';
 import { UTILS } from '@awg-shared/utils/object-utils';
+
 import { EDITION_ROUTE_CONSTANTS } from '@awg-views/edition-view/edition-routes.constants';
 import { EditionOutlineSection, EditionOutlineSeries } from '@awg-views/edition-view/models';
 import { EditionOutlineService, EditionStateService } from '@awg-views/edition-view/services';
@@ -47,6 +58,13 @@ export class EditionIntroComponent implements OnDestroy, OnInit {
     private readonly _editionStateService = inject(EditionStateService);
 
     /**
+     * Private readonly injection variable: _editionViewService.
+     *
+     * It keeps the instance of the injected EditionViewService.
+     */
+    private readonly _editionViewService = inject(EditionViewService);
+
+    /**
      * Private readonly injection variable: _router.
      *
      * It keeps the instance of the injected Angular Router.
@@ -68,23 +86,6 @@ export class EditionIntroComponent implements OnDestroy, OnInit {
     protected readonly UTILS = UTILS;
 
     /**
-     * Public variable: currentLanguage.
-     *
-     * It keeps the current language of the edition intro: 0 for German, 1 for English.
-     */
-    currentLanguage = 0;
-
-    /**
-     * Public variable: notesLabels.
-     *
-     * It keeps the labels for the notes in the edition intro.
-     */
-    notesLabels: Map<number, string> = new Map([
-        [0, 'Anmerkungen'],
-        [1, 'Notes'],
-    ]);
-
-    /**
      * Readonly signal: selectedEditionComplex.
      *
      * It holds the state of the selected edition complex.
@@ -96,7 +97,21 @@ export class EditionIntroComponent implements OnDestroy, OnInit {
      *
      * It holds the state of the intro view data.
      */
-    readonly viewData = inject(EditionViewService).introViewData;
+    readonly viewData = this._editionViewService.introViewData;
+
+    /**
+     * Public signal: selectedLanguage.
+     *
+     * It holds the selected language of the edition preface.
+     */
+    selectedLanguage = signal<LanguageId>(LanguageId.DE);
+
+    /**
+     * Readonly signal: notesSectionLabel.
+     *
+     * It computes the label for the notes section in the edition intro based on the selected language.
+     */
+    readonly notesSectionLabel = computed(() => this.selectedLanguage() === LanguageId.DE ? 'Anmerkungen' : 'Notes');
 
     /**
      * Constructor of the EditionIntroComponent.
@@ -173,18 +188,6 @@ export class EditionIntroComponent implements OnDestroy, OnInit {
             fragment: introIds?.fragmentId ?? '',
         };
         this._router.navigate([], navigationExtras);
-    }
-
-    /**
-     * Public method: onLanguageSet.
-     *
-     * It sets the current language of the edition intro.
-     *
-     * @param {number} language The given language number.
-     * @returns {void} Sets the current language.
-     */
-    onLanguageSet(language: number): void {
-        this.currentLanguage = language;
     }
 
     /**

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro.component.ts
@@ -102,7 +102,7 @@ export class EditionIntroComponent implements OnDestroy, OnInit {
     /**
      * Public signal: selectedLanguage.
      *
-     * It holds the selected language of the edition preface.
+     * It holds the selected language of the edition intro.
      */
     selectedLanguage = signal<LanguageId>(LanguageId.DE);
 
@@ -111,7 +111,7 @@ export class EditionIntroComponent implements OnDestroy, OnInit {
      *
      * It computes the label for the notes section in the edition intro based on the selected language.
      */
-    readonly notesSectionLabel = computed(() => this.selectedLanguage() === LanguageId.DE ? 'Anmerkungen' : 'Notes');
+    readonly notesSectionLabel = computed(() => (this.selectedLanguage() === LanguageId.DE ? 'Anmerkungen' : 'Notes'));
 
     /**
      * Constructor of the EditionIntroComponent.

--- a/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.html
+++ b/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.html
@@ -7,8 +7,11 @@
         @let preface = view.data.prefaceData.preface;
 
         <div class="awg-preface-view p-5 border rounded-3">
-            <awg-language-switcher [currentLanguage]="currentLanguage" (languageChangeRequest)="setLanguage($event)" />
-            @for (prefaceParagraph of preface[currentLanguage].content; track $index) {
+            <awg-language-switcher [(selectedLanguage)]="selectedLanguage" />
+
+            @let lang = selectedLanguage();
+
+            @for (prefaceParagraph of preface[lang]?.content; track $index) {
                 <div
                     class="awg-edition-preface-block"
                     [compile-html]="prefaceParagraph"

--- a/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.spec.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.spec.ts
@@ -21,6 +21,8 @@ import {
 import { mockEditionData } from '@testing/mock-data';
 
 import { CompileHtmlComponent } from '@awg-shared/compile-html';
+import { LanguageId } from '@awg-shared/language-switcher/language.model';
+
 import {
     EditionDataAssetsError,
     EditionViewData,
@@ -40,14 +42,13 @@ describe('EditionPrefaceComponent (DONE)', () => {
     let mockEditionGlyphService: Partial<EditionGlyphService>;
 
     let getGlyphSpy: Spy;
-    let setLanguageSpy: Spy;
     let editionGlyphServiceGetGlyphSpy: Spy;
 
     let mockViewDataSignal: WritableSignal<EditionViewData<'preface'>>;
     let expectedViewDataContent: EditionViewDataContent<'preface'>;
     let expectedDefaultViewDataContent: EditionViewDataContent<'preface'>;
     let expectedPrefaceData: PrefaceList;
-    let expectedCurrentLanguage: number;
+    let expectedSelectedLanguage: LanguageId;
 
     beforeEach(async () => {
         // Mock services
@@ -59,8 +60,8 @@ describe('EditionPrefaceComponent (DONE)', () => {
         };
 
         await TestBed.configureTestingModule({
-            imports: [AlertErrorStubComponent, TwelveToneSpinnerStubComponent],
-            declarations: [EditionPrefaceComponent, CompileHtmlComponent, LanguageSwitcherStubComponent],
+            imports: [AlertErrorStubComponent, LanguageSwitcherStubComponent, TwelveToneSpinnerStubComponent],
+            declarations: [EditionPrefaceComponent, CompileHtmlComponent],
             providers: [
                 { provide: EditionViewService, useValue: { prefaceViewData: mockViewDataSignal.asReadonly() } },
                 { provide: EditionGlyphService, useValue: mockEditionGlyphService },
@@ -73,7 +74,7 @@ describe('EditionPrefaceComponent (DONE)', () => {
         editionGlyphServiceGetGlyphSpy = vi.spyOn(mockEditionGlyphService, 'getGlyph');
 
         // Test data
-        expectedCurrentLanguage = 0;
+        expectedSelectedLanguage = LanguageId.DE;
         expectedPrefaceData = structuredClone(mockEditionData.mockPrefaceData);
 
         // Create component fixture
@@ -83,7 +84,6 @@ describe('EditionPrefaceComponent (DONE)', () => {
 
         // Component spies
         getGlyphSpy = vi.spyOn(component, 'getGlyph');
-        setLanguageSpy = vi.spyOn(component, 'setLanguage');
     });
 
     afterEach(() => {
@@ -101,8 +101,10 @@ describe('EditionPrefaceComponent (DONE)', () => {
             expectToEqual(component.viewData(), createMockViewData(expectedDefaultViewDataContent));
         });
 
-        it('... should have `currentLanguage` = 0', () => {
-            expectToBe(component.currentLanguage, expectedCurrentLanguage);
+        it('... should have signal `selectedLanguage` to hold the default language (DE)', () => {
+            expectToBe(isSignal(component.selectedLanguage), true);
+
+            expectToBe(component.selectedLanguage(), expectedSelectedLanguage);
         });
 
         it('... should have `ref`', () => {
@@ -126,7 +128,7 @@ describe('EditionPrefaceComponent (DONE)', () => {
                 getAndExpectDebugElementByCss(compDe, 'div.awg-preface-view', 0, 0);
             });
 
-            it('... should contain no language switcher component (stubbed)', () => {
+            it('... should contain no LanguageSwitcherComponent (stubbed)', () => {
                 getAndExpectDebugElementByDirective(compDe, LanguageSwitcherStubComponent, 0, 0);
             });
         });
@@ -149,6 +151,10 @@ describe('EditionPrefaceComponent (DONE)', () => {
 
         it('... should have signal `viewData` to hold the expected data', () => {
             expectToEqual(component.viewData(), createMockViewData(expectedViewDataContent));
+        });
+
+        it('... should have called EditionGlyphService', () => {
+            expectSpyCall(editionGlyphServiceGetGlyphSpy, 1);
         });
 
         describe('VIEW', () => {
@@ -236,13 +242,13 @@ describe('EditionPrefaceComponent (DONE)', () => {
                     getAndExpectDebugElementByCss(compDe, 'div.awg-preface-view', 1, 1);
                 });
 
-                it('... should contain one language switcher component (stubbed) in div.awg-preface-view', () => {
+                it('... should contain one LanguageSwitcherComponent (stubbed) in div.awg-preface-view', () => {
                     const divDes = getAndExpectDebugElementByCss(compDe, 'div.awg-preface-view', 1, 1);
 
                     getAndExpectDebugElementByDirective(divDes[0], LanguageSwitcherStubComponent, 1, 1);
                 });
 
-                it('... should pass down `currentLanguage` to language switcher component', () => {
+                it('... should pass down `selectedLanguage` to LanguageSwitcherComponent', () => {
                     const switcherDes = getAndExpectDebugElementByDirective(
                         compDe,
                         LanguageSwitcherStubComponent,
@@ -253,7 +259,24 @@ describe('EditionPrefaceComponent (DONE)', () => {
                         LanguageSwitcherStubComponent
                     ) as LanguageSwitcherStubComponent;
 
-                    expectToEqual(switcherCmp.currentLanguage, expectedCurrentLanguage);
+                    expectToEqual(switcherCmp.selectedLanguage(), expectedSelectedLanguage);
+                });
+
+                it('... should update `selectedLanguage` when LanguageSwitcherComponent emits a change', () => {
+                    const switcherDes = getAndExpectDebugElementByDirective(
+                        compDe,
+                        LanguageSwitcherStubComponent,
+                        1,
+                        1
+                    );
+
+                    expectToBe(component.selectedLanguage(), LanguageId.DE);
+
+                    switcherDes[0].triggerEventHandler('selectedLanguageChange', LanguageId.EN);
+
+                    fixture.detectChanges();
+
+                    expectToBe(component.selectedLanguage(), LanguageId.EN);
                 });
 
                 it('... should contain as many preface block elements in div.awg-preface-view as content items in preview data (german)', () => {
@@ -308,46 +331,6 @@ describe('EditionPrefaceComponent (DONE)', () => {
                     const result = component.getGlyph('[bb]');
 
                     expectToBe(result, 'glyphString');
-                });
-            });
-
-            describe('#setLanguage()', () => {
-                it('... should have a method `setLanguage`', () => {
-                    expect(component.setLanguage).toBeDefined();
-                });
-
-                it('... should trigger on event from LanguageSwitcherComponent', () => {
-                    const switcherDes = getAndExpectDebugElementByDirective(
-                        compDe,
-                        LanguageSwitcherStubComponent,
-                        1,
-                        1
-                    );
-                    const switcherCmp = switcherDes[0].injector.get(
-                        LanguageSwitcherStubComponent
-                    ) as LanguageSwitcherStubComponent;
-
-                    // Language = 0
-                    switcherCmp.languageChangeRequest.emit(0);
-
-                    expectSpyCall(setLanguageSpy, 1, 0);
-
-                    // Language = 1
-                    switcherCmp.languageChangeRequest.emit(1);
-
-                    expectSpyCall(setLanguageSpy, 2, 1);
-                });
-
-                it('... should set the currentLanguage to 0 when called with 0', () => {
-                    component.setLanguage(0);
-
-                    expectToBe(component.currentLanguage, 0);
-                });
-
-                it('... should set the currentLanguage to 1 when called with 1', () => {
-                    component.setLanguage(1);
-
-                    expectToBe(component.currentLanguage, 1);
                 });
             });
         });

--- a/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-preface/edition-preface.component.ts
@@ -1,6 +1,8 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 
-import { EditionGlyphService } from '@awg-views/edition-view/services';
+import { LanguageId } from '@awg-shared/language-switcher/language.model';
+
+import { EditionGlyphService } from '@awg-views/edition-view/services/edition-glyph.service';
 import { EditionViewService } from '@awg-views/edition-view/services/edition-view.service';
 
 /**
@@ -25,18 +27,6 @@ export class EditionPrefaceComponent {
     private readonly _editionGlyphService = inject(EditionGlyphService);
 
     /**
-     * Public variable: currentLanguage.
-     *
-     * It keeps the current language of the edition preface: 0 for German, 1 for English.
-     */
-    currentLanguage = 0;
-
-    /**
-     * Self-referring variable needed for CompileHtml library.
-     */
-    ref: EditionPrefaceComponent;
-
-    /**
      * Readonly signal: viewData.
      *
      * It holds the state of the preface view data.
@@ -44,14 +34,16 @@ export class EditionPrefaceComponent {
     readonly viewData = inject(EditionViewService).prefaceViewData;
 
     /**
-     * Constructor of the EditionPrefaceComponent.
+     * Public signal: selectedLanguage.
      *
-     * It declares the self-referring ref variable needed for CompileHtml library.
-     *
+     * It holds the selected language of the edition preface.
      */
-    constructor() {
-        this.ref = this;
-    }
+    selectedLanguage = signal<LanguageId>(LanguageId.DE);
+
+    /**
+     * Self-referring variable needed for CompileHtml library.
+     */
+    ref: EditionPrefaceComponent = this;
 
     /**
      * Public method: getGlyph.
@@ -64,17 +56,5 @@ export class EditionPrefaceComponent {
      */
     getGlyph(glyphString: string): string {
         return this._editionGlyphService.getGlyph(glyphString);
-    }
-
-    /**
-     * Public method: setLanguage.
-     *
-     * It sets the current language of the edition preface.
-     *
-     * @param {number} language The given language number.
-     * @returns {void} Sets the current language.
-     */
-    setLanguage(language: number): void {
-        this.currentLanguage = language;
     }
 }

--- a/src/testing/component-stubs.ts
+++ b/src/testing/component-stubs.ts
@@ -1,21 +1,23 @@
-import { Component, EventEmitter, Input, input, model, Output } from '@angular/core';
+import { Component, Input, input, model } from '@angular/core';
+import { SafeResourceUrl } from '@angular/platform-browser';
 
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 
 import { NavbarItem } from '@awg-core/navbar/navbar.model';
 
+import { LanguageId } from '@awg-shared/language-switcher/language.model';
 import { Logo, Logos } from '@awg-shared/logos/logos.model';
 import { MetaContact, MetaIdentifiers, MetaPage } from '@awg-shared/meta/meta.model';
 import { LabeledRoute } from '@awg-shared/models/labeled-route.model';
 
 import { HomeViewCard } from '@awg-views/home-view/home-view-card/home-view-card.model';
 
-import { SafeResourceUrl } from '@angular/platform-browser';
 import {
     EditionOutlineComplexItem,
     EditionOutlineSection,
     EditionOutlineSeries,
 } from '@awg-app/views/edition-view/models';
+
 import {
     StatisticsComplexBreakdown,
     StatisticsComplexBreakdownData,
@@ -113,13 +115,9 @@ export class HeadingStubComponent {
 @Component({
     selector: 'awg-language-switcher',
     template: '',
-    standalone: false,
 })
 export class LanguageSwitcherStubComponent {
-    @Input()
-    currentLanguage: number;
-    @Output()
-    languageChangeRequest = new EventEmitter<number>();
+    selectedLanguage = model.required<LanguageId>();
 }
 
 @Component({


### PR DESCRIPTION
This PR migrates the shared LanguageSwitcher to modern Angular (standalone, signals) and adjusts the comps that use it.