### PR TITLE
refactor(shared): rewrite compile-html directive for AOT

### DIFF
--- a/src/app/shared/compile-html/compile-html.directive.spec.ts
+++ b/src/app/shared/compile-html/compile-html.directive.spec.ts
@@ -173,7 +173,7 @@ describe('CompileHtmlDirective (DONE)', () => {
 
             it('... should call `_handleInteraction` with event target and event', () => {
                 const mockTarget = document.createElement('a');
-                const mockEvent = { target: mockTarget } as unknown as MouseEvent;
+                const mockEvent = { target: mockTarget as EventTarget } as unknown as MouseEvent;
 
                 (directive as any).onHostClick(mockEvent);
 
@@ -192,7 +192,7 @@ describe('CompileHtmlDirective (DONE)', () => {
                     { desc: 'the Space key', key: ' ' },
                 ])(`... $desc`, ({ key }) => {
                     const mockTarget = document.createElement('a');
-                    const mockEvent = { target: mockTarget, key: key } as unknown as KeyboardEvent;
+                    const mockEvent = { target: mockTarget as EventTarget, key: key } as unknown as KeyboardEvent;
 
                     (directive as any).onHostKeydown(mockEvent);
 
@@ -207,7 +207,7 @@ describe('CompileHtmlDirective (DONE)', () => {
                     { desc: 'any other key', key: 'ArrowUp' },
                 ])(`... $desc`, ({ key }) => {
                     const mockTarget = document.createElement('a');
-                    const mockEvent = { target: mockTarget, key: key } as unknown as KeyboardEvent;
+                    const mockEvent = { target: mockTarget as EventTarget, key: key } as unknown as KeyboardEvent;
 
                     (directive as any).onHostKeydown(mockEvent);
 
@@ -253,27 +253,17 @@ describe('CompileHtmlDirective (DONE)', () => {
                     expect(rendererSetAttributeSpy).toHaveBeenCalledWith(foundAnchor, 'tabindex', '0');
                     expect(rendererSetAttributeSpy).toHaveBeenCalledWith(foundAnchor, 'role', 'link');
                 });
-
-                it('... should not add accessibility attributes to standard links without data-attributes', async () => {
-                    rendererSetAttributeSpy.mockClear();
-
-                    const plainHtml = '<a href="https://example.com">External Link</a>';
-                    mockNativeElement.innerHTML = plainHtml;
-
-                    mockHtmlContentSignal.set(plainHtml);
-
-                    TestBed.tick();
-
-                    expectSpyCall(rendererSetAttributeSpy, 0);
-                });
             });
 
-            it('... should not add accessibility attributes to standard links without data-attributes', () => {
+            it('... should not add accessibility attributes to standard links without data-attributes', async () => {
                 rendererSetAttributeSpy.mockClear();
 
-                mockNativeElement.innerHTML = '<a href="https://example.com">External Link</a>';
+                const plainHtml = '<a href="https://example.com">External Link</a>';
+                mockNativeElement.innerHTML = plainHtml;
 
-                (directive as any)._applyAccessibilityAttributes();
+                mockHtmlContentSignal.set(plainHtml);
+
+                TestBed.tick();
 
                 expectSpyCall(rendererSetAttributeSpy, 0);
             });
@@ -334,11 +324,11 @@ describe('CompileHtmlDirective (DONE)', () => {
             });
 
             describe('... should do nothing', () => {
-                it('... if the target is neither an anchor nor an image', () => {
-                    const mockTarget = document.createElement('div');
+                it('... if the target is a Text node instead of an Element', () => {
+                    const mockTextNode = document.createTextNode('Just some text') as unknown as EventTarget;
                     const mockEvent = {} as unknown as Event;
 
-                    (directive as any)._handleInteraction(mockTarget, mockEvent);
+                    (directive as any)._handleInteraction(mockTextNode, mockEvent);
 
                     expectSpyCall(handleAnchorNavigationSpy, 0);
                     expectSpyCall(handleImageNavigationSpy, 0);

--- a/src/app/shared/compile-html/compile-html.directive.spec.ts
+++ b/src/app/shared/compile-html/compile-html.directive.spec.ts
@@ -1,0 +1,571 @@
+import { ElementRef, Renderer2, signal, WritableSignal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+type Spy = ReturnType<typeof vi.fn>;
+
+import { expectSpyCall, expectToBe } from '@testing/expect-helper';
+
+import { EditionGlyphService } from '@awg-views/edition-view/services';
+import {
+    EditionNavigationService,
+    FragmentClickEvent,
+    SheetClickEvent,
+} from '@awg-views/edition-view/services/edition-navigation.service';
+
+import { CompileHtmlDirective } from './compile-html.directive';
+
+describe('CompileHtmlDirective (DONE)', () => {
+    let directive: CompileHtmlDirective;
+
+    let applyAccessibilityAttributesSpy: Spy;
+    let handleInteractionSpy: Spy;
+    let handleAnchorNavigationSpy: Spy;
+    let handleImageNavigationSpy: Spy;
+    let serviceNavigateToIntroSpy: Spy;
+    let serviceNavigateToSheetSpy: Spy;
+    let serviceNavigateToReportSpy: Spy;
+    let serviceGetGlyphSpy: Spy;
+    let rendererSetAttributeSpy: Spy;
+    let rendererSetPropertySpy: Spy;
+
+    let mockHtmlContentSignal: WritableSignal<string>;
+    let mockNativeElement: HTMLElement;
+
+    let expectedComplexId: string;
+    let expectedIntroFragment: string;
+    let expectedReportFragment: string;
+    let expectedSvgSheetId: string;
+
+    beforeEach(() => {
+        // Mock the input signal and native element
+        mockHtmlContentSignal = signal('');
+        mockNativeElement = document.createElement('div');
+
+        TestBed.configureTestingModule({
+            providers: [
+                CompileHtmlDirective,
+                {
+                    provide: ElementRef,
+                    useValue: { nativeElement: mockNativeElement },
+                },
+                {
+                    provide: Renderer2,
+                    useValue: {
+                        setAttribute: vi.fn(),
+                        setProperty: vi.fn(),
+                    },
+                },
+                {
+                    provide: EditionNavigationService,
+                    useValue: {
+                        navigateToIntroFragment: vi.fn(),
+                        navigateToSvgSheet: vi.fn(),
+                        navigateToReportFragment: vi.fn(),
+                    },
+                },
+            ],
+        });
+
+        directive = TestBed.inject(CompileHtmlDirective);
+
+        (directive as any).htmlContent = mockHtmlContentSignal;
+
+        // Spies
+        applyAccessibilityAttributesSpy = vi.spyOn(directive as any, '_applyAccessibilityAttributes');
+        handleInteractionSpy = vi.spyOn(directive as any, '_handleInteraction');
+        handleAnchorNavigationSpy = vi.spyOn(directive as any, '_handleAnchorNavigation');
+        handleImageNavigationSpy = vi.spyOn(directive as any, '_handleImageNavigation');
+
+        const navigationService = TestBed.inject(EditionNavigationService);
+        serviceNavigateToIntroSpy = vi.spyOn(navigationService, 'navigateToIntroFragment');
+        serviceNavigateToSheetSpy = vi.spyOn(navigationService, 'navigateToSvgSheet');
+        serviceNavigateToReportSpy = vi.spyOn(navigationService, 'navigateToReportFragment');
+
+        const renderer = TestBed.inject(Renderer2);
+        rendererSetAttributeSpy = vi.spyOn(renderer, 'setAttribute');
+        rendererSetPropertySpy = vi.spyOn(renderer, 'setProperty');
+
+        const glyphService = TestBed.inject(EditionGlyphService);
+        serviceGetGlyphSpy = vi.spyOn(glyphService, 'getGlyph').mockImplementation((glyph: string) => `${glyph}`);
+
+        // Test data
+        expectedComplexId = 'op12';
+        expectedIntroFragment = 'note-80';
+        expectedReportFragment = 'source_A';
+        expectedSvgSheetId = 'test-1';
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should create an instance', () => {
+        expect(directive).toBeTruthy();
+    });
+
+    describe('effect()', () => {
+        describe('... should set innerHTML correctly depending on the input including', () => {
+            it.each([
+                {
+                    desc: 'an empty string if content is missing',
+                    inputValue: null,
+                    expectedOutput: '',
+                },
+                {
+                    desc: 'a standard HTML string',
+                    inputValue: '<p>Hello World</p>',
+                    expectedOutput: '<p>Hello World</p>',
+                },
+                {
+                    desc: 'simple plain text without HTML tags',
+                    inputValue: 'Plain Text Content',
+                    expectedOutput: 'Plain Text Content',
+                },
+            ])(`... $desc`, async ({ inputValue, expectedOutput }) => {
+                mockHtmlContentSignal.set(inputValue);
+
+                TestBed.tick();
+
+                expectSpyCall(rendererSetPropertySpy, 1, [mockNativeElement, 'innerHTML', expectedOutput]);
+            });
+        });
+
+        describe('... should preserve data-attributes including', () => {
+            it.each([
+                {
+                    desc: 'data-complex-id and data-intro-fragment-id',
+                    getExpectedOutput: () =>
+                        `<a data-complex-id="${expectedComplexId}" data-intro-fragment-id="${expectedIntroFragment}">Link</a>`,
+                },
+                {
+                    desc: 'data-complex-id and data-sheet-id attributes',
+                    getExpectedOutput: () =>
+                        `<a data-complex-id="${expectedComplexId}" data-sheet-id="${expectedSvgSheetId}">Sheet</a>`,
+                },
+                {
+                    desc: 'data-complex-id and data-report-fragment-id',
+                    getExpectedOutput: () =>
+                        `<a data-complex-id="${expectedComplexId}" data-report-fragment-id="${expectedReportFragment}">Report</a>`,
+                },
+            ])(`... $desc`, async ({ getExpectedOutput }) => {
+                mockHtmlContentSignal.set(getExpectedOutput());
+
+                TestBed.tick();
+
+                expectSpyCall(rendererSetPropertySpy, 1, [mockNativeElement, 'innerHTML', getExpectedOutput()]);
+            });
+        });
+
+        it('... should call `_applyAccessibilityAttributes()` when htmlContent changes', async () => {
+            mockHtmlContentSignal.set('<p>Test</p>');
+            TestBed.tick();
+
+            expectSpyCall(applyAccessibilityAttributesSpy, 1);
+        });
+    });
+
+    describe('METHODS', () => {
+        describe('#onHostClick()', () => {
+            it('... should have a method `onHostClick`', () => {
+                expect((directive as any).onHostClick).toBeDefined();
+            });
+
+            it('... should call `_handleInteraction` with event target and event', () => {
+                const mockTarget = document.createElement('a');
+                const mockEvent = { target: mockTarget } as unknown as MouseEvent;
+
+                (directive as any).onHostClick(mockEvent);
+
+                expectSpyCall(handleInteractionSpy, 1, [mockTarget, mockEvent]);
+            });
+        });
+
+        describe('#onHostKeydown()', () => {
+            it('... should have a method `onHostKeydown`', () => {
+                expect((directive as any).onHostKeydown).toBeDefined();
+            });
+
+            describe('... should call `_handleInteraction` when pressing', () => {
+                it.each([
+                    { desc: 'the Enter key', key: 'Enter' },
+                    { desc: 'the Space key', key: ' ' },
+                ])(`... $desc`, ({ key }) => {
+                    const mockTarget = document.createElement('a');
+                    const mockEvent = { target: mockTarget, key: key } as unknown as KeyboardEvent;
+
+                    (directive as any).onHostKeydown(mockEvent);
+
+                    expectSpyCall(handleInteractionSpy, 1, [mockTarget, mockEvent]);
+                });
+            });
+
+            describe('... should not call `_handleInteraction` when pressing', () => {
+                it.each([
+                    { desc: 'the Escape key', key: 'Escape' },
+                    { desc: 'the Tab key', key: 'Tab' },
+                    { desc: 'any other key', key: 'ArrowUp' },
+                ])(`... $desc`, ({ key }) => {
+                    const mockTarget = document.createElement('a');
+                    const mockEvent = { target: mockTarget, key: key } as unknown as KeyboardEvent;
+
+                    (directive as any).onHostKeydown(mockEvent);
+
+                    expect(handleInteractionSpy).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('#_applyAccessibilityAttributes()', () => {
+            it('... should have a method `_applyAccessibilityAttributes`', () => {
+                expect((directive as any)._applyAccessibilityAttributes).toBeDefined();
+            });
+
+            describe('... should add accessibility attributes to dynamic links including', () => {
+                it.each([
+                    {
+                        desc: 'links with data-intro-fragment-id',
+                        getExpectedOutput: () =>
+                            `<a data-complex-id="${expectedComplexId}" data-intro-fragment-id="${expectedIntroFragment}">Link</a>`,
+                    },
+                    {
+                        desc: 'links with data-sheet-id',
+                        getExpectedOutput: () =>
+                            `<a data-complex-id="${expectedComplexId}" data-sheet-id="${expectedSvgSheetId}">Sheet</a>`,
+                    },
+                    {
+                        desc: 'links with data-report-fragment-id',
+                        getExpectedOutput: () =>
+                            `<a data-complex-id="${expectedComplexId}" data-report-fragment-id="${expectedReportFragment}">Report</a>`,
+                    },
+                ])(`... $desc`, async ({ getExpectedOutput }) => {
+                    const htmlString = getExpectedOutput();
+
+                    mockNativeElement.innerHTML = htmlString;
+
+                    mockHtmlContentSignal.set(htmlString);
+
+                    TestBed.tick();
+
+                    const foundAnchor = mockNativeElement.querySelector('a');
+
+                    expectSpyCall(rendererSetAttributeSpy, 2);
+                    expect(rendererSetAttributeSpy).toHaveBeenCalledWith(foundAnchor, 'tabindex', '0');
+                    expect(rendererSetAttributeSpy).toHaveBeenCalledWith(foundAnchor, 'role', 'link');
+                });
+
+                it('... should not add accessibility attributes to standard links without data-attributes', async () => {
+                    rendererSetAttributeSpy.mockClear();
+
+                    const plainHtml = '<a href="https://example.com">External Link</a>';
+                    mockNativeElement.innerHTML = plainHtml;
+
+                    mockHtmlContentSignal.set(plainHtml);
+
+                    TestBed.tick();
+
+                    expectSpyCall(rendererSetAttributeSpy, 0);
+                });
+            });
+
+            it('... should not add accessibility attributes to standard links without data-attributes', () => {
+                rendererSetAttributeSpy.mockClear();
+
+                mockNativeElement.innerHTML = '<a href="https://example.com">External Link</a>';
+
+                (directive as any)._applyAccessibilityAttributes();
+
+                expectSpyCall(rendererSetAttributeSpy, 0);
+            });
+        });
+
+        describe('#_handleInteraction()', () => {
+            it('... should have a method `_handleInteraction`', () => {
+                expect((directive as any)._handleInteraction).toBeDefined();
+            });
+
+            describe('... should forward the interaction to the correct handler if target is', () => {
+                const createMockDOM = (tagName: string, wrapInAnchor = false) => {
+                    const element = document.createElement(tagName);
+                    if (wrapInAnchor) {
+                        const anchor = document.createElement('a');
+                        anchor.appendChild(element);
+                        return element;
+                    }
+                    return element;
+                };
+
+                it.each([
+                    {
+                        desc: 'an anchor element directly',
+                        target: createMockDOM('a'),
+                        getExpectedSpy: () => handleAnchorNavigationSpy,
+                        getUnexpectedSpy: () => handleImageNavigationSpy,
+                    },
+                    {
+                        desc: 'a span element wrapped inside an anchor',
+                        target: createMockDOM('span', true),
+                        getExpectedSpy: () => handleAnchorNavigationSpy,
+                        getUnexpectedSpy: () => handleImageNavigationSpy,
+                    },
+                    {
+                        desc: 'an image element directly',
+                        target: createMockDOM('img'),
+                        getExpectedSpy: () => handleImageNavigationSpy,
+                        getUnexpectedSpy: () => handleAnchorNavigationSpy,
+                    },
+                    {
+                        desc: 'an image element wrapped inside an anchor (anchor takes priority)',
+                        target: createMockDOM('img', true),
+                        getExpectedSpy: () => handleAnchorNavigationSpy,
+                        getUnexpectedSpy: () => handleImageNavigationSpy,
+                    },
+                ])(`... $desc`, ({ target, getExpectedSpy, getUnexpectedSpy }) => {
+                    const mockEvent = {} as unknown as Event;
+
+                    (directive as any)._handleInteraction(target, mockEvent);
+
+                    const expectedSpy = getExpectedSpy();
+                    const expectedElement = target.closest(expectedSpy === handleAnchorNavigationSpy ? 'a' : 'img');
+                    expectSpyCall(expectedSpy, 1, [expectedElement, mockEvent]);
+
+                    expectSpyCall(getUnexpectedSpy(), 0);
+                });
+            });
+
+            describe('... should do nothing', () => {
+                it('... if the target is neither an anchor nor an image', () => {
+                    const mockTarget = document.createElement('div');
+                    const mockEvent = {} as unknown as Event;
+
+                    (directive as any)._handleInteraction(mockTarget, mockEvent);
+
+                    expectSpyCall(handleAnchorNavigationSpy, 0);
+                    expectSpyCall(handleImageNavigationSpy, 0);
+                });
+            });
+        });
+
+        describe('#_handleAnchorNavigation()', () => {
+            it('... should have a method `_handleAnchorNavigation`', () => {
+                expect((directive as any)._handleAnchorNavigation).toBeDefined();
+            });
+
+            describe('... should navigate to', () => {
+                const testCases = [
+                    {
+                        desc: 'intro fragment with complexId if data-intro-fragment-id is given',
+                        attributes: { 'data-complex-id': 'op12', 'data-intro-fragment-id': 'intro-1' },
+                        expectedArgs: { complexId: 'op12', fragmentId: 'intro-1' } as FragmentClickEvent,
+                        getExpectedSpy: () => serviceNavigateToIntroSpy,
+                    },
+                    {
+                        desc: 'intro fragment with empty complexId if data-complex-id is missing',
+                        attributes: { 'data-intro-fragment-id': 'intro-2' },
+                        expectedArgs: { complexId: '', fragmentId: 'intro-2' } as FragmentClickEvent,
+                        getExpectedSpy: () => serviceNavigateToIntroSpy,
+                    },
+                    {
+                        desc: 'svg sheet if data-sheet-id and data-complex-id are given',
+                        attributes: { 'data-complex-id': 'op12', 'data-sheet-id': 'sheet-3' },
+                        expectedArgs: { complexId: 'op12', sheetId: 'sheet-3' } as SheetClickEvent,
+                        getExpectedSpy: () => serviceNavigateToSheetSpy,
+                    },
+                    {
+                        desc: 'report fragment if data-report-fragment-id and data-complex-id are given',
+                        attributes: { 'data-complex-id': 'op12', 'data-report-fragment-id': 'report-4' },
+                        expectedArgs: { complexId: 'op12', fragmentId: 'report-4' } as FragmentClickEvent,
+                        getExpectedSpy: () => serviceNavigateToReportSpy,
+                    },
+                ];
+
+                it.each(testCases)(`... $desc`, ({ attributes, expectedArgs, getExpectedSpy }) => {
+                    const mockAnchor = {
+                        getAttribute: (key: string) => attributes[key as keyof typeof attributes] || null,
+                    } as unknown as HTMLAnchorElement;
+
+                    const mockEvent = {
+                        preventDefault: vi.fn(),
+                    } as unknown as Event;
+
+                    (directive as any)._handleAnchorNavigation(mockAnchor, mockEvent);
+
+                    expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+
+                    const targetSpy = getExpectedSpy();
+
+                    expectSpyCall(targetSpy, 1, [expectedArgs]);
+
+                    [serviceNavigateToIntroSpy, serviceNavigateToSheetSpy, serviceNavigateToReportSpy]
+                        .filter(spy => spy !== targetSpy)
+                        .forEach(spy => expectSpyCall(spy, 0));
+                });
+            });
+
+            describe('... should not navigate (if data-complex-id is missing)', () => {
+                const testCases = [
+                    {
+                        desc: 'to svg sheet',
+                        attributes: { 'data-sheet-id': 'sheet-5' },
+                    },
+                    {
+                        desc: 'to report fragment',
+                        attributes: { 'data-report-fragment-id': 'report-6' },
+                    },
+                    {
+                        desc: 'if data-complex-id is present but no data-sheet-id or data-report-fragment-id',
+                        attributes: { 'data-complex-id': 'op12' },
+                    },
+                ];
+
+                it.each(testCases)(`... $desc`, ({ attributes }) => {
+                    const mockAnchor = {
+                        getAttribute: (key: string) => attributes[key as keyof typeof attributes] || null,
+                    } as unknown as HTMLAnchorElement;
+
+                    const mockEvent = {
+                        preventDefault: vi.fn(),
+                    } as unknown as Event;
+
+                    (directive as any)._handleAnchorNavigation(mockAnchor, mockEvent);
+
+                    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+
+                    expectSpyCall(serviceNavigateToIntroSpy, 0);
+                    expectSpyCall(serviceNavigateToSheetSpy, 0);
+                    expectSpyCall(serviceNavigateToReportSpy, 0);
+                });
+            });
+        });
+
+        describe('#_handleImageNavigation()', () => {
+            it('... should have a method `_handleImageNavigation`', () => {
+                expect((directive as any)._handleImageNavigation).toBeDefined();
+            });
+
+            describe('... should handle snippet images', () => {
+                it('... and open the snippet if data-snippet-id and data-snippet-src are present', () => {
+                    const mockImg = {
+                        hasAttribute: (attr: string) => attr === 'data-snippet-id' || attr === 'data-snippet-src',
+                        getAttribute: (attr: string) => {
+                            if (attr === 'data-snippet-src') {
+                                return 'path/to/image.png';
+                            }
+                            if (attr === 'data-snippet-id') {
+                                return 'snip-123';
+                            }
+                            return null;
+                        },
+                    } as unknown as HTMLImageElement;
+
+                    const mockEvent = { preventDefault: vi.fn() } as unknown as Event;
+
+                    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+                    (directive as any)._handleImageNavigation(mockImg, mockEvent);
+
+                    expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+                    expect(consoleSpy).toHaveBeenCalledWith('Snippet öffnen:', {
+                        src: 'path/to/image.png',
+                        id: 'snip-123',
+                    });
+
+                    consoleSpy.mockRestore();
+                });
+            });
+
+            describe('... should not handle images if', () => {
+                it.each([
+                    {
+                        desc: 'data-snippet-id is missing (but src is present)',
+                        hasId: false,
+                        hasSrc: true,
+                        attributes: { 'data-snippet-src': 'path/to/image.png' },
+                    },
+                    {
+                        desc: 'data-snippet-src is missing (but id is present)',
+                        hasId: true,
+                        hasSrc: false,
+                        attributes: { 'data-snippet-id': 'snip-123' },
+                    },
+                    {
+                        desc: 'both data-snippet-id and data-snippet-src are missing',
+                        hasId: false,
+                        hasSrc: false,
+                        attributes: {},
+                    },
+                ])(`... $desc`, ({ hasId, hasSrc, attributes }) => {
+                    const mockImg = {
+                        hasAttribute: (attr: string) => {
+                            if (attr === 'data-snippet-id') {
+                                return hasId;
+                            }
+                            if (attr === 'data-snippet-src') {
+                                return hasSrc;
+                            }
+                            return false;
+                        },
+                        getAttribute: (attr: string) => attributes[attr as keyof typeof attributes] || null,
+                    } as unknown as HTMLImageElement;
+
+                    const mockEvent = { preventDefault: vi.fn() } as unknown as Event;
+
+                    (directive as any)._handleImageNavigation(mockImg, mockEvent);
+
+                    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('#_replaceGlyphPlaceholders()', () => {
+            it('... should have a method `_replaceGlyphPlaceholders`', () => {
+                expect((directive as any)._replaceGlyphPlaceholders).toBeDefined();
+            });
+
+            const glyphTestCases = [
+                {
+                    desc: 'return the original string if no glyph placeholder is present',
+                    inputValue: '<p>Standard HTML Content</p>',
+                    getExpectedOutput: () => '<p>Standard HTML Content</p>',
+                    shouldCallService: false,
+                    expectedServiceArgs: [],
+                },
+                {
+                    desc: 'replace a single glyph placeholder with the value from GlyphService',
+                    inputValue: "Text with <span class='glyph accid'>{{ref.getGlyph('[a]')}}</span> here.",
+                    getExpectedOutput: () => "Text with <span class='glyph accid'>[a]</span> here.",
+                    shouldCallService: true,
+                    expectedServiceArgs: ['[a]'],
+                },
+                {
+                    desc: 'replace multiple glyph placeholders within the same HTML string',
+                    inputValue:
+                        "<span class='glyph'>{{ref.getGlyph('[p]')}}</span> and <span class='glyph unicode'>{{ref.getGlyph('[ped]')}}</span>",
+                    getExpectedOutput: () =>
+                        "<span class='glyph'>[p]</span> and <span class='glyph unicode'>[ped]</span>",
+                    shouldCallService: true,
+                    expectedServiceArgs: ['[p]', '[ped]'],
+                },
+            ];
+
+            it.each(glyphTestCases)(
+                `... should $desc`,
+                ({ inputValue, getExpectedOutput, shouldCallService, expectedServiceArgs }) => {
+                    const result = (directive as any)._replaceGlyphPlaceholders(inputValue);
+
+                    expectToBe(result, getExpectedOutput());
+
+                    if (shouldCallService) {
+                        expect(serviceGetGlyphSpy).toHaveBeenCalledTimes(expectedServiceArgs.length);
+
+                        expectedServiceArgs.forEach((arg, index) => {
+                            expect(serviceGetGlyphSpy).toHaveBeenNthCalledWith(index + 1, arg);
+                        });
+                    } else {
+                        expectSpyCall(serviceGetGlyphSpy, 0);
+                    }
+                }
+            );
+        });
+    });
+});

--- a/src/app/shared/compile-html/compile-html.directive.ts
+++ b/src/app/shared/compile-html/compile-html.directive.ts
@@ -1,0 +1,216 @@
+import { Directive, effect, ElementRef, inject, input, Renderer2 } from '@angular/core';
+import { EditionGlyphService } from '@awg-app/views/edition-view/services';
+
+import { EditionNavigationService } from '@awg-views/edition-view/services/edition-navigation.service';
+
+/**
+ * The CompileHtmlDirective.
+ *
+ * It compiles and renders HTML content in the host element.
+ * It also emits events for clicks on specific elements within the compiled HTML.
+ */
+@Directive({
+    selector: '[awgCompileHtml]',
+    host: {
+        '(click)': 'onHostClick($event)',
+        '(keydown)': 'onHostKeydown($event)',
+    },
+    standalone: true,
+})
+export class CompileHtmlDirective {
+    /**
+     * Private readonly injection variable: _el
+     *
+     * It keeps the instance of the injected ElementRef.
+     */
+    private readonly _el = inject(ElementRef);
+
+    /**
+     * Private readonly injection variable: _renderer
+     *
+     * It keeps the instance of the injected Renderer2.
+     */
+    private readonly _renderer = inject(Renderer2);
+
+    /**
+     * Private readonly injection variable: _glyphService
+     *
+     * It keeps the instance of the injected EditionGlyphService.
+     */
+    private readonly _glyphService = inject(EditionGlyphService);
+
+    /**
+     * Private readonly injection variable: _navigationService
+     *
+     * It keeps the instance of the injected EditionNavigationService.
+     */
+    private readonly _navigationService = inject(EditionNavigationService);
+
+    /**
+     * Readonly input signal: htmlContent.
+     *
+     * It keeps the HTML content to be compiled and rendered.
+     */
+    readonly htmlContent = input<string>('', { alias: 'awgCompileHtml' });
+
+    /**
+     * The constructor of the CompileHtmlDirective.
+     *
+     * It sets up the effect to update the innerHTML of the host element.
+     */
+    constructor() {
+        effect(() => {
+            let content = this.htmlContent() || '';
+
+            content = this._replaceGlyphPlaceholders(content);
+
+            this._renderer.setProperty(this._el.nativeElement, 'innerHTML', content);
+
+            this._applyAccessibilityAttributes();
+        });
+    }
+
+    /**
+     * Protected method: onHostClick.
+     *
+     * It handles click events on the host element.
+     *
+     * @param {MouseEvent} event The click event.
+     * @returns {void} Calls the appropriate handler methods based on the target element.
+     */
+    protected onHostClick(event: MouseEvent): void {
+        const target = event.target as HTMLElement;
+        this._handleInteraction(target, event);
+    }
+
+    /**
+     * Protected method: onHostKeydown.
+     *
+     * It handles keydown events on the host element for Enter and Space keys.
+     *
+     * @param {KeyboardEvent} event The keydown event.
+     * @returns {void} Calls the appropriate handler methods based on the target element.
+     */
+    protected onHostKeydown(event: KeyboardEvent): void {
+        const target = event.target as HTMLElement;
+
+        if (event.key === 'Enter' || event.key === ' ') {
+            this._handleInteraction(target, event);
+        }
+    }
+
+    /**
+     * Private method: _applyAccessibilityAttributes.
+     *
+     * It finds all dynamic edition links inside the host element and applies
+     * tabindex and role attributes for better accessibility and keyboard navigation.
+     *
+     * @returns {void} Applies the attributes directly to the DOM elements.
+     */
+    private _applyAccessibilityAttributes(): void {
+        const selectors = 'a[data-complex-id], a[data-intro-fragment-id], a[data-sheet-id], a[data-report-fragment-id]';
+        const anchors = this._el.nativeElement.querySelectorAll(selectors);
+
+        anchors.forEach((anchor: HTMLAnchorElement) => {
+            this._renderer.setAttribute(anchor, 'tabindex', '0');
+            this._renderer.setAttribute(anchor, 'role', 'link');
+        });
+    }
+
+    /**
+     * Private method: _handleInteraction.
+     *
+     * It handles click and keydown events on the host element and calls the appropriate handler methods.
+     *
+     * @param {HTMLElement} target The target element of the event.
+     * @param {Event} event The click or keydown event.
+     * @returns {void} Calls the appropriate handler methods based on the target element.
+     */
+    private _handleInteraction(target: HTMLElement, event: Event): void {
+        const anchor = target.closest('a');
+        if (anchor) {
+            this._handleAnchorNavigation(anchor, event);
+            return;
+        }
+
+        const img = target.closest('img');
+        if (img) {
+            this._handleImageNavigation(img, event);
+        }
+    }
+
+    /**
+     * Private method: _handleAnchorNavigation.
+     *
+     * It handles click events on anchor elements and calls the appropriate navigation methods from the EditionNavigationService.
+     *
+     * @param {HTMLAnchorElement} anchor The clicked anchor element.
+     * @param {Event} event The click event.
+     * @returns {void} Calls the appropriate navigation methods based on the clicked anchor element.
+     */
+    private _handleAnchorNavigation(anchor: HTMLAnchorElement, event: Event): void {
+        const complexId = anchor.getAttribute('data-complex-id') || '';
+
+        const introFragmentId = anchor.getAttribute('data-intro-fragment-id');
+        if (introFragmentId) {
+            event.preventDefault();
+            this._navigationService.navigateToIntroFragment({ complexId, fragmentId: introFragmentId });
+            return;
+        }
+
+        if (complexId) {
+            const sheetId = anchor.getAttribute('data-sheet-id');
+            if (sheetId) {
+                event.preventDefault();
+                this._navigationService.navigateToSvgSheet({ complexId, sheetId });
+                return;
+            }
+
+            const reportFragmentId = anchor.getAttribute('data-report-fragment-id');
+            if (reportFragmentId) {
+                event.preventDefault();
+                this._navigationService.navigateToReportFragment({ complexId, fragmentId: reportFragmentId });
+                return;
+            }
+        }
+    }
+
+    /**
+     * Private method: _handleImageNavigation.
+     *
+     * It handles click events on image elements and calls the appropriate navigation methods from the EditionNavigationService.
+     *
+     * @param {HTMLImageElement} img The clicked image element.
+     * @param {Event} event The click event.
+     * @returns {void} Calls the appropriate navigation methods based on the clicked image element.
+     */
+    private _handleImageNavigation(img: HTMLImageElement, event: Event): void {
+        if (!img.hasAttribute('data-snippet-id') || !img.hasAttribute('data-snippet-src')) {
+            return;
+        }
+
+        event.preventDefault();
+        const src = img.getAttribute('data-snippet-src');
+        const id = img.getAttribute('data-snippet-id');
+
+        // TODO: Handling of snippets
+        // This._navigationService.openSnippet(src, id);
+        console.log('Snippet öffnen:', { src, id });
+    }
+
+    /**
+     * Private method: _replaceGlyphPlaceholders.
+     *
+     * It replaces placeholders in the content with the corresponding glyphs from the EditionGlyphService.
+     *
+     * @param {string} content The HTML content to be processed.
+     * @returns {string} The processed content with glyph placeholders replaced.
+     */
+    private _replaceGlyphPlaceholders(content: string): string {
+        if (!content.includes('ref.getGlyph')) {
+            return content;
+        }
+        const regex = /\{\{ref\.getGlyph\('([^']+)'\)\}\}/g;
+        return content.replace(regex, (_, glyphString) => this._glyphService.getGlyph(glyphString));
+    }
+}

--- a/src/app/shared/compile-html/compile-html.directive.ts
+++ b/src/app/shared/compile-html/compile-html.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, effect, ElementRef, inject, input, Renderer2 } from '@angular/core';
-import { EditionGlyphService } from '@awg-app/views/edition-view/services';
 
+import { EditionGlyphService } from '@awg-views/edition-view/services/edition-glyph.service';
 import { EditionNavigationService } from '@awg-views/edition-view/services/edition-navigation.service';
 
 /**
@@ -57,6 +57,15 @@ export class CompileHtmlDirective {
      * The constructor of the CompileHtmlDirective.
      *
      * It sets up the effect to update the innerHTML of the host element.
+     *
+     * @security This input bypasses Angular's innerHTML sanitization via Renderer2
+     * because the application exclusively feeds it with strictly trusted, static HTML
+     * strings loaded directly from internal, project-managed JSON assets (such as the
+     * edition intro or report data).
+     *
+     * To maintain security and prevent Cross-Site Scripting (XSS) vulnerabilities,
+     * this input MUST NEVER be bound to dynamic user-generated content or external,
+     * untrusted API data sources.
      */
     constructor() {
         effect(() => {
@@ -79,8 +88,7 @@ export class CompileHtmlDirective {
      * @returns {void} Calls the appropriate handler methods based on the target element.
      */
     protected onHostClick(event: MouseEvent): void {
-        const target = event.target as HTMLElement;
-        this._handleInteraction(target, event);
+        this._handleInteraction(event.target, event);
     }
 
     /**
@@ -92,10 +100,8 @@ export class CompileHtmlDirective {
      * @returns {void} Calls the appropriate handler methods based on the target element.
      */
     protected onHostKeydown(event: KeyboardEvent): void {
-        const target = event.target as HTMLElement;
-
         if (event.key === 'Enter' || event.key === ' ') {
-            this._handleInteraction(target, event);
+            this._handleInteraction(event.target, event);
         }
     }
 
@@ -122,11 +128,15 @@ export class CompileHtmlDirective {
      *
      * It handles click and keydown events on the host element and calls the appropriate handler methods.
      *
-     * @param {HTMLElement} target The target element of the event.
+     * @param {EventTarget | null} target The target element of the event.
      * @param {Event} event The click or keydown event.
      * @returns {void} Calls the appropriate handler methods based on the target element.
      */
-    private _handleInteraction(target: HTMLElement, event: Event): void {
+    private _handleInteraction(target: EventTarget | null, event: Event): void {
+        if (!(target instanceof Element)) {
+            return;
+        }
+
         const anchor = target.closest('a');
         if (anchor) {
             this._handleAnchorNavigation(anchor, event);

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -35,6 +35,7 @@ import { ViewHandleButtonGroupComponent } from './view-handle-button-group/view-
 //
 // Shared directives
 import { AbbrDirective } from './abbr/abbr.directive';
+import { CompileHtmlDirective } from './compile-html/compile-html.directive';
 import { ExternalLinkDirective } from './external-link/external-link.directive';
 
 //
@@ -65,9 +66,10 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
         LicenseComponent,
         LogoComponent,
         MetaIdentifierBadgesComponent,
-        ExternalLinkDirective,
         ScrollToTopButtonComponent,
         TwelveToneSpinnerComponent,
+        ExternalLinkDirective,
+        CompileHtmlDirective,
     ],
     declarations: [
         DisclaimerWorkeditionsComponent,
@@ -110,6 +112,7 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
         ViewHandleButtonGroupComponent,
         AbbrDirective,
         ExternalLinkDirective,
+        CompileHtmlDirective,
         OrderByPipe,
     ],
 })

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-graph/edition-graph.component.ts
@@ -21,11 +21,6 @@ import { EditionViewService } from '@awg-views/edition-view/services/edition-vie
 })
 export class EditionGraphComponent {
     /**
-     * Self-referring variable needed for CompileHtml library.
-     */
-    ref: EditionGraphComponent;
-
-    /**
      * Readonly signal: isFullscreen.
      *
      * It holds the fullscreen status.
@@ -47,6 +42,13 @@ export class EditionGraphComponent {
     readonly viewData = inject(EditionViewService).graphViewData;
 
     /**
+     * Protected readonly variable: UTILS.
+     *
+     * It keeps the reference to the {@link UTILS} methods.
+     */
+    protected readonly UTILS = UTILS;
+
+    /**
      * Readonly variable: GRAPH_IMAGES.
      *
      * It keeps the paths to static graph images.
@@ -57,18 +59,7 @@ export class EditionGraphComponent {
     };
 
     /**
-     * Protected readonly variable: UTILS.
-     *
-     * It keeps the reference to the {@link UTILS} methods.
+     * Self-referring variable needed for CompileHtml library.
      */
-    protected readonly UTILS = UTILS;
-
-    /**
-     * Constructor of the EditionGraphComponent.
-     *
-     * It initializes the self-referring variable needed for CompileHtml library.
-     */
-    constructor() {
-        this.ref = this;
-    }
+    ref: EditionGraphComponent = this;
 }

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-content/edition-intro-content.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-intro/edition-intro-content/edition-intro-content.component.ts
@@ -18,6 +18,13 @@ import { EditionGlyphService } from '@awg-views/edition-view/services';
 })
 export class EditionIntroContentComponent {
     /**
+     * Private readonly injection variable: _editionGlyphService.
+     *
+     * It keeps the instance of the injected EditionGlyphService.
+     */
+    private readonly _editionGlyphService = inject(EditionGlyphService);
+
+    /**
      * Input variable: introBlockContent.
      *
      * It keeps the content blocks of the intro.
@@ -69,23 +76,7 @@ export class EditionIntroContentComponent {
     /**
      * Self-referring variable needed for CompileHtml library.
      */
-    ref: EditionIntroContentComponent;
-
-    /**
-     * Private readonly injection variable: _editionGlyphService.
-     *
-     * It keeps the instance of the injected EditionGlyphService.
-     */
-    private readonly _editionGlyphService = inject(EditionGlyphService);
-
-    /**
-     * Constructor of the EditionIntroContentComponent.
-     *
-     * It initializes the self-referring variable needed for CompileHtml library.
-     */
-    constructor() {
-        this.ref = this;
-    }
+    ref: EditionIntroContentComponent = this;
 
     /**
      * Public method: getGlyph.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-content-table/source-description-content-table.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-content-table/source-description-content-table.component.ts
@@ -34,11 +34,6 @@ export class SourceDescriptionContentTableComponent {
     selectSvgSheetRequest: EventEmitter<{ complexId: string; sheetId: string }> = new EventEmitter();
 
     /**
-     * Self-referring variable needed for CompileHtml library.
-     */
-    ref: SourceDescriptionContentTableComponent;
-
-    /**
      * Protected readonly variable: UTILS.
      *
      * It keeps the reference to the {@link UTILS} methods.
@@ -46,13 +41,9 @@ export class SourceDescriptionContentTableComponent {
     protected readonly UTILS = UTILS;
 
     /**
-     * Constructor of the SourceDescriptionContentTableComponent.
-     *
-     * It initializes the self-referring variable needed for CompileHtml library.
+     * Self-referring variable needed for CompileHtml library.
      */
-    constructor() {
-        this.ref = this;
-    }
+    ref: SourceDescriptionContentTableComponent = this;
 
     /**
      * Public method: selectSvgSheet.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-contents/source-description-contents.component.ts
@@ -41,11 +41,6 @@ export class SourceDescriptionContentsComponent {
     openAllContentDetails = true;
 
     /**
-     * Self-referring variable needed for CompileHtml library.
-     */
-    ref: SourceDescriptionContentsComponent;
-
-    /**
      * Protected readonly variable: UTILS.
      *
      * It keeps the reference to the {@link UTILS} methods.
@@ -53,13 +48,9 @@ export class SourceDescriptionContentsComponent {
     protected readonly UTILS = UTILS;
 
     /**
-     * Constructor of the SourceDescriptionContentComponent.
-     *
-     * It initializes the self-referring variable needed for CompileHtml library.
+     * Self-referring variable needed for CompileHtml library.
      */
-    constructor() {
-        this.ref = this;
-    }
+    ref: SourceDescriptionContentsComponent = this;
 
     /**
      * Public method: selectSvgSheet.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-corrections/source-description-corrections.component.ts
@@ -59,16 +59,7 @@ export class SourceDescriptionCorrectionsComponent {
     /**
      * Self-referring variable needed for CompileHtml library.
      */
-    ref: SourceDescriptionCorrectionsComponent;
-
-    /**
-     * Constructor of the SourceDescriptionComponent.
-     *
-     * It initializes the self-referring variable needed for CompileHtml library.
-     */
-    constructor() {
-        this.ref = this;
-    }
+    ref: SourceDescriptionCorrectionsComponent = this;
 
     /**
      * Public method: navigateToReportFragment.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-details/source-description-details.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-details/source-description-details.component.ts
@@ -65,11 +65,6 @@ export class SourceDescriptionDetailsComponent {
     selectSvgSheetRequest: EventEmitter<{ complexId: string; sheetId: string }> = new EventEmitter();
 
     /**
-     * Self-referring variable needed for CompileHtml library.
-     */
-    ref: SourceDescriptionDetailsComponent;
-
-    /**
      * Protected readonly variable: UTILS.
      *
      * It keeps the reference to the {@link UTILS} methods.
@@ -77,13 +72,9 @@ export class SourceDescriptionDetailsComponent {
     protected readonly UTILS = UTILS;
 
     /**
-     * Constructor of the SourceDescriptionDetailsComponent.
-     *
-     * It initializes the self-referring variable needed for CompileHtml library.
+     * Self-referring variable needed for CompileHtml library.
      */
-    constructor() {
-        this.ref = this;
-    }
+    ref: SourceDescriptionDetailsComponent = this;
 
     /**
      * Public method: navigateToReportFragment.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-writing-materials/source-description-writing-materials.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description-writing-materials/source-description-writing-materials.component.ts
@@ -33,11 +33,6 @@ export class SourceDescriptionWritingMaterialsComponent {
     writingMaterials: SourceDescriptionWritingMaterial[];
 
     /**
-     * Self-referring variable needed for CompileHtml library.
-     */
-    ref: SourceDescriptionWritingMaterialsComponent;
-
-    /**
      * Protected readonly variable: UTILS.
      *
      * It keeps the reference to the {@link UTILS} methods.
@@ -52,13 +47,9 @@ export class SourceDescriptionWritingMaterialsComponent {
     readonly TRADEMARKS = EDITION_TRADEMARKS_DATA;
 
     /**
-     * Constructor of the SourceDescriptionContentComponent.
-     *
-     * It initializes the self-referring variable needed for CompileHtml library.
+     * Self-referring variable needed for CompileHtml library.
      */
-    constructor() {
-        this.ref = this;
-    }
+    ref: SourceDescriptionWritingMaterialsComponent = this;
 
     /**
      * Public method: getTradeMark.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-description/source-description.component.ts
@@ -51,11 +51,6 @@ export class SourceDescriptionComponent {
     selectSvgSheetRequest: EventEmitter<{ complexId: string; sheetId: string }> = new EventEmitter();
 
     /**
-     * Self-referring variable needed for CompileHtml library.
-     */
-    ref: SourceDescriptionComponent;
-
-    /**
      * Protected readonly variable: UTILS.
      *
      * It keeps the reference to the {@link UTILS} methods.
@@ -63,13 +58,9 @@ export class SourceDescriptionComponent {
     protected readonly UTILS = UTILS;
 
     /**
-     * Constructor of the SourceDescriptionComponent.
-     *
-     * It initializes the self-referring variable needed for CompileHtml library.
+     * Self-referring variable needed for CompileHtml library.
      */
-    constructor() {
-        this.ref = this;
-    }
+    ref: SourceDescriptionComponent = this;
 
     /**
      * Public method: getWritingInstruments.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-evaluation/source-evaluation.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-evaluation/source-evaluation.component.ts
@@ -60,11 +60,6 @@ export class SourceEvaluationComponent {
     selectSvgSheetRequest: EventEmitter<{ complexId: string; sheetId: string }> = new EventEmitter();
 
     /**
-     * Self-referring variable needed for CompileHtml library.
-     */
-    ref: SourceEvaluationComponent;
-
-    /**
      * Protected readonly variable: UTILS.
      *
      * It keeps the reference to the {@link UTILS} methods.
@@ -72,13 +67,9 @@ export class SourceEvaluationComponent {
     protected readonly UTILS = UTILS;
 
     /**
-     * Constructor of the SourceEvaluationComponent.
-     *
-     * It initializes the self-referring ref variable needed for CompileHtml library.
+     * Self-referring variable needed for CompileHtml library.
      */
-    constructor() {
-        this.ref = this;
-    }
+    ref: SourceEvaluationComponent = this;
 
     /**
      * Getter variable: editionRouteConstants.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-list/source-list.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/source-list/source-list.component.ts
@@ -44,11 +44,6 @@ export class SourceListComponent {
     openModalRequest: EventEmitter<string> = new EventEmitter();
 
     /**
-     * Self-referring variable needed for CompileHtml library.
-     */
-    ref: SourceListComponent;
-
-    /**
      * Protected readonly variable: UTILS.
      *
      * It keeps the reference to the {@link UTILS} methods.
@@ -56,13 +51,9 @@ export class SourceListComponent {
     protected readonly UTILS = UTILS;
 
     /**
-     * Constructor of the SourceListComponent.
-     *
-     * It initializes the self-referring ref variable needed for CompileHtml library.
+     * Self-referring variable needed for CompileHtml library.
      */
-    constructor() {
-        this.ref = this;
-    }
+    ref: SourceListComponent = this;
 
     /**
      * Public method: onSourceClick.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-report/textcritics-list/textcritics-list.component.ts
@@ -53,11 +53,6 @@ export class TextcriticsListComponent {
     selectSvgSheetRequest: EventEmitter<{ complexId: string; sheetId: string }> = new EventEmitter();
 
     /**
-     * Self-referring variable needed for CompileHtml library.
-     */
-    ref: TextcriticsListComponent;
-
-    /**
      * Protected readonly variable: EDITION_UTILS.
      *
      * It keeps the reference to the {@link EDITION_UTILS} methods.
@@ -72,13 +67,9 @@ export class TextcriticsListComponent {
     protected readonly UTILS = UTILS;
 
     /**
-     * Constructor of the TextcriticsComponent.
-     *
-     * It initializes the self-referring ref variable needed for CompileHtml library.
+     * Self-referring variable needed for CompileHtml library.
      */
-    constructor() {
-        this.ref = this;
-    }
+    ref: TextcriticsListComponent = this;
 
     /**
      * Public method: navigateToReportFragment.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-footer/edition-svg-sheet-footer.component.ts
@@ -70,6 +70,13 @@ export class EditionSvgSheetFooterComponent {
     selectSvgSheetRequest: EventEmitter<{ complexId: string; sheetId: string }> = new EventEmitter();
 
     /**
+     * Protected readonly variable: UTILS.
+     *
+     * It keeps the reference to the {@link UTILS} methods.
+     */
+    protected readonly UTILS = UTILS;
+
+    /**
      * Public variable: faChevronRight.
      *
      * It instantiates fontawesome's faChevronRight icon.
@@ -86,7 +93,7 @@ export class EditionSvgSheetFooterComponent {
     /**
      * Self-referring variable needed for CompileHtml library.
      */
-    ref: EditionSvgSheetFooterComponent;
+    ref: EditionSvgSheetFooterComponent = this;
 
     /**
      * Public variable: showEvaluation.
@@ -94,23 +101,6 @@ export class EditionSvgSheetFooterComponent {
      * It keeps a boolean flag if the evaluation shall be displayed.
      */
     showEvaluation = false;
-
-    /**
-     * Protected readonly variable: UTILS.
-     *
-     * It keeps the reference to the {@link UTILS} methods.
-     */
-    protected readonly UTILS = UTILS;
-
-    /**
-     * Constructor of the EditionSvgSheetFooterComponent.
-     *
-     * It initializes the self-referring ref variable needed for CompileHtml library.
-     *
-     */
-    constructor() {
-        this.ref = this;
-    }
 
     /**
      * Public method: navigateToReportFragment.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-accolade/edition-svg-sheet-viewer/edition-svg-sheet-viewer.component.ts
@@ -47,6 +47,27 @@ import * as D3_ZOOM from 'd3-zoom';
 })
 export class EditionSvgSheetViewerComponent implements OnChanges, OnDestroy, AfterViewInit {
     /**
+     * Private readonly injection variable: _cdr.
+     *
+     * It keeps the instance of the injected Angular ChangeDetectorRef.
+     */
+    private readonly _cdr = inject(ChangeDetectorRef);
+
+    /**
+     * Private readonly injection variable: _svgDrawingService.
+     *
+     * It keeps the instance of the injected EditionSvgDrawingService.
+     */
+    private readonly _svgDrawingService = inject(EditionSvgDrawingService);
+
+    /**
+     * Private readonly injection variable: _svgOverlayService.
+     *
+     * It keeps the instance of the injected EditionSvgOverlayService.
+     */
+    private readonly _svgOverlayService = inject(EditionSvgOverlayService);
+
+    /**
      * ViewChild variable: svgSheetContainerRef.
      *
      * It keeps the reference to the svg sheet container.
@@ -164,7 +185,7 @@ export class EditionSvgSheetViewerComponent implements OnChanges, OnDestroy, Aft
     /**
      * Self-referring variable needed for CompileHtml library.
      */
-    ref: EditionSvgSheetViewerComponent;
+    ref: EditionSvgSheetViewerComponent = this;
 
     /**
      * Private variable: _divWidth.
@@ -207,36 +228,6 @@ export class EditionSvgSheetViewerComponent implements OnChanges, OnDestroy, Aft
      * It keeps a subject for a resize event.
      */
     private readonly _resize$: Subject<boolean> = new Subject<boolean>();
-
-    /**
-     * Private readonly injection variable: _cdr.
-     *
-     * It keeps the instance of the injected Angular ChangeDetectorRef.
-     */
-    private readonly _cdr = inject(ChangeDetectorRef);
-
-    /**
-     * Private readonly injection variable: _svgDrawingService.
-     *
-     * It keeps the instance of the injected EditionSvgDrawingService.
-     */
-    private readonly _svgDrawingService = inject(EditionSvgDrawingService);
-
-    /**
-     * Private readonly injection variable: _svgOverlayService.
-     *
-     * It keeps the instance of the injected EditionSvgOverlayService.
-     */
-    private readonly _svgOverlayService = inject(EditionSvgOverlayService);
-
-    /**
-     * Constructor of the EditionSvgSheetViewerComponent.
-     *
-     * It declares the self-referring variable needed for CompileHtml library.
-     */
-    constructor() {
-        this.ref = this;
-    }
 
     /**
      * HostListener: onResize.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/edition-folio-viewer.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-sheets/edition-convolute/edition-folio-viewer/edition-folio-viewer.component.ts
@@ -39,6 +39,13 @@ import * as D3_SELECTION from 'd3-selection';
 })
 export class EditionFolioViewerComponent implements OnChanges, AfterViewChecked {
     /**
+     * Private readonly injection variable: _folioService.
+     *
+     * It keeps the instance of the injected FolioService.
+     */
+    private readonly _folioService = inject(FolioService);
+
+    /**
      * Input variable: selectedConvolute.
      *
      * It keeps the selected convolute.
@@ -97,7 +104,7 @@ export class EditionFolioViewerComponent implements OnChanges, AfterViewChecked 
     /**
      * Self-referring variable needed for CompileHtml library.
      */
-    ref: EditionFolioViewerComponent;
+    ref: EditionFolioViewerComponent = this;
 
     /**
      * Private readonly variable: _folioSettings.
@@ -112,22 +119,6 @@ export class EditionFolioViewerComponent implements OnChanges, AfterViewChecked 
         initialOffsetY: 5,
         numberOfFolios: 0,
     };
-
-    /**
-     * Private readonly injection variable: _folioService.
-     *
-     * It keeps the instance of the injected FolioService.
-     */
-    private readonly _folioService = inject(FolioService);
-
-    /**
-     * Constructor of the FolioComponent.
-     *
-     * It initializes the self-referring ref variable needed for CompileHtml library.
-     */
-    constructor() {
-        this.ref = this;
-    }
 
     /**
      * Angular life cycle hook: ngOnChanges.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-evaluations/edition-tka-evaluations.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-evaluations/edition-tka-evaluations.component.ts
@@ -17,6 +17,13 @@ import { EditionGlyphService } from '@awg-views/edition-view/services';
 })
 export class EditionTkaEvaluationsComponent {
     /**
+     * Private readonly injection variable: _editionGlyphService.
+     *
+     * It keeps the instance of the injected EditionGlyphService.
+     */
+    private readonly _editionGlyphService = inject(EditionGlyphService);
+
+    /**
      * Input variable: evaluations.
      *
      * It keeps the evaluations data.
@@ -52,23 +59,7 @@ export class EditionTkaEvaluationsComponent {
     /**
      * Self-referring variable needed for CompileHtml library.
      */
-    ref: EditionTkaEvaluationsComponent;
-
-    /**
-     * Private readonly injection variable: _editionGlyphService.
-     *
-     * It keeps the instance of the injected EditionGlyphService.
-     */
-    private readonly _editionGlyphService = inject(EditionGlyphService);
-
-    /**
-     * Constructor of the EditionTkaEvaluationsComponent.
-     *
-     * It initializes the self-referring ref variable needed for CompileHtml library.
-     */
-    constructor() {
-        this.ref = this;
-    }
+    ref: EditionTkaEvaluationsComponent = this;
 
     /**
      * Public method: getGlyph.

--- a/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-table/edition-tka-table.component.ts
+++ b/src/app/views/edition-view/edition-outlets/edition-complex/edition-detail/edition-tka/edition-tka-table/edition-tka-table.component.ts
@@ -116,6 +116,20 @@ export class EditionTkaTableComponent {
     snippetModalTemplate: TemplateRef<any>;
 
     /**
+     * Protected readonly variable: EDITION_UTILS.
+     *
+     * It keeps the reference to the {@link EDITION_UTILS} methods.
+     */
+    protected readonly EDITION_UTILS = EDITION_UTILS;
+
+    /**
+     * Protected readonly variable: UTILS.
+     *
+     * It keeps the reference to the {@link UTILS} methods.
+     */
+    protected readonly UTILS = UTILS;
+
+    /**
      * Public variable: snippetId.
      *
      * It keeps the id of the snippet image to be displayed in the modal.
@@ -132,7 +146,7 @@ export class EditionTkaTableComponent {
     /**
      * Self-referring variable needed for CompileHtml library.
      */
-    ref: EditionTkaTableComponent;
+    ref: EditionTkaTableComponent = this;
 
     /**
      * Public variable: tableHeaderStrings.
@@ -159,29 +173,6 @@ export class EditionTkaTableComponent {
             { reference: 'comment', label: 'Anmerkung' },
         ],
     };
-
-    /**
-     * Protected readonly variable: EDITION_UTILS.
-     *
-     * It keeps the reference to the {@link EDITION_UTILS} methods.
-     */
-    protected readonly EDITION_UTILS = EDITION_UTILS;
-
-    /**
-     * Protected readonly variable: UTILS.
-     *
-     * It keeps the reference to the {@link UTILS} methods.
-     */
-    protected readonly UTILS = UTILS;
-
-    /**
-     * Constructor of the EditionTkaTableComponent.
-     *
-     * It initializes the self-referring ref variable needed for CompileHtml library.
-     */
-    constructor() {
-        this.ref = this;
-    }
 
     /**
      * Public method: getComment.

--- a/src/app/views/edition-view/services/edition-navigation.service.spec.ts
+++ b/src/app/views/edition-view/services/edition-navigation.service.spec.ts
@@ -1,0 +1,726 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+type Spy = ReturnType<typeof vi.spyOn>;
+
+import { EditionStateHelper } from '@testing/edition-state-helper';
+import { expectSpyCall } from '@testing/expect-helper';
+import { mockEditionData } from '@testing/mock-data/mockEditionData';
+
+import { EditionComplex } from '../models/edition-complex.model';
+import { EditionSvgSheet } from '../models/edition-svg-sheet.model';
+
+import { EDITION_ROUTE_CONSTANTS } from '../edition-routes.constants';
+import { EditionStateService } from './edition-state.service';
+
+import { EditionNavigationService, FragmentClickEvent, SheetClickEvent } from './edition-navigation.service';
+
+describe('EditionNavigationService (DONE)', () => {
+    let service: EditionNavigationService;
+
+    let editionStateService: EditionStateService;
+
+    let router: Router;
+
+    let navigationSpy: Spy;
+    let navigateWithComplexIdSpy: Spy;
+
+    let expectedComplexId: string;
+    let expectedComplex: EditionComplex;
+    let expectedComplexBaseRoute: string;
+    let expectedNextComplexId: string;
+    let expectedIntroFragment: string;
+    let expectedReportFragment: string;
+    let expectedSvgSheet: EditionSvgSheet;
+
+    const expectedIntroRoute = EDITION_ROUTE_CONSTANTS.EDITION_INTRO.route;
+    const expectedSheetRoute = EDITION_ROUTE_CONSTANTS.EDITION_SHEETS.route;
+    const expectedReportRoute = EDITION_ROUTE_CONSTANTS.EDITION_REPORT.route;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [EditionNavigationService, provideRouter([])],
+        });
+
+        // Inject services
+        service = TestBed.inject(EditionNavigationService);
+        editionStateService = TestBed.inject(EditionStateService);
+        router = TestBed.inject(Router);
+
+        // Service spies
+        navigateWithComplexIdSpy = vi.spyOn(service as any, '_navigateWithComplexId');
+        navigationSpy = vi.spyOn(router, 'navigate').mockReturnValue(Promise.resolve(true));
+
+        // Test data
+        expectedComplexId = 'op12';
+        expectedComplexBaseRoute = `/edition/complex/${expectedComplexId}`;
+        expectedComplex = EditionStateHelper.getComplex(expectedComplexId);
+        expectedNextComplexId = 'testComplex2';
+        expectedIntroFragment = 'note-80';
+        expectedReportFragment = 'source_A';
+        expectedSvgSheet = structuredClone(mockEditionData.mockSvgSheet_Sk1);
+
+        editionStateService.updateSelectedEditionComplex(expectedComplex);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+
+    describe('METHODS', () => {
+        describe('#navigateToIntroFragment()', () => {
+            it('... should have a method `navigateToIntroFragment`', () => {
+                expect(service.navigateToIntroFragment).toBeDefined();
+            });
+
+            it('... should call `_navigateWithComplexId()` method with correct parameters', () => {
+                const expectedIntroIds: FragmentClickEvent = {
+                    complexId: expectedComplexId,
+                    fragmentId: expectedIntroFragment,
+                };
+                const expectedNavigationExtras = {
+                    fragment: expectedIntroIds.fragmentId,
+                };
+
+                service.navigateToIntroFragment(expectedIntroIds);
+
+                expectSpyCall(navigateWithComplexIdSpy, 1, [
+                    expectedIntroIds.complexId,
+                    expectedIntroRoute,
+                    expectedNavigationExtras,
+                ]);
+            });
+
+            describe('... should call `_navigateWithComplexId()` method with empty fragment id if', () => {
+                it('... fragment id is undefined', () => {
+                    const expectedIntroIds: FragmentClickEvent = {
+                        complexId: expectedComplexId,
+                        fragmentId: undefined,
+                    };
+                    const expectedNavigationExtras = {
+                        fragment: '',
+                    };
+
+                    service.navigateToIntroFragment(expectedIntroIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        expectedIntroIds.complexId,
+                        expectedIntroRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... fragment id is null', () => {
+                    const expectedIntroIds: FragmentClickEvent = {
+                        complexId: expectedComplexId,
+                        fragmentId: null,
+                    };
+                    const expectedNavigationExtras = {
+                        fragment: '',
+                    };
+
+                    service.navigateToIntroFragment(expectedIntroIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        expectedIntroIds.complexId,
+                        expectedIntroRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... fragment id is empty string', () => {
+                    const expectedIntroIds: FragmentClickEvent = { complexId: expectedComplexId, fragmentId: '' };
+                    const expectedNavigationExtras = {
+                        fragment: '',
+                    };
+
+                    service.navigateToIntroFragment(expectedIntroIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        expectedIntroIds.complexId,
+                        expectedIntroRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+            });
+
+            describe('... should call `_navigateWithComplexId()` method with undefined complex id if', () => {
+                it('... introIds are undefined', () => {
+                    const expectedIntroIds: FragmentClickEvent = undefined;
+                    const expectedNavigationExtras = {
+                        fragment: '',
+                    };
+
+                    service.navigateToIntroFragment(expectedIntroIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        undefined,
+                        expectedIntroRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... introIds are null', () => {
+                    const expectedIntroIds: FragmentClickEvent = null;
+                    const expectedNavigationExtras = {
+                        fragment: '',
+                    };
+
+                    service.navigateToIntroFragment(expectedIntroIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        undefined,
+                        expectedIntroRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... complex id is empty string', () => {
+                    const expectedIntroIds: FragmentClickEvent = {
+                        complexId: '',
+                        fragmentId: expectedIntroFragment,
+                    };
+                    const expectedNavigationExtras = {
+                        fragment: expectedIntroIds.fragmentId,
+                    };
+
+                    service.navigateToIntroFragment(expectedIntroIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, ['', expectedIntroRoute, expectedNavigationExtras]);
+                });
+            });
+        });
+
+        describe('#navigateToReportFragment()', () => {
+            it('... should have a method `navigateToReportFragment`', () => {
+                expect(service.navigateToReportFragment).toBeDefined();
+            });
+
+            it('... should call `_navigateWithComplexId()` method with correct parameters', () => {
+                const expectedReportIds: FragmentClickEvent = {
+                    complexId: expectedComplexId,
+                    fragmentId: expectedReportFragment,
+                };
+                const expectedNavigationExtras = {
+                    fragment: expectedReportIds.fragmentId,
+                };
+
+                service.navigateToReportFragment(expectedReportIds);
+
+                expectSpyCall(navigateWithComplexIdSpy, 1, [
+                    expectedReportIds.complexId,
+                    expectedReportRoute,
+                    expectedNavigationExtras,
+                ]);
+            });
+
+            describe('... should call `_navigateWithComplexId()` method with empty fragment id if', () => {
+                it('... fragment id is undefined', () => {
+                    const expectedReportIds: FragmentClickEvent = {
+                        complexId: expectedComplexId,
+                        fragmentId: undefined,
+                    };
+                    const expectedNavigationExtras = {
+                        fragment: '',
+                    };
+
+                    service.navigateToReportFragment(expectedReportIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        expectedReportIds.complexId,
+                        expectedReportRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... fragment id is null', () => {
+                    const expectedReportIds: FragmentClickEvent = {
+                        complexId: expectedComplexId,
+                        fragmentId: null,
+                    };
+                    const expectedNavigationExtras = {
+                        fragment: '',
+                    };
+
+                    service.navigateToReportFragment(expectedReportIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        expectedReportIds.complexId,
+                        expectedReportRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... fragment id is empty string', () => {
+                    const expectedReportIds: FragmentClickEvent = {
+                        complexId: expectedComplexId,
+                        fragmentId: '',
+                    };
+                    const expectedNavigationExtras = {
+                        fragment: '',
+                    };
+
+                    service.navigateToReportFragment(expectedReportIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        expectedReportIds.complexId,
+                        expectedReportRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+            });
+
+            describe('... should call `_navigateWithComplexId()` method with undefined complex id if', () => {
+                it('... reportIds are undefined', () => {
+                    const expectedReportIds: FragmentClickEvent = undefined;
+                    const expectedNavigationExtras = {
+                        fragment: '',
+                    };
+
+                    service.navigateToReportFragment(expectedReportIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        undefined,
+                        expectedReportRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... reportIds are null', () => {
+                    const expectedReportIds: FragmentClickEvent = null;
+                    const expectedNavigationExtras = {
+                        fragment: '',
+                    };
+
+                    service.navigateToReportFragment(expectedReportIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        undefined,
+                        expectedReportRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... complex id is empty string', () => {
+                    const expectedReportIds: FragmentClickEvent = {
+                        complexId: '',
+                        fragmentId: expectedReportFragment,
+                    };
+                    const expectedNavigationExtras = {
+                        fragment: expectedReportIds.fragmentId,
+                    };
+
+                    service.navigateToReportFragment(expectedReportIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, ['', expectedReportRoute, expectedNavigationExtras]);
+                });
+            });
+        });
+
+        describe('#navigateToSvgSheet()', () => {
+            it('... should have a method `navigateToSvgSheet`', () => {
+                expect(service.navigateToSvgSheet).toBeDefined();
+            });
+
+            it('... should call `_navigateWithComplexId()` method with correct parameters', () => {
+                const expectedSheetIds: SheetClickEvent = {
+                    complexId: expectedComplexId,
+                    sheetId: expectedSvgSheet.id,
+                };
+                const expectedNavigationExtras = {
+                    queryParams: { id: expectedSheetIds.sheetId },
+                };
+
+                service.navigateToSvgSheet(expectedSheetIds);
+
+                expectSpyCall(navigateWithComplexIdSpy, 1, [
+                    expectedSheetIds.complexId,
+                    expectedSheetRoute,
+                    expectedNavigationExtras,
+                ]);
+            });
+
+            describe('... should call `_navigateWithComplexId()` method with empty fragment id if', () => {
+                it('... fragment id is undefined', () => {
+                    const expectedSheetIds: SheetClickEvent = { complexId: expectedComplexId, sheetId: undefined };
+                    const expectedNavigationExtras = {
+                        queryParams: { id: '' },
+                    };
+
+                    service.navigateToSvgSheet(expectedSheetIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        expectedSheetIds.complexId,
+                        expectedSheetRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... fragment id is null', () => {
+                    const expectedSheetIds: SheetClickEvent = { complexId: expectedComplexId, sheetId: null };
+                    const expectedNavigationExtras = {
+                        queryParams: { id: '' },
+                    };
+
+                    service.navigateToSvgSheet(expectedSheetIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        expectedSheetIds.complexId,
+                        expectedSheetRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... fragment id is empty string', () => {
+                    const expectedSheetIds: SheetClickEvent = { complexId: expectedComplexId, sheetId: '' };
+                    const expectedNavigationExtras = {
+                        queryParams: { id: '' },
+                    };
+
+                    service.navigateToSvgSheet(expectedSheetIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        expectedSheetIds.complexId,
+                        expectedSheetRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+            });
+
+            describe('... should call `_navigateWithComplexId()` method with undefined complex id if', () => {
+                it('... introIds are undefined', () => {
+                    const expectedSheetIds: SheetClickEvent = undefined;
+                    const expectedNavigationExtras = {
+                        queryParams: { id: '' },
+                    };
+
+                    service.navigateToSvgSheet(expectedSheetIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        undefined,
+                        expectedSheetRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... introIds are null', () => {
+                    const expectedSheetIds: SheetClickEvent = null;
+                    const expectedNavigationExtras = {
+                        queryParams: { id: '' },
+                    };
+
+                    service.navigateToSvgSheet(expectedSheetIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        undefined,
+                        expectedSheetRoute,
+                        expectedNavigationExtras,
+                    ]);
+                });
+
+                it('... complex id is empty string', () => {
+                    const expectedSheetIds: SheetClickEvent = { complexId: '', sheetId: expectedSvgSheet.id };
+                    const expectedNavigationExtras = {
+                        queryParams: { id: expectedSheetIds.sheetId },
+                    };
+
+                    service.navigateToSvgSheet(expectedSheetIds);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, ['', expectedSheetRoute, expectedNavigationExtras]);
+                });
+            });
+        });
+
+        describe('#_navigateWithComplexId()', () => {
+            it('... should have a method `_navigateWithComplexId`', () => {
+                expect((service as any)._navigateWithComplexId).toBeDefined();
+            });
+
+            describe('... should navigate within same complex if', () => {
+                const expectedTargetRoute = 'targetRoute';
+                const expectedNavigationExtras = { fragment: '' };
+
+                it.each([
+                    {
+                        desc: 'complex id is undefined',
+                        complexId: undefined,
+                        getExpectedRoute: () => expectedComplexBaseRoute,
+                    },
+                    {
+                        desc: 'complex id is null',
+                        complexId: null,
+                        getExpectedRoute: () => expectedComplexBaseRoute,
+                    },
+                    {
+                        desc: 'complex id is empty string',
+                        complexId: '',
+                        getExpectedRoute: () => expectedComplexBaseRoute,
+                    },
+                    {
+                        desc: 'complex id is equal to the current complex id',
+                        complexId: 'op12',
+                        getExpectedRoute: () => `/edition/complex/${expectedComplexId}`,
+                    },
+                ])(`... $desc`, ({ complexId, getExpectedRoute }) => {
+                    (service as any)._navigateWithComplexId(complexId, expectedTargetRoute, expectedNavigationExtras);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        complexId,
+                        expectedTargetRoute,
+                        expectedNavigationExtras,
+                    ]);
+
+                    expectSpyCall(navigationSpy, 1, [
+                        [getExpectedRoute(), expectedTargetRoute],
+                        expectedNavigationExtras,
+                    ]);
+                });
+            });
+
+            describe('... should navigate to different complex if', () => {
+                it('... complex id is given and not equal to the current complex id', () => {
+                    const expectedNextComplexRoute = `/edition/complex/${expectedNextComplexId}`;
+                    const expectedTargetRoute = 'targetRoute';
+                    const expectedNavigationExtras = { fragment: '' };
+
+                    (service as any)._navigateWithComplexId(
+                        expectedNextComplexId,
+                        expectedTargetRoute,
+                        expectedNavigationExtras
+                    );
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        expectedNextComplexId,
+                        expectedTargetRoute,
+                        expectedNavigationExtras,
+                    ]);
+                    expectSpyCall(navigationSpy, 1, [
+                        [expectedNextComplexRoute, expectedTargetRoute],
+                        expectedNavigationExtras,
+                    ]);
+                });
+            });
+
+            describe('... should navigate to series overview if selectedComplex is null', () => {
+                beforeEach(() => {
+                    editionStateService.updateSelectedEditionComplex(null);
+                });
+
+                it.each([
+                    {
+                        desc: 'with a given sheet id',
+                        getTargetRoute: () => expectedSheetRoute,
+                        getNavigationExtras: () => ({ queryParams: { id: expectedSvgSheet.id } }),
+                    },
+                    {
+                        desc: 'with a given report fragment',
+                        getTargetRoute: () => expectedReportRoute,
+                        getNavigationExtras: () => ({ fragment: expectedReportFragment }),
+                    },
+                ])(`... $desc`, ({ getTargetRoute, getNavigationExtras }) => {
+                    const expectedTargetRoute = getTargetRoute();
+                    const expectedNavigationExtras = getNavigationExtras();
+
+                    (service as any)._navigateWithComplexId(undefined, expectedTargetRoute, expectedNavigationExtras);
+
+                    expectSpyCall(navigateWithComplexIdSpy, 1, [
+                        undefined,
+                        expectedTargetRoute,
+                        expectedNavigationExtras,
+                    ]);
+
+                    expectSpyCall(navigationSpy, 1, [
+                        ['/edition/series', expectedTargetRoute],
+                        expectedNavigationExtras,
+                    ]);
+                });
+            });
+
+            describe('... with no edition complex id given', () => {
+                describe('... should navigate within same complex to a given', () => {
+                    it.each([
+                        {
+                            desc: 'intro route with a fragment',
+                            getTargetRoute: () => expectedIntroRoute,
+                            getNavigationExtras: () => ({ fragment: expectedIntroFragment }),
+                        },
+                        {
+                            desc: 'intro route without a fragment',
+                            getTargetRoute: () => expectedIntroRoute,
+                            getNavigationExtras: () => ({ fragment: '' }),
+                        },
+                        {
+                            desc: 'report route with a fragment',
+                            getTargetRoute: () => expectedReportRoute,
+                            getNavigationExtras: () => ({ fragment: expectedReportFragment }),
+                        },
+                        {
+                            desc: 'report route without a fragment',
+                            getTargetRoute: () => expectedReportRoute,
+                            getNavigationExtras: () => ({ fragment: '' }),
+                        },
+                        {
+                            desc: 'sheet route with a sheet id',
+                            getTargetRoute: () => expectedSheetRoute,
+                            getNavigationExtras: () => ({ queryParams: { id: expectedSvgSheet.id } }),
+                        },
+                        {
+                            desc: 'sheet route without a sheet id',
+                            getTargetRoute: () => expectedSheetRoute,
+                            getNavigationExtras: () => ({ queryParams: { id: '' } }),
+                        },
+                    ])(`... $desc`, ({ getTargetRoute, getNavigationExtras }) => {
+                        const expectedTargetRoute = getTargetRoute();
+                        const expectedNavigationExtras = getNavigationExtras();
+
+                        const expectedRouteCommands =
+                            expectedTargetRoute === expectedIntroRoute
+                                ? []
+                                : [expectedComplexBaseRoute, expectedTargetRoute];
+
+                        (service as any)._navigateWithComplexId(
+                            undefined,
+                            expectedTargetRoute,
+                            expectedNavigationExtras
+                        );
+
+                        expectSpyCall(navigateWithComplexIdSpy, 1, [
+                            undefined,
+                            expectedTargetRoute,
+                            expectedNavigationExtras,
+                        ]);
+
+                        expectSpyCall(navigationSpy, 1, [expectedRouteCommands, expectedNavigationExtras]);
+                    });
+                });
+            });
+
+            describe('... with the current edition complex id given', () => {
+                describe('... should navigate within same complex to a given', () => {
+                    it.each([
+                        {
+                            desc: 'intro route with a fragment',
+                            getTargetRoute: () => expectedIntroRoute,
+                            getNavigationExtras: () => ({ fragment: expectedIntroFragment }),
+                        },
+                        {
+                            desc: 'intro route without a fragment',
+                            getTargetRoute: () => expectedIntroRoute,
+                            getNavigationExtras: () => ({ fragment: '' }),
+                        },
+                        {
+                            desc: 'report route with a fragment',
+                            getTargetRoute: () => expectedReportRoute,
+                            getNavigationExtras: () => ({ fragment: expectedReportFragment }),
+                        },
+                        {
+                            desc: 'report route without a fragment',
+                            getTargetRoute: () => expectedReportRoute,
+                            getNavigationExtras: () => ({ fragment: '' }),
+                        },
+                        {
+                            desc: 'sheet route with a sheet id',
+                            getTargetRoute: () => expectedSheetRoute,
+                            getNavigationExtras: () => ({ queryParams: { id: expectedSvgSheet.id } }),
+                        },
+                        {
+                            desc: 'sheet route without a sheet id',
+                            getTargetRoute: () => expectedSheetRoute,
+                            getNavigationExtras: () => ({ queryParams: { id: '' } }),
+                        },
+                    ])(`... $desc`, ({ getTargetRoute, getNavigationExtras }) => {
+                        const expectedComplexRoute = `/edition/complex/${expectedComplexId}`;
+                        const expectedTargetRoute = getTargetRoute();
+                        const expectedNavigationExtras = getNavigationExtras();
+
+                        const expectedRouteCommands =
+                            expectedTargetRoute === expectedIntroRoute
+                                ? []
+                                : [expectedComplexRoute, expectedTargetRoute];
+
+                        (service as any)._navigateWithComplexId(
+                            expectedComplexId,
+                            expectedTargetRoute,
+                            expectedNavigationExtras
+                        );
+
+                        expectSpyCall(navigateWithComplexIdSpy, 1, [
+                            expectedComplexId,
+                            expectedTargetRoute,
+                            expectedNavigationExtras,
+                        ]);
+
+                        expectSpyCall(navigationSpy, 1, [expectedRouteCommands, expectedNavigationExtras]);
+                    });
+                });
+            });
+
+            describe('... with a different edition complex id given', () => {
+                describe('... should navigate to the target route of that complex with a given', () => {
+                    const testCases = [
+                        {
+                            desc: 'intro route with a fragment',
+                            getTargetRoute: () => expectedIntroRoute,
+                            getNavigationExtras: () => ({ fragment: expectedIntroFragment }),
+                        },
+                        {
+                            desc: 'intro route without a fragment',
+                            getTargetRoute: () => expectedIntroRoute,
+                            getNavigationExtras: () => ({ fragment: '' }),
+                        },
+                        {
+                            desc: 'report route with a fragment',
+                            getTargetRoute: () => expectedReportRoute,
+                            getNavigationExtras: () => ({ fragment: expectedReportFragment }),
+                        },
+                        {
+                            desc: 'report route without a fragment',
+                            getTargetRoute: () => expectedReportRoute,
+                            getNavigationExtras: () => ({ fragment: '' }),
+                        },
+                        {
+                            desc: 'sheet route with a sheet id',
+                            getTargetRoute: () => expectedSheetRoute,
+                            getNavigationExtras: () => ({ queryParams: { id: expectedSvgSheet.id } }),
+                        },
+                        {
+                            desc: 'sheet route without a sheet id',
+                            getTargetRoute: () => expectedSheetRoute,
+                            getNavigationExtras: () => ({ queryParams: { id: '' } }),
+                        },
+                    ];
+
+                    it.each(testCases)(`... $desc`, ({ getTargetRoute, getNavigationExtras }) => {
+                        const expectedNextComplexRoute = `/edition/complex/${expectedNextComplexId}`;
+                        const expectedTargetRoute = getTargetRoute();
+                        const expectedNavigationExtras = getNavigationExtras();
+
+                        const expectedRouteCommands =
+                            expectedTargetRoute === expectedIntroRoute
+                                ? []
+                                : [expectedNextComplexRoute, expectedTargetRoute];
+
+                        (service as any)._navigateWithComplexId(
+                            expectedNextComplexId,
+                            expectedTargetRoute,
+                            expectedNavigationExtras
+                        );
+
+                        expectSpyCall(navigateWithComplexIdSpy, 1, [
+                            expectedNextComplexId,
+                            expectedTargetRoute,
+                            expectedNavigationExtras,
+                        ]);
+
+                        expectSpyCall(navigationSpy, 1, [expectedRouteCommands, expectedNavigationExtras]);
+                    });
+                });
+            });
+        });
+    });
+});

--- a/src/app/views/edition-view/services/edition-navigation.service.ts
+++ b/src/app/views/edition-view/services/edition-navigation.service.ts
@@ -1,0 +1,138 @@
+import { inject, Injectable } from '@angular/core';
+import { NavigationExtras, Router } from '@angular/router';
+
+import { EDITION_ROUTE_CONSTANTS } from '../edition-routes.constants';
+
+import { EditionStateService } from './edition-state.service';
+
+/**
+ * The FragmentClickEvent interface.
+ *
+ * It defines the structure for the intro fragment click event.
+ */
+export interface FragmentClickEvent {
+    /**
+     * The complex id of the click event.
+     */
+    complexId: string;
+
+    /**
+     * The intro fragment id of the click event.
+     */
+    fragmentId: string;
+}
+
+/**
+ * The SheetClickEvent interface.
+ *
+ * It defines the structure for the SVG sheet click event.
+ */
+export interface SheetClickEvent {
+    /**
+     * The complex id of the click event.
+     */
+    complexId: string;
+
+    /**
+     * The sheet id of the click event.
+     */
+    sheetId: string;
+}
+
+/**
+ * The EditionNavigationService.
+ *
+ * It provides navigation functionality for the edition view of the app.
+ */
+@Injectable({
+    providedIn: 'root',
+})
+export class EditionNavigationService {
+    /**
+     * Private readonly injection variable: _router.
+     *
+     * It keeps the instance of the injected Angular Router.
+     */
+    private readonly _router = inject(Router);
+
+    /**
+     * Readonly signal: selectedEditionComplex.
+     *
+     * It holds the state of the selected edition complex.
+     */
+    readonly selectedEditionComplex = inject(EditionStateService).selectedEditionComplex;
+
+    /**
+     * Public method: navigateToIntroFragment.
+     *
+     * It navigates to the '/intro/' route with the given complexId and fragmentId.
+     *
+     * @param {FragmentClickEvent} introIds The given intro ids as { complexId: string, fragmentId: string }.
+     * @returns {void} Navigates to the edition intro fragment.
+     */
+    navigateToIntroFragment(introIds: FragmentClickEvent): void {
+        const introRoute = EDITION_ROUTE_CONSTANTS.EDITION_INTRO.route;
+        const navigationExtras: NavigationExtras = {
+            fragment: introIds?.fragmentId ?? '',
+        };
+        this._navigateWithComplexId(introIds?.complexId, introRoute, navigationExtras);
+    }
+
+    /**
+     * Public method: navigateToReportFragment.
+     *
+     * It navigates to the '/report/' route with the given complexId and fragmentId.
+     *
+     * @param {FragmentClickEvent} reportIds The given report ids as { complexId: string, fragmentId: string }.
+     * @returns {void} Navigates to the edition report fragment.
+     */
+    navigateToReportFragment(reportIds: FragmentClickEvent): void {
+        const reportRoute = EDITION_ROUTE_CONSTANTS.EDITION_REPORT.route;
+        const navigationExtras: NavigationExtras = {
+            fragment: reportIds?.fragmentId ?? '',
+        };
+        this._navigateWithComplexId(reportIds?.complexId, reportRoute, navigationExtras);
+    }
+
+    /**
+     * Public method: navigateToSvgSheet.
+     *
+     * It navigates to the '/sheet/' route using the provided sheetId
+     * within the context of an edition complex identified by the provided complexId.
+     *
+     * @param {SheetClickEvent} sheetIds The given sheet ids as { complexId: string, sheetId: string }.
+     * @returns {void} Navigates to the edition sheets.
+     */
+    navigateToSvgSheet(sheetIds: SheetClickEvent): void {
+        const sheetRoute = EDITION_ROUTE_CONSTANTS.EDITION_SHEETS.route;
+        const navigationExtras: NavigationExtras = {
+            queryParams: { id: sheetIds?.sheetId ?? '' },
+            // .queryParamsHandling: '',
+        };
+
+        this._navigateWithComplexId(sheetIds?.complexId, sheetRoute, navigationExtras);
+    }
+
+    /**
+     * Private method: _navigateWithComplexId.
+     *
+     * It navigates to a target route using the provided complexId.
+     *
+     * @param {string} complexId The given complex id.
+     * @param {string} targetRoute The given target route.
+     * @param {NavigationExtras} navigationExtras The given navigation extras.
+     * @returns {void} Navigates to the target route.
+     */
+    private _navigateWithComplexId(complexId: string, targetRoute: string, navigationExtras: NavigationExtras): void {
+        const selectedComplex = this.selectedEditionComplex();
+
+        const complexRoute = complexId
+            ? `/edition/complex/${complexId}`
+            : (selectedComplex?.baseRoute ?? '/edition/series');
+
+        const routeCommands =
+            targetRoute === EDITION_ROUTE_CONSTANTS.EDITION_INTRO.route ? [] : [complexRoute, targetRoute];
+
+        this._router.navigate(routeCommands, navigationExtras);
+    }
+}


### PR DESCRIPTION
This PR rewrites the old compile-html helper to make use of modern Angular (signals, standalone), and most important, to make the helper AOT-compatible. The old variant blocked AOT and was the only reason the app was still running in JIT mode. Application of the new helper will be executed in subsequent PRs.