### PR TITLE
refactor(shared): refactor modal handling

### DIFF
--- a/src/app/shared/compile-html/compile-html.directive.spec.ts
+++ b/src/app/shared/compile-html/compile-html.directive.spec.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.fn>;
 
 import { expectSpyCall, expectToBe } from '@testing/expect-helper';
+import { mockEditionData } from '@testing/mock-data/mockEditionData';
 
 import { ModalService } from '@awg-shared/modal/modal.service';
 import { EditionGlyphService } from '@awg-views/edition-view/services';
@@ -27,7 +28,8 @@ describe('CompileHtmlDirective (DONE)', () => {
     let serviceNavigateToSheetSpy: Spy;
     let serviceNavigateToReportSpy: Spy;
     let serviceGetGlyphSpy: Spy;
-    let serviceUpdateModalIdSpy: Spy;
+    let serviceOpenImageModalSpy: Spy;
+    let serviceOpenTextModalSpy: Spy;
     let rendererSetAttributeSpy: Spy;
     let rendererSetPropertySpy: Spy;
 
@@ -38,7 +40,7 @@ describe('CompileHtmlDirective (DONE)', () => {
     let expectedIntroFragment: string;
     let expectedReportFragment: string;
     let expectedSvgSheetId: string;
-    let expectedModalId: string;
+    let expectedTextModalId: string;
 
     beforeEach(() => {
         // Mock the input signal and native element
@@ -70,7 +72,8 @@ describe('CompileHtmlDirective (DONE)', () => {
                 {
                     provide: ModalService,
                     useValue: {
-                        updateModalId: vi.fn(),
+                        openTextModal: vi.fn(),
+                        openImageModal: vi.fn(),
                     },
                 },
             ],
@@ -99,14 +102,15 @@ describe('CompileHtmlDirective (DONE)', () => {
         serviceGetGlyphSpy = vi.spyOn(glyphService, 'getGlyph').mockImplementation((glyph: string) => `${glyph}`);
 
         const modalService = TestBed.inject(ModalService);
-        serviceUpdateModalIdSpy = vi.spyOn(modalService, 'updateModalId');
+        serviceOpenImageModalSpy = vi.spyOn(modalService, 'openImageModal');
+        serviceOpenTextModalSpy = vi.spyOn(modalService, 'openTextModal');
 
         // Test data
         expectedComplexId = 'op12';
         expectedIntroFragment = 'note-80';
         expectedReportFragment = 'source_A';
         expectedSvgSheetId = 'test-1';
-        expectedModalId = 'modal_snippet_5';
+        expectedTextModalId = structuredClone(mockEditionData.mockModalSnippet);
     });
 
     afterEach(() => {
@@ -172,6 +176,7 @@ describe('CompileHtmlDirective (DONE)', () => {
 
         it('... should call `_applyAccessibilityAttributes()` when htmlContent changes', async () => {
             mockHtmlContentSignal.set('<p>Test</p>');
+
             TestBed.tick();
 
             expectSpyCall(applyAccessibilityAttributesSpy, 1);
@@ -240,48 +245,66 @@ describe('CompileHtmlDirective (DONE)', () => {
                         desc: 'links with data-intro-fragment-id',
                         getExpectedOutput: () =>
                             `<a data-complex-id="${expectedComplexId}" data-intro-fragment-id="${expectedIntroFragment}">Link</a>`,
+                        expectedSelector: 'a',
                         expectedRole: 'link',
                     },
                     {
                         desc: 'links with data-sheet-id',
                         getExpectedOutput: () =>
                             `<a data-complex-id="${expectedComplexId}" data-sheet-id="${expectedSvgSheetId}">Sheet</a>`,
+                        expectedSelector: 'a',
                         expectedRole: 'link',
                     },
                     {
                         desc: 'links with data-report-fragment-id',
                         getExpectedOutput: () =>
                             `<a data-complex-id="${expectedComplexId}" data-report-fragment-id="${expectedReportFragment}">Report</a>`,
+                        expectedSelector: 'a',
                         expectedRole: 'link',
                     },
                     {
                         desc: 'links with data-modal-id',
-                        getExpectedOutput: () => `<a data-modal-id="${expectedModalId}">Modal Link</a>`,
+                        getExpectedOutput: () => `<a data-modal-id="${expectedTextModalId}">Modal Link</a>`,
+                        expectedSelector: 'a',
                         expectedRole: 'button',
                     },
-                ])(`... $desc`, async ({ getExpectedOutput, expectedRole }) => {
+                    {
+                        desc: 'images with data-snippet-id and data-snippet-src',
+                        getExpectedOutput: () =>
+                            `<img data-snippet-id="snippet-1" data-snippet-src="assets/img/test.png" alt="Test" />`,
+                        expectedSelector: 'img',
+                        expectedRole: 'button',
+                    },
+                ])(`... $desc`, async ({ getExpectedOutput, expectedSelector, expectedRole }) => {
                     const htmlString = getExpectedOutput();
 
                     mockNativeElement.innerHTML = htmlString;
-
                     mockHtmlContentSignal.set(htmlString);
 
                     TestBed.tick();
 
-                    const foundAnchor = mockNativeElement.querySelector('a');
+                    const foundElement = mockNativeElement.querySelector(expectedSelector);
 
                     expectSpyCall(rendererSetAttributeSpy, 2);
-                    expect(rendererSetAttributeSpy).toHaveBeenCalledWith(foundAnchor, 'tabindex', '0');
-                    expect(rendererSetAttributeSpy).toHaveBeenCalledWith(foundAnchor, 'role', expectedRole);
+                    expect(rendererSetAttributeSpy).toHaveBeenCalledWith(foundElement, 'tabindex', '0');
+                    expect(rendererSetAttributeSpy).toHaveBeenCalledWith(foundElement, 'role', expectedRole);
                 });
             });
 
             it('... should not add accessibility attributes to standard links without data-attributes', async () => {
-                rendererSetAttributeSpy.mockClear();
-
                 const plainHtml = '<a href="https://example.com">External Link</a>';
                 mockNativeElement.innerHTML = plainHtml;
 
+                mockHtmlContentSignal.set(plainHtml);
+
+                TestBed.tick();
+
+                expectSpyCall(rendererSetAttributeSpy, 0);
+            });
+
+            it('... should not add accessibility attributes to standard images without snippet data-attributes', async () => {
+                const plainHtml = '<img src="https://example.com" alt="Logo" />';
+                mockNativeElement.innerHTML = plainHtml;
                 mockHtmlContentSignal.set(plainHtml);
 
                 TestBed.tick();
@@ -375,40 +398,60 @@ describe('CompileHtmlDirective (DONE)', () => {
             describe('... should navigate to', () => {
                 const testCases = [
                     {
-                        desc: 'modal snippet if data-modal-id is given',
-                        attributes: { 'data-modal-id': 'modal_snippet_5' },
-                        expectedArgs: 'modal_snippet_5',
-                        getExpectedSpy: () => serviceUpdateModalIdSpy,
+                        desc: 'text modal snippet if data-modal-id is given',
+                        getAttributes: () => ({ 'data-modal-id': expectedTextModalId }),
+                        getExpectedArgs: () => expectedTextModalId,
+                        getExpectedSpy: () => serviceOpenTextModalSpy,
                     },
                     {
                         desc: 'intro fragment with complexId if data-intro-fragment-id is given',
-                        attributes: { 'data-complex-id': 'op12', 'data-intro-fragment-id': 'intro-1' },
-                        expectedArgs: { complexId: 'op12', fragmentId: 'intro-1' } as FragmentClickEvent,
+                        getAttributes: () => ({
+                            'data-complex-id': expectedComplexId,
+                            'data-intro-fragment-id': expectedIntroFragment,
+                        }),
+                        getExpectedArgs: () =>
+                            ({ complexId: expectedComplexId, fragmentId: expectedIntroFragment }) as FragmentClickEvent,
                         getExpectedSpy: () => serviceNavigateToIntroSpy,
                     },
                     {
                         desc: 'intro fragment with empty complexId if data-complex-id is missing',
-                        attributes: { 'data-intro-fragment-id': 'intro-2' },
-                        expectedArgs: { complexId: '', fragmentId: 'intro-2' } as FragmentClickEvent,
+                        getAttributes: () => ({ 'data-intro-fragment-id': expectedIntroFragment }),
+                        getExpectedArgs: () =>
+                            ({ complexId: '', fragmentId: expectedIntroFragment }) as FragmentClickEvent,
                         getExpectedSpy: () => serviceNavigateToIntroSpy,
                     },
                     {
                         desc: 'svg sheet if data-sheet-id and data-complex-id are given',
-                        attributes: { 'data-complex-id': 'op12', 'data-sheet-id': 'sheet-3' },
-                        expectedArgs: { complexId: 'op12', sheetId: 'sheet-3' } as SheetClickEvent,
+                        getAttributes: () => ({
+                            'data-complex-id': expectedComplexId,
+                            'data-sheet-id': expectedSvgSheetId,
+                        }),
+                        getExpectedArgs: () =>
+                            ({ complexId: expectedComplexId, sheetId: expectedSvgSheetId }) as SheetClickEvent,
                         getExpectedSpy: () => serviceNavigateToSheetSpy,
                     },
                     {
                         desc: 'report fragment if data-report-fragment-id and data-complex-id are given',
-                        attributes: { 'data-complex-id': 'op12', 'data-report-fragment-id': 'report-4' },
-                        expectedArgs: { complexId: 'op12', fragmentId: 'report-4' } as FragmentClickEvent,
+                        getAttributes: () => ({
+                            'data-complex-id': expectedComplexId,
+                            'data-report-fragment-id': expectedReportFragment,
+                        }),
+                        getExpectedArgs: () =>
+                            ({
+                                complexId: expectedComplexId,
+                                fragmentId: expectedReportFragment,
+                            }) as FragmentClickEvent,
                         getExpectedSpy: () => serviceNavigateToReportSpy,
                     },
                 ];
 
-                it.each(testCases)(`... $desc`, ({ attributes, expectedArgs, getExpectedSpy }) => {
+                it.each(testCases)(`... $desc`, ({ getAttributes, getExpectedArgs, getExpectedSpy }) => {
+                    const attributes = getAttributes();
+                    const expectedArgs = getExpectedArgs();
+                    const targetSpy = getExpectedSpy();
+
                     const mockAnchor = {
-                        getAttribute: (key: string) => attributes[key as keyof typeof attributes] || null,
+                        getAttribute: (attr: string) => attributes[attr as keyof typeof attributes] || null,
                     } as unknown as HTMLAnchorElement;
 
                     const mockEvent = {
@@ -419,12 +462,10 @@ describe('CompileHtmlDirective (DONE)', () => {
 
                     expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
 
-                    const targetSpy = getExpectedSpy();
-
                     expectSpyCall(targetSpy, 1, [expectedArgs]);
 
                     [
-                        serviceUpdateModalIdSpy,
+                        serviceOpenTextModalSpy,
                         serviceNavigateToIntroSpy,
                         serviceNavigateToSheetSpy,
                         serviceNavigateToReportSpy,
@@ -481,14 +522,16 @@ describe('CompileHtmlDirective (DONE)', () => {
 
             describe('... should handle snippet images', () => {
                 it('... and open the snippet if data-snippet-id and data-snippet-src are present', () => {
+                    const mockId = 'snip-123';
+                    const mockSrc = 'path/to/image.png';
                     const mockImg = {
                         hasAttribute: (attr: string) => attr === 'data-snippet-id' || attr === 'data-snippet-src',
                         getAttribute: (attr: string) => {
-                            if (attr === 'data-snippet-src') {
-                                return 'path/to/image.png';
-                            }
                             if (attr === 'data-snippet-id') {
-                                return 'snip-123';
+                                return mockId;
+                            }
+                            if (attr === 'data-snippet-src') {
+                                return mockSrc;
                             }
                             return null;
                         },
@@ -496,17 +539,10 @@ describe('CompileHtmlDirective (DONE)', () => {
 
                     const mockEvent = { preventDefault: vi.fn() } as unknown as Event;
 
-                    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
                     (directive as any)._handleImageNavigation(mockImg, mockEvent);
 
                     expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
-                    expect(consoleSpy).toHaveBeenCalledWith('Snippet öffnen:', {
-                        src: 'path/to/image.png',
-                        id: 'snip-123',
-                    });
-
-                    consoleSpy.mockRestore();
+                    expectSpyCall(serviceOpenImageModalSpy, 1, [mockId, mockSrc]);
                 });
             });
 
@@ -549,6 +585,7 @@ describe('CompileHtmlDirective (DONE)', () => {
                     (directive as any)._handleImageNavigation(mockImg, mockEvent);
 
                     expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+                    expectSpyCall(serviceOpenImageModalSpy, 0);
                 });
             });
         });

--- a/src/app/shared/compile-html/compile-html.directive.ts
+++ b/src/app/shared/compile-html/compile-html.directive.ts
@@ -122,18 +122,25 @@ export class CompileHtmlDirective {
      * @returns {void} Applies the attributes directly to the DOM elements.
      */
     private _applyAccessibilityAttributes(): void {
-        const selectors =
-            'a[data-modal-id], a[data-complex-id], a[data-intro-fragment-id], a[data-sheet-id], a[data-report-fragment-id]';
-        const anchors = this._el.nativeElement.querySelectorAll(selectors);
+        const selectors = [
+            'a[data-modal-id]',
+            'a[data-complex-id]',
+            'a[data-intro-fragment-id]',
+            'a[data-sheet-id]',
+            'a[data-report-fragment-id]',
+            'img[data-snippet-id][data-snippet-src]',
+        ].join(', ');
 
-        anchors.forEach((anchor: HTMLAnchorElement) => {
-            this._renderer.setAttribute(anchor, 'tabindex', '0');
+        const elements = this._el.nativeElement.querySelectorAll(selectors);
 
-            if (anchor.hasAttribute('data-modal-id')) {
-                this._renderer.setAttribute(anchor, 'role', 'button');
-            } else {
-                this._renderer.setAttribute(anchor, 'role', 'link');
-            }
+        elements.forEach((el: HTMLElement) => {
+            this._renderer.setAttribute(el, 'tabindex', '0');
+
+            const isImage = el.tagName.toLowerCase() === 'img';
+            const isModalAnchor = el.hasAttribute('data-modal-id');
+
+            const role = isImage || isModalAnchor ? 'button' : 'link';
+            this._renderer.setAttribute(el, 'role', role);
         });
     }
 
@@ -176,7 +183,7 @@ export class CompileHtmlDirective {
         const modalId = anchor.getAttribute('data-modal-id');
         if (modalId) {
             event.preventDefault();
-            this._modalService.updateModalId(modalId);
+            this._modalService.openTextModal(modalId);
             return;
         }
 
@@ -221,12 +228,10 @@ export class CompileHtmlDirective {
         }
 
         event.preventDefault();
-        const src = img.getAttribute('data-snippet-src');
-        const id = img.getAttribute('data-snippet-id');
+        const src = img.getAttribute('data-snippet-src') as string;
+        const id = img.getAttribute('data-snippet-id') as string;
 
-        // TODO: Handling of snippets
-        // This._navigationService.openSnippet(src, id);
-        console.log('Snippet öffnen:', { src, id });
+        this._modalService.openImageModal(id, src);
     }
 
     /**

--- a/src/app/shared/modal/modal-text-snippets.data.ts
+++ b/src/app/shared/modal/modal-text-snippets.data.ts
@@ -3,7 +3,7 @@
  *
  * It provides the text snippets to be used in a modal.
  */
-export const MODAL_CONTENT_SNIPPETS = {
+export const MODAL_TEXT_SNIPPETS = {
     OP12_SOURCE_NOT_AVAILABLE:
         '<p>Die Beschreibung der weiteren Quellenbestandteile von <strong>A</strong> sowie der Quellen <strong>C</strong> bis <strong>G<sup>H</sup></strong> einschließlich der darin gegebenenfalls enthaltenen Korrekturen erfolgt im Zusammenhang der vollständigen Edition der <em>Vier Lieder</em> op. 12 in AWG I/5.</p>',
     OP12_SHEET_COMING_SOON:

--- a/src/app/shared/modal/modal.component.html
+++ b/src/app/shared/modal/modal.component.html
@@ -1,22 +1,22 @@
-@let data = modalData;
-
-<div class="modal-header">
-    <h5 class="modal-title">{{ data.title }}</h5>
-    <button type="button" class="btn-close" aria-label="Close modal" (click)="activeModal.dismiss()"></button>
-</div>
-<div class="modal-body text-center">
-    @if (data.type === 'image') {
-        <img [src]="data.content" [alt]="data.title" class="img-fluid" />
-    } @else {
-        <div [innerHTML]="data.content" class="text-start"></div>
-    }
-</div>
-<div class="modal-footer">
-    <button
-        type="button"
-        class="btn btn-outline-dark awg-modal-button"
-        ngbAutofocus
-        (click)="activeModal.close('Close click')">
-        Schließen
-    </button>
-</div>
+@if (modalData; as data) {
+    <div class="modal-header">
+        <h5 class="modal-title">{{ data.title }}</h5>
+        <button type="button" class="btn-close" aria-label="Close modal" (click)="activeModal.dismiss()"></button>
+    </div>
+    <div class="modal-body text-center">
+        @if (data.type === 'image') {
+            <img [src]="data.content" [alt]="data.title" class="img-fluid" />
+        } @else {
+            <div [innerHTML]="data.content" class="text-start"></div>
+        }
+    </div>
+    <div class="modal-footer">
+        <button
+            type="button"
+            class="btn btn-outline-dark awg-modal-button"
+            ngbAutofocus
+            (click)="activeModal.close('Close click')">
+            Schließen
+        </button>
+    </div>
+}

--- a/src/app/shared/modal/modal.component.html
+++ b/src/app/shared/modal/modal.component.html
@@ -1,20 +1,22 @@
-<ng-template #modalTemplate let-modal>
-    <div class="modal-header">
-        <h4 class="modal-title" id="modal-basic-title">{{ modalTitle }}</h4>
-        <button
-            type="button"
-            class="btn-close"
-            aria-label="Close modal"
-            (click)="modal.dismiss('Click on dismiss button')"></button>
-    </div>
-    <div class="modal-body" [compile-html]="modalContent" [compile-html-ref]="this"></div>
-    <div class="modal-footer">
-        <button
-            type="button"
-            class="btn btn-outline-dark awg-modal-button"
-            ngbAutofocus
-            (click)="modal.close('Click on {{ modalCloseLabel }}')">
-            {{ modalCloseLabel }}
-        </button>
-    </div>
-</ng-template>
+@let data = modalData;
+
+<div class="modal-header">
+    <h5 class="modal-title">{{ data.title }}</h5>
+    <button type="button" class="btn-close" aria-label="Close modal" (click)="activeModal.dismiss()"></button>
+</div>
+<div class="modal-body text-center">
+    @if (data.type === 'image') {
+        <img [src]="data.content" [alt]="data.title" class="img-fluid" />
+    } @else {
+        <div [innerHTML]="data.content" class="text-start"></div>
+    }
+</div>
+<div class="modal-footer">
+    <button
+        type="button"
+        class="btn btn-outline-dark awg-modal-button"
+        ngbAutofocus
+        (click)="activeModal.close('Close click')">
+        Schließen
+    </button>
+</div>

--- a/src/app/shared/modal/modal.component.spec.ts
+++ b/src/app/shared/modal/modal.component.spec.ts
@@ -12,7 +12,7 @@ import { expectSpyCall, expectToBe, getAndExpectDebugElementByCss } from '@testi
 import { ModalComponent } from './modal.component';
 import { ModalData } from './modal.model';
 
-describe('ModalComponent', () => {
+describe('ModalComponent (DONE)', () => {
     let component: ModalComponent;
     let fixture: ComponentFixture<ModalComponent>;
     let compDe: DebugElement;
@@ -20,7 +20,8 @@ describe('ModalComponent', () => {
     let mockDocument: Document;
     let mockActiveModal: Partial<NgbActiveModal>;
 
-    let activeModalSpy: Spy;
+    let modalCloseSpy: Spy;
+    let modalDismissSpy: Spy;
 
     let expectedTextData: ModalData;
     let expectedImageData: ModalData;
@@ -30,6 +31,7 @@ describe('ModalComponent', () => {
             close: vi.fn(),
             dismiss: vi.fn(),
         };
+
         await TestBed.configureTestingModule({
             imports: [ModalComponent],
             providers: [
@@ -44,9 +46,11 @@ describe('ModalComponent', () => {
     beforeEach(() => {
         // Inject services
         mockDocument = TestBed.inject(DOCUMENT);
+        mockActiveModal = TestBed.inject(NgbActiveModal);
 
         // Spies
-        activeModalSpy = TestBed.inject(NgbActiveModal) as unknown as typeof mockActiveModal;
+        modalCloseSpy = vi.spyOn(mockActiveModal, 'close');
+        modalDismissSpy = vi.spyOn(mockActiveModal, 'dismiss');
 
         // Test data
         expectedTextData = {
@@ -83,35 +87,16 @@ describe('ModalComponent', () => {
         });
 
         describe('VIEW', () => {
-            it('... should have one div.modal-header', () => {
-                getAndExpectDebugElementByCss(compDe, 'div.modal-header', 1, 1);
+            it('... should have no div.modal-header', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.modal-header', 0, 0);
             });
 
-            it('... should have h5.modal-title in div.modal-header', () => {
-                const divDes = getAndExpectDebugElementByCss(compDe, 'div.modal-header', 1, 1);
-                getAndExpectDebugElementByCss(divDes[0], 'h5.modal-title', 1, 1);
+            it('... should have no div.modal-body', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.modal-body', 0, 0);
             });
 
-            it('... should have close button without label in div.modal-header', () => {
-                const divDes = getAndExpectDebugElementByCss(compDe, 'div.modal-header', 1, 1);
-                const btnDes = getAndExpectDebugElementByCss(divDes[0], 'button.btn-close', 1, 1);
-                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
-
-                expectToBe(btnEl.textContent, '');
-                expectToBe(btnEl.getAttribute('aria-label'), 'Close modal');
-            });
-
-            it('... should have one div.modal-body', () => {
-                getAndExpectDebugElementByCss(compDe, 'div.modal-body', 1, 1);
-            });
-
-            it('... should have one div.modal-footer', () => {
-                getAndExpectDebugElementByCss(compDe, 'div.modal-footer', 1, 1);
-            });
-
-            it('... should have one close button.awg-modal-button in div.modal-footer', () => {
-                const footerDes = getAndExpectDebugElementByCss(compDe, 'div.modal-footer', 1, 1);
-                getAndExpectDebugElementByCss(footerDes[0], 'button.awg-modal-button', 1, 1);
+            it('... should have no div.modal-footer', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.modal-footer', 0, 0);
             });
         });
     });
@@ -130,7 +115,25 @@ describe('ModalComponent', () => {
         });
 
         describe('VIEW', () => {
-            it('... should call activeModal.dismiss when clicking the header close button', async () => {
+            it('... should have one div.modal-header', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.modal-header', 1, 1);
+            });
+
+            it('... should have h5.modal-title in div.modal-header', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div.modal-header', 1, 1);
+                getAndExpectDebugElementByCss(divDes[0], 'h5.modal-title', 1, 1);
+            });
+
+            it('... should have dismiss button without label in div.modal-header', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div.modal-header', 1, 1);
+                const btnDes = getAndExpectDebugElementByCss(divDes[0], 'button.btn-close', 1, 1);
+                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
+
+                expectToBe(btnEl.textContent, '');
+                expectToBe(btnEl.getAttribute('aria-label'), 'Close modal');
+            });
+
+            it('... should call activeModal.dismiss when clicking the header dismiss button', async () => {
                 const dismissBtnDes = getAndExpectDebugElementByCss(
                     compDe,
                     'div.modal-header > button.btn-close',
@@ -139,7 +142,20 @@ describe('ModalComponent', () => {
                 );
                 await clickAndAwaitChanges(dismissBtnDes[0], fixture);
 
-                expectSpyCall(activeModalSpy.dismiss, 1);
+                expectSpyCall(modalDismissSpy, 1);
+            });
+
+            it('... should have one div.modal-body', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.modal-body', 1, 1);
+            });
+
+            it('... should have one div.modal-footer', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.modal-footer', 1, 1);
+            });
+
+            it('... should have one close button.awg-modal-button in div.modal-footer', () => {
+                const footerDes = getAndExpectDebugElementByCss(compDe, 'div.modal-footer', 1, 1);
+                getAndExpectDebugElementByCss(footerDes[0], 'button.awg-modal-button', 1, 1);
             });
 
             it('... should render the modal close label in footer', () => {
@@ -163,7 +179,7 @@ describe('ModalComponent', () => {
                 );
                 await clickAndAwaitChanges(closeBtnDes[0], fixture);
 
-                expectSpyCall(activeModalSpy.close, 1);
+                expectSpyCall(modalCloseSpy, 1);
             });
 
             describe('with text content', () => {

--- a/src/app/shared/modal/modal.component.spec.ts
+++ b/src/app/shared/modal/modal.component.spec.ts
@@ -1,111 +1,75 @@
-import {
-    AfterViewInit,
-    ChangeDetectorRef,
-    Component,
-    DebugElement,
-    DOCUMENT,
-    inject,
-    TemplateRef,
-    ViewChild,
-} from '@angular/core';
+import { DebugElement, DOCUMENT } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.spyOn>;
 
-import { ModalDismissReasons, NgbModal, NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
-import { detectChangesOnPush } from '@testing/detect-changes-on-push-helper';
+import { clickAndAwaitChanges } from '@testing/click-helper';
 import { expectSpyCall, expectToBe, getAndExpectDebugElementByCss } from '@testing/expect-helper';
 
-import { CompileHtmlComponent } from '@awg-shared/compile-html';
-
 import { ModalComponent } from './modal.component';
-
-// Mock wrapper component for the modal content
-@Component({
-    template: `
-        <div>
-            <ng-container *ngTemplateOutlet="modal"> </ng-container>
-        </div>
-        <awg-modal> </awg-modal>
-    `,
-    standalone: false,
-})
-class WrapperComponent implements AfterViewInit {
-    @ViewChild(ModalComponent)
-    modalComponentRef: ModalComponent;
-    modal: TemplateRef<any>;
-    private _cdr = inject(ChangeDetectorRef);
-
-    ngAfterViewInit() {
-        this.modal = this.modalComponentRef.modalTemplate;
-        this._cdr.detectChanges();
-    }
-}
-
-// Mock class for NgbModalRef
-export class MockNgbModalRef {
-    componentInstance = {
-        title: undefined,
-        content: undefined,
-    };
-    result: Promise<any> = new Promise(() => {
-        // Keep pending by default; individual tests set resolve/reject behavior explicitly.
-    });
-}
+import { ModalData } from './modal.model';
 
 describe('ModalComponent', () => {
     let component: ModalComponent;
-    let wrapperComponent: WrapperComponent;
-    let fixture: ComponentFixture<WrapperComponent>;
-    let wrapperDe: DebugElement;
-
-    let ngbModal: NgbModal;
-    const mockModalRef: MockNgbModalRef = new MockNgbModalRef();
-    let ngbModalOpenSpy: Spy;
+    let fixture: ComponentFixture<ModalComponent>;
+    let compDe: DebugElement;
 
     let mockDocument: Document;
+    let mockActiveModal: Partial<NgbActiveModal>;
 
-    const expectedModalTitle = 'Hinweis';
-    const expectedModalCloseLabel = 'Schließen';
-    const EXPECTED_MODAL_CONTENT_SNIPPETS = {
-        OP12_SOURCE_NOT_AVAILABLE:
-            '<p>Die Beschreibung der weiteren Quellenbestandteile von <strong>A</strong> sowie der Quellen <strong>C</strong> bis <strong>G<sup>H</sup></strong> einschließlich der darin gegebenenfalls enthaltenen Korrekturen erfolgt im Zusammenhang der vollständigen Edition der <em>Vier Lieder</em> op. 12 in AWG I/5.</p>',
-        OP12_SHEET_COMING_SOON:
-            'Die edierten Notentexte der Skizzen zu M 213 (<strong>A<sup>c</sup></strong>), M 216 (<strong>A<sup>d</sup></strong>) und M 217 (<strong>A<sup>b</sup></strong>) erscheinen im Zusammenhang der vollständigen Edition der <em>Vier Lieder</em> op. 12 in AWG I/5.',
-    };
-    const expectedSnippetKey1 = 'OP12_SOURCE_NOT_AVAILABLE';
-    const expectedSnippetKey2 = 'OP12_SHEET_COMING_SOON';
-    const expectedUnknownSnippetKey = 'UNKNOWN_SNIPPET_KEY';
+    let activeModalSpy: Spy;
+
+    let expectedTextData: ModalData;
+    let expectedImageData: ModalData;
 
     beforeEach(async () => {
+        mockActiveModal = {
+            close: vi.fn(),
+            dismiss: vi.fn(),
+        };
         await TestBed.configureTestingModule({
-            imports: [NgbModalModule],
-            declarations: [WrapperComponent, ModalComponent, CompileHtmlComponent],
-            providers: [NgbModal],
+            imports: [ModalComponent],
+            providers: [
+                {
+                    provide: NgbActiveModal,
+                    useValue: mockActiveModal,
+                },
+            ],
         }).compileComponents();
     });
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(WrapperComponent);
-        wrapperComponent = fixture.debugElement.componentInstance;
-        fixture.detectChanges(); // Initial data binding of wrapper component.
-
-        wrapperDe = fixture.debugElement;
-        component = wrapperComponent.modalComponentRef;
-        // Trigger initial data binding of modal component
-        fixture.detectChanges();
-
-        ngbModal = TestBed.inject(NgbModal);
+        // Inject services
         mockDocument = TestBed.inject(DOCUMENT);
 
-        // Spies on the modal service
-        ngbModalOpenSpy = vi.spyOn(ngbModal, 'open').mockReturnValue(mockModalRef as any);
+        // Spies
+        activeModalSpy = TestBed.inject(NgbActiveModal) as unknown as typeof mockActiveModal;
+
+        // Test data
+        expectedTextData = {
+            type: 'text',
+            id: 'TEST_KEY',
+            title: 'Test title',
+            content: '<p>Test content HTML</p>',
+        };
+
+        expectedImageData = {
+            type: 'image',
+            id: 'TEST_IMG',
+            title: 'Abbildung: TEST_IMG',
+            content: 'assets/img/test.png',
+        };
+
+        // Create component fixture
+        fixture = TestBed.createComponent(ModalComponent);
+        component = fixture.debugElement.componentInstance;
+        compDe = fixture.debugElement;
     });
 
     afterEach(() => {
-        // Clear mocks after each test
         vi.restoreAllMocks();
     });
 
@@ -113,189 +77,157 @@ describe('ModalComponent', () => {
         expect(component).toBeTruthy();
     });
 
-    it('... should create the wrapper component', () => {
-        expect(wrapperComponent).toBeTruthy();
-    });
-
-    it('... should have modal title', () => {
-        expectToBe(component.modalTitle, expectedModalTitle);
-    });
-
-    it('... should have modal close label', () => {
-        expectToBe(component.modalCloseLabel, expectedModalCloseLabel);
-    });
-
-    it('... should recognize the modal template', () => {
-        expectToBe(component.modalTemplate, wrapperComponent.modal);
-        expect(component.modalTemplate).toBeInstanceOf(TemplateRef);
-    });
-
-    it('... should recognize the modal template in wrapper component', () => {
-        expect(wrapperComponent.modal).toBeDefined();
-    });
-
-    it('... should not have modal content', () => {
-        expect(component.modalContent).toBeUndefined();
-    });
-
-    it('... should not have closeResult', () => {
-        expect(component.closeResult).toBeUndefined();
-    });
-
-    describe('VIEW', () => {
-        it('... should have one div.modal-header', () => {
-            getAndExpectDebugElementByCss(wrapperDe, 'div.modal-header', 1, 1);
+    describe('BEFORE initial data binding', () => {
+        it('... should not have `modalData`', () => {
+            expect(component.modalData).toBeUndefined();
         });
 
-        it('... should have h4.modal-title in div.modal-header', () => {
-            const divDes = getAndExpectDebugElementByCss(wrapperDe, 'div.modal-header', 1, 1);
-            getAndExpectDebugElementByCss(divDes[0], 'h4.modal-title', 1, 1);
-        });
+        describe('VIEW', () => {
+            it('... should have one div.modal-header', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.modal-header', 1, 1);
+            });
 
-        it('... should render the modal title label', () => {
-            const divDes = getAndExpectDebugElementByCss(wrapperDe, 'div.modal-header', 1, 1);
-            const hDes = getAndExpectDebugElementByCss(divDes[0], 'h4.modal-title', 1, 1);
-            const hEl: HTMLHeadingElement = hDes[0].nativeElement;
+            it('... should have h5.modal-title in div.modal-header', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div.modal-header', 1, 1);
+                getAndExpectDebugElementByCss(divDes[0], 'h5.modal-title', 1, 1);
+            });
 
-            expectToBe(hEl.textContent, expectedModalTitle);
-        });
+            it('... should have close button without label in div.modal-header', () => {
+                const divDes = getAndExpectDebugElementByCss(compDe, 'div.modal-header', 1, 1);
+                const btnDes = getAndExpectDebugElementByCss(divDes[0], 'button.btn-close', 1, 1);
+                const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
 
-        it('... should have close button without label in div.modal-header', () => {
-            const divDes = getAndExpectDebugElementByCss(wrapperDe, 'div.modal-header', 1, 1);
-            const btnDes = getAndExpectDebugElementByCss(divDes[0], 'button.btn-close', 1, 1);
-            const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
+                expectToBe(btnEl.textContent, '');
+                expectToBe(btnEl.getAttribute('aria-label'), 'Close modal');
+            });
 
-            expectToBe(btnEl.textContent, '');
-            expectToBe(btnEl.getAttribute('aria-label'), 'Close modal');
-        });
+            it('... should have one div.modal-body', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.modal-body', 1, 1);
+            });
 
-        it('... should have one div.modal-body', () => {
-            getAndExpectDebugElementByCss(wrapperDe, 'div.modal-body', 1, 1);
-        });
+            it('... should have one div.modal-footer', () => {
+                getAndExpectDebugElementByCss(compDe, 'div.modal-footer', 1, 1);
+            });
 
-        it('... should render the modal content in div.modal-body', async () => {
-            component.open(expectedSnippetKey1);
-
-            await detectChangesOnPush(fixture);
-
-            const bodyDes = getAndExpectDebugElementByCss(wrapperDe, 'div.modal-body', 1, 1);
-            const bodyEl: HTMLDivElement = bodyDes[0].nativeElement;
-
-            // Process HTML expression of content snippet
-            const htmlSnippet = mockDocument.createElement('p');
-            htmlSnippet.innerHTML = EXPECTED_MODAL_CONTENT_SNIPPETS[expectedSnippetKey1];
-
-            expectToBe(bodyEl.textContent.trim(), htmlSnippet.textContent.trim());
-        });
-
-        it('... should have one div.modal-footer', () => {
-            getAndExpectDebugElementByCss(wrapperDe, 'div.modal-footer', 1, 1);
-        });
-
-        it('... should have one close button.awg-modal-button in div.modal-footer', () => {
-            const footerDes = getAndExpectDebugElementByCss(wrapperDe, 'div.modal-footer', 1, 1);
-            getAndExpectDebugElementByCss(footerDes[0], 'button.awg-modal-button', 1, 1);
-        });
-
-        it('... should render the modal close label', () => {
-            const footerDes = getAndExpectDebugElementByCss(wrapperDe, 'div.modal-footer', 1, 1);
-            const btnDes = getAndExpectDebugElementByCss(footerDes[0], 'button.awg-modal-button', 1, 1);
-            const btnEl: HTMLButtonElement = btnDes[0].nativeElement;
-
-            expectToBe(btnEl.textContent.trim(), expectedModalCloseLabel);
+            it('... should have one close button.awg-modal-button in div.modal-footer', () => {
+                const footerDes = getAndExpectDebugElementByCss(compDe, 'div.modal-footer', 1, 1);
+                getAndExpectDebugElementByCss(footerDes[0], 'button.awg-modal-button', 1, 1);
+            });
         });
     });
 
-    describe('#open()', () => {
+    describe('AFTER initial data binding', () => {
         beforeEach(() => {
-            component.open(expectedSnippetKey1);
+            // Set the initial values for the signal inputs
+            fixture.componentRef.setInput('modalData', expectedTextData);
+
+            // Trigger initial data binding
+            fixture.detectChanges();
         });
 
-        it('... should have a method `open`', () => {
-            expect(component.open).toBeDefined();
+        it('... should have `modalData`', () => {
+            expectToBe(component.modalData, expectedTextData);
         });
 
-        it('... should open the modal via ngbModal', () => {
-            // Modal is open
-            expectSpyCall(ngbModalOpenSpy, 1, [component.modalTemplate, { ariaLabelledBy: 'awg-modal' }]);
-            expect(component.closeResult).toBeUndefined();
-        });
+        describe('VIEW', () => {
+            it('... should call activeModal.dismiss when clicking the header close button', async () => {
+                const dismissBtnDes = getAndExpectDebugElementByCss(
+                    compDe,
+                    'div.modal-header > button.btn-close',
+                    1,
+                    1
+                );
+                await clickAndAwaitChanges(dismissBtnDes[0], fixture);
 
-        it('... should set the correct modal content if snippet is known', async () => {
-            expectToBe(component.modalContent, EXPECTED_MODAL_CONTENT_SNIPPETS[expectedSnippetKey1]);
-
-            component.open(expectedSnippetKey2);
-            await detectChangesOnPush(fixture);
-
-            expectToBe(component.modalContent, EXPECTED_MODAL_CONTENT_SNIPPETS[expectedSnippetKey2]);
-        });
-
-        it('... should set the modal content to empty string if snippet is unknown', async () => {
-            component.open(expectedUnknownSnippetKey);
-            await detectChangesOnPush(fixture);
-
-            expectToBe(component.modalContent, '');
-        });
-
-        it('... should return the close result of the modal', async () => {
-            const closeMessage = `Click on ${expectedModalCloseLabel}`;
-            const expectedCloseResult = `Closed with: ${closeMessage}`;
-            mockModalRef.result = new Promise(resolve => resolve(closeMessage));
-
-            component.open(expectedSnippetKey1);
-            await detectChangesOnPush(fixture);
-
-            await expect(
-                ngbModal.open(component.modalTemplate, { ariaLabelledBy: 'awg-modal' }).result
-            ).resolves.toEqual(closeMessage);
-
-            expectToBe(component.closeResult, expectedCloseResult);
-        });
-
-        describe('should return the dismiss reason of the modal', () => {
-            it('... when clicking on close button', async () => {
-                const dismissEvent = 'Click on dismiss button';
-                const expectedDismissReason = `Dismissed with: ${dismissEvent}`;
-                mockModalRef.result = new Promise((_resolve, reject) => reject(dismissEvent));
-
-                component.open(expectedSnippetKey1);
-                await detectChangesOnPush(fixture);
-
-                await expect(
-                    ngbModal.open(component.modalTemplate, { ariaLabelledBy: 'awg-modal' }).result
-                ).rejects.toEqual(dismissEvent);
-
-                expectToBe(component.closeResult, expectedDismissReason);
+                expectSpyCall(activeModalSpy.dismiss, 1);
             });
 
-            it('... when pressing ESC key', async () => {
-                const dismissEvent = ModalDismissReasons.ESC;
-                const expectedDismissReason = `Dismissed by pressing ESC`;
-                mockModalRef.result = new Promise((_resolve, reject) => reject(dismissEvent));
+            it('... should render the modal close label in footer', () => {
+                const closeBtnDes = getAndExpectDebugElementByCss(
+                    compDe,
+                    'div.modal-footer > button.awg-modal-button',
+                    1,
+                    1
+                );
+                const closeBtnEl: HTMLButtonElement = closeBtnDes[0].nativeElement;
 
-                component.open(expectedSnippetKey1);
-                await detectChangesOnPush(fixture);
-
-                await expect(
-                    ngbModal.open(component.modalTemplate, { ariaLabelledBy: 'awg-modal' }).result
-                ).rejects.toEqual(dismissEvent);
-
-                expectToBe(component.closeResult, expectedDismissReason);
+                expectToBe(closeBtnEl.textContent.trim(), 'Schließen');
             });
 
-            it('... when clicking on backdrop', async () => {
-                const dismissEvent = ModalDismissReasons.BACKDROP_CLICK;
-                const expectedDismissReason = `Dismissed by clicking on a backdrop`;
-                mockModalRef.result = new Promise((_resolve, reject) => reject(dismissEvent));
+            it('... should call activeModal.close when clicking the footer close button', async () => {
+                const closeBtnDes = getAndExpectDebugElementByCss(
+                    compDe,
+                    'div.modal-footer > button.awg-modal-button',
+                    1,
+                    1
+                );
+                await clickAndAwaitChanges(closeBtnDes[0], fixture);
 
-                component.open(expectedSnippetKey1);
-                await detectChangesOnPush(fixture);
+                expectSpyCall(activeModalSpy.close, 1);
+            });
 
-                await expect(
-                    ngbModal.open(component.modalTemplate, { ariaLabelledBy: 'awg-modal' }).result
-                ).rejects.toEqual(dismissEvent);
+            describe('with text content', () => {
+                beforeEach(() => {
+                    fixture.componentRef.setInput('modalData', expectedTextData);
 
-                expectToBe(component.closeResult, expectedDismissReason);
+                    fixture.detectChanges();
+                });
+
+                it('... should render the modal title label', () => {
+                    const divDes = getAndExpectDebugElementByCss(compDe, 'div.modal-header', 1, 1);
+                    const hDes = getAndExpectDebugElementByCss(divDes[0], 'h5.modal-title', 1, 1); // H5 an dein neues Template angepasst
+                    const hEl: HTMLHeadingElement = hDes[0].nativeElement;
+
+                    expectToBe(hEl.textContent.trim(), expectedTextData.title);
+                });
+
+                it('... should render the modal content in div.modal-body', () => {
+                    const bodyDes = getAndExpectDebugElementByCss(compDe, 'div.modal-body', 1, 1);
+                    const innerDivDes = getAndExpectDebugElementByCss(bodyDes[0], 'div.text-start', 1, 1);
+                    const innerDivEl: HTMLDivElement = innerDivDes[0].nativeElement;
+
+                    const htmlSnippet = mockDocument.createElement('p');
+                    htmlSnippet.innerHTML = expectedTextData.content;
+
+                    expectToBe(innerDivEl.textContent.trim(), htmlSnippet.textContent.trim());
+                });
+
+                it('... should not render an image tag when type is text', () => {
+                    const bodyDes = getAndExpectDebugElementByCss(compDe, 'div.modal-body', 1, 1);
+
+                    getAndExpectDebugElementByCss(bodyDes[0], 'img.img-fluid', 0, 0);
+                });
+            });
+
+            describe('with image content', () => {
+                beforeEach(() => {
+                    fixture.componentRef.setInput('modalData', expectedImageData);
+
+                    fixture.detectChanges();
+                });
+
+                it('... should render the dynamic image title label', () => {
+                    const divDes = getAndExpectDebugElementByCss(compDe, 'div.modal-header', 1, 1);
+                    const hDes = getAndExpectDebugElementByCss(divDes[0], 'h5.modal-title', 1, 1);
+                    const hEl: HTMLHeadingElement = hDes[0].nativeElement;
+
+                    expectToBe(hEl.textContent.trim(), expectedImageData.title);
+                });
+
+                it('... should render the image tag with correct src and alt attributes', () => {
+                    const bodyDes = getAndExpectDebugElementByCss(compDe, 'div.modal-body', 1, 1);
+                    const imgDes = getAndExpectDebugElementByCss(bodyDes[0], 'img.img-fluid', 1, 1);
+                    const imgEl: HTMLImageElement = imgDes[0].nativeElement;
+
+                    expectToBe(imgEl.getAttribute('src'), expectedImageData.content);
+                    expectToBe(imgEl.getAttribute('alt'), expectedImageData.title);
+                });
+
+                it('... should not render the text container when type is image', () => {
+                    const bodyDes = getAndExpectDebugElementByCss(compDe, 'div.modal-body', 1, 1);
+
+                    getAndExpectDebugElementByCss(bodyDes[0], 'div.text-start', 0, 0);
+                });
             });
         });
     });

--- a/src/app/shared/modal/modal.component.ts
+++ b/src/app/shared/modal/modal.component.ts
@@ -1,114 +1,33 @@
-import { Component, inject, TemplateRef, ViewChild } from '@angular/core';
-import { ModalDismissReasons, NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { Component, inject, Input } from '@angular/core';
 
-import { MODAL_CONTENT_SNIPPETS } from './modal-content-snippets.data';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+
+import { ModalData } from './modal.model';
 
 /**
  * The Modal component.
  *
- * It contains a modal template that is
- * provided via the {@link SharedModule}.
+ * It contains a modal template that passes the modal data to the modal content component.
  */
 @Component({
     selector: 'awg-modal',
     templateUrl: './modal.component.html',
     styleUrls: ['./modal.component.scss'],
-    standalone: false,
 })
 export class ModalComponent {
     /**
-     * ViewChild variable: modalTemplate.
+     * Readonly injection variable: _activeModal.
      *
-     * It keeps the reference to the HTML template.
+     * It keeps the instance of the injected NgbActiveModal.
      */
-    @ViewChild('modalTemplate')
-    modalTemplate: TemplateRef<any>;
+    readonly activeModal = inject(NgbActiveModal);
 
     /**
-     * Public variable: modalTitle.
+     * Input variable: modalData.
      *
-     * It keeps the title of the modal
-     * to be displayed in the header.
+     * It keeps the data for the modal content.
+     *
+     * @todo Use input signal as soon as NgbActiveModal supports signals
      */
-    modalTitle = 'Hinweis';
-
-    /**
-     * Public variable: modalCloseLabel.
-     *
-     * It keeps the label for the
-     * closing button of the modal
-     * to be displayed in the footer.
-     */
-    modalCloseLabel = 'Schließen';
-
-    /**
-     * Public variable: modalContent.
-     *
-     * It keeps the content of the modal
-     * to be displayed in the body.
-     */
-    modalContent: string;
-
-    /**
-     * Public variable: closeResult.
-     *
-     * It keeps a message after the
-     * closing event of the modal.
-     */
-    closeResult: string;
-
-    /**
-     * Private readonly injection variable: _ngbModal.
-     *
-     * It keeps the instance of the injected NgbModal.
-     */
-    private readonly _ngbModal = inject(NgbModal);
-
-    /**
-     * Private static method: _getDismissReason.
-     *
-     * It gets the dismiss reason message
-     * of the closing event of the modal.
-     *
-     * @param {*} reason The given reason.
-     * @returns {string} The dismiss reason message.
-     */
-    private static _getDismissReason(reason: any): string {
-        if (reason === ModalDismissReasons.ESC) {
-            return 'by pressing ESC';
-        } else if (reason === ModalDismissReasons.BACKDROP_CLICK) {
-            return 'by clicking on a backdrop';
-        } else {
-            return `with: ${reason}`;
-        }
-    }
-
-    /**
-     * Public method: open.
-     *
-     * It opens the modal with the text snippet
-     * represented by the given snippet key.
-     *
-     * Snippet key must be an existing key of MODAL_CONTENT_SNIPPETS.
-     *
-     * @param {string} modalContentSnippetKey The given snippet key.
-     *
-     * @returns {void} Opens the modal.
-     */
-    open(modalContentSnippetKey: string): void {
-        // Get modal text
-        this.modalContent = MODAL_CONTENT_SNIPPETS[modalContentSnippetKey]
-            ? MODAL_CONTENT_SNIPPETS[modalContentSnippetKey]
-            : '';
-
-        // Open modalTemplate via modalService
-        this._ngbModal.open(this.modalTemplate, { ariaLabelledBy: 'awg-modal' }).result.then(
-            result => {
-                this.closeResult = `Closed with: ${result}`;
-            },
-            reason => {
-                this.closeResult = `Dismissed ${ModalComponent._getDismissReason(reason)}`;
-            }
-        );
-    }
+    @Input() modalData: ModalData;
 }

--- a/src/app/shared/modal/modal.component.ts
+++ b/src/app/shared/modal/modal.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, Input } from '@angular/core';
 
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
 
 import { ModalData } from './modal.model';
 
@@ -29,5 +29,5 @@ export class ModalComponent {
      *
      * @todo Use input signal as soon as NgbActiveModal supports signals
      */
-    @Input() modalData: ModalData;
+    @Input() modalData: ModalData | undefined;
 }

--- a/src/app/shared/modal/modal.model.ts
+++ b/src/app/shared/modal/modal.model.ts
@@ -1,0 +1,33 @@
+/**
+ * The ModalType type.
+ *
+ * It defines the possible types of modal data, either 'text' or 'image'.
+ */
+export type ModalType = 'text' | 'image';
+
+/**
+ * The ModalData interface.
+ *
+ * It defines the structure of the data used in the modal component.
+ */
+export interface ModalData {
+    /**
+     * The type of the modal data.
+     */
+    type: ModalType;
+
+    /**
+     * The identifier for the modal data.
+     */
+    id: string;
+
+    /**
+     * The title of the modal data.
+     */
+    title: string;
+
+    /**
+     * The content of the modal data, which can be text or an image source.
+     */
+    content: string;
+}

--- a/src/app/shared/modal/modal.service.spec.ts
+++ b/src/app/shared/modal/modal.service.spec.ts
@@ -1,60 +1,193 @@
 import { isSignal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+type Spy = ReturnType<typeof vi.spyOn>;
 
-import { expectToBe } from '@testing/expect-helper';
+import { ModalDismissReasons, NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap/modal';
+
+import { expectSpyCall, expectToBe, expectToEqual } from '@testing/expect-helper';
+import { mockEditionData } from '@testing/mock-data/mockEditionData';
+
+import { MODAL_TEXT_SNIPPETS } from './modal-text-snippets.data';
+import { ModalComponent } from './modal.component';
+import { ModalData } from './modal.model';
 
 import { ModalService } from './modal.service';
 
 describe('ModalService (DONE)', () => {
     let service: ModalService;
 
+    let mockModal: Partial<NgbModal>;
+    let mockModalRef: Partial<NgbModalRef>;
+
+    let openSpy: Spy;
+    let openModalSpy: Spy;
+
+    let expectedSnippetKey: string;
+    let expectedTextModalData: ModalData;
+    let expectedImageModalData: ModalData;
+
+    let expectedImgId: string;
+    let expectedImgSrc: string;
+
     beforeEach(() => {
+        // Mock NgbModal and NgbModalRef
+        mockModalRef = {
+            componentInstance: {},
+            result: new Promise(() => {}),
+        };
+
+        mockModal = {
+            open: vi.fn().mockReturnValue(mockModalRef),
+        };
+
         TestBed.configureTestingModule({
-            providers: [ModalService],
+            providers: [ModalService, { provide: NgbModal, useValue: mockModal }],
         });
+
         // Inject services
         service = TestBed.inject(ModalService);
+
+        // Spies
+        openSpy = vi.spyOn(service as any, '_open');
+        openModalSpy = vi.spyOn(mockModal, 'open');
+
+        // Test data
+        expectedSnippetKey = structuredClone(mockEditionData.mockModalSnippet);
+        const expectedText = MODAL_TEXT_SNIPPETS[expectedSnippetKey] || '';
+        expectedTextModalData = {
+            type: 'text',
+            id: expectedSnippetKey,
+            title: 'Hinweis',
+            content: expectedText,
+        };
+
+        expectedImgId = 'snip-123';
+        expectedImgSrc = 'assets/img/test.png';
+        expectedImageModalData = {
+            type: 'image',
+            id: expectedImgId,
+            title: `Abbildung: ${expectedImgId}`,
+            content: expectedImgSrc,
+        };
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('... should be created', () => {
         expect(service).toBeTruthy();
     });
 
-    it('... should have signal `_selectedModalId` to hold null initially', () => {
-        expectToBe(isSignal((service as any)._selectedModalId), true);
+    it('... should have signal `closeResult` to hold empty string initially', () => {
+        expect(isSignal(service.closeResult)).toBe(true);
 
-        expectToBe((service as any)._selectedModalId(), null);
-    });
-
-    it('... should have signal `selectedModalId` to hold null initially', () => {
-        expectToBe(isSignal(service.selectedModalId), true);
-
-        expectToBe(service.selectedModalId(), null);
+        expectToBe(service.closeResult(), '');
     });
 
     describe('METHODS', () => {
-        describe('#updateModalId()', () => {
-            it('... should have a method `updateModalId`', () => {
-                expect(service.updateModalId).toBeDefined();
+        describe('#openTextModal()', () => {
+            it('... should have a method `openTextModal`', () => {
+                expect(service.openTextModal).toBeDefined();
             });
 
-            it('... should set the `selectedModalId` signal to the given id', () => {
-                const expectedId = 'snippet_123';
+            it('... should prepare correct ModalData and call `_open`', () => {
+                service.openTextModal(expectedSnippetKey);
 
-                service.updateModalId(expectedId);
-
-                expectToBe(service.selectedModalId(), expectedId);
+                expectSpyCall(openSpy, 1, [expectedTextModalData]);
             });
 
-            it('... should set the `_selectedModalId` signal to null if null is given', () => {
-                service.updateModalId('snippet_abc');
-                expectToBe(service.selectedModalId(), 'snippet_abc');
+            it('... should prepare ModalData with empty content if snippetKey is unknown and forward it to `_open`', () => {
+                const unknownKey = 'NON_EXISTING_KEY';
+                const expectedUnknownModalData = {
+                    type: 'text',
+                    id: unknownKey,
+                    title: 'Hinweis',
+                    content: '',
+                };
 
-                service.updateModalId(null);
+                service.openTextModal(unknownKey);
 
-                expectToBe(service.selectedModalId(), null);
+                expectSpyCall(openSpy, 1, [expectedUnknownModalData]);
+            });
+        });
+
+        describe('#openImageModal()', () => {
+            it('... should have a method `openImageModal`', () => {
+                expect(service.openImageModal).toBeDefined();
+            });
+
+            it('... should prepare correct ModalData for images and call `_open`', () => {
+                service.openImageModal(expectedImgId, expectedImgSrc);
+
+                expectSpyCall(openSpy, 1, [expectedImageModalData]);
+            });
+        });
+
+        describe('#_open()', () => {
+            it('... should have a method `_open`', () => {
+                expect((service as any)._open).toBeDefined();
+            });
+
+            const modalCases = [{ type: 'text' }, { type: 'image' }];
+
+            describe('... should open the ModalComponent via NgbModal for', () => {
+                it.each(modalCases)('...  $type modal', ({ type }) => {
+                    const expectedData = type === 'text' ? expectedTextModalData : expectedImageModalData;
+
+                    (service as any)._open(expectedData);
+
+                    expectSpyCall(openModalSpy, 1, [
+                        ModalComponent,
+                        {
+                            size: 'xl',
+                            centered: true,
+                            ariaLabelledBy: 'awg-modal',
+                        },
+                    ]);
+                });
+            });
+
+            describe('... should pass modalData to componentInstance for', () => {
+                it.each(modalCases)('... $type modal', ({ type }) => {
+                    const expectedData = type === 'text' ? expectedTextModalData : expectedImageModalData;
+
+                    (service as any)._open(expectedData);
+
+                    expectToEqual(mockModalRef.componentInstance.modalData, expectedData);
+                });
+            });
+
+            it('... should set signal `closeResult` when modal is closed successfully', async () => {
+                mockModalRef.result = Promise.resolve('Save click');
+
+                service.openTextModal(expectedSnippetKey);
+
+                await new Promise(process.nextTick);
+
+                expectToBe(service.closeResult(), 'Closed with: Save click');
+            });
+        });
+
+        describe('#_getDismissReason()', () => {
+            it('... should have a method `_getDismissReason`', () => {
+                expect((service as any)._getDismissReason).toBeDefined();
+            });
+
+            it.each([
+                { reason: ModalDismissReasons.ESC, expected: 'by pressing ESC' },
+                { reason: ModalDismissReasons.BACKDROP_CLICK, expected: 'by clicking on a backdrop' },
+                { reason: 'any other reason', expected: 'with: any other reason' },
+            ])('... should return "$expected" when reason is $reason', async ({ reason, expected }) => {
+                mockModalRef.result = Promise.reject(reason);
+
+                service.openTextModal(expectedSnippetKey);
+
+                await new Promise(process.nextTick);
+
+                expectToBe(service.closeResult(), `Dismissed ${expected}`);
             });
         });
     });

--- a/src/app/shared/modal/modal.service.ts
+++ b/src/app/shared/modal/modal.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, signal } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
+
+import { ModalDismissReasons, NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
+
+import { MODAL_TEXT_SNIPPETS } from './modal-text-snippets.data';
+import { ModalComponent } from './modal.component';
+import { ModalData } from './modal.model';
 
 /**
  * The ModalService.
@@ -10,28 +16,104 @@ import { Injectable, signal } from '@angular/core';
 })
 export class ModalService {
     /**
-     * Private readonly signal: _selectedModalId.
+     * Private readonly injection variable: _ngbModal.
      *
-     * It holds the id of the currently selected modal snippet.
+     * It keeps the instance of the injected NgbModal.
      */
-    private readonly _selectedModalId = signal<string | null>(null);
+    private readonly _ngbModal = inject(NgbModal);
 
     /**
-     * Public readonly signal: selectedModalId.
+     * Readonly signal: closeResult.
      *
-     * It exposes the id of the currently selected modal snippet as a readonly signal.
+     * It holds the result of the modal close or dismiss action.
      */
-    readonly selectedModalId = this._selectedModalId.asReadonly();
+    readonly closeResult = signal('');
 
     /**
-     * Public method: updateModalId.
+     * Public method: openTextModal.
      *
-     * It updates the selected modal snippet id or resets it to null.
+     * It opens the modal component with a text snippet from MODAL_CONTENT_SNIPPETS.
      *
-     * @param {string | null} id The given modal snippet id or null to reset.
-     * @returns {void} Updates the signal.
+     * @param {string} snippetKey The key of the text snippet.
+     * @returns {void} Opens the modal.
      */
-    updateModalId(id: string | null): void {
-        this._selectedModalId.set(id);
+    openTextModal(snippetKey: string): void {
+        const textSnippet = MODAL_TEXT_SNIPPETS[snippetKey] || '';
+
+        const modalData: ModalData = {
+            type: 'text',
+            id: snippetKey,
+            title: 'Hinweis',
+            content: textSnippet,
+        };
+
+        this._open(modalData);
+    }
+
+    /**
+     * Public method: openImageModal.
+     *
+     * It opens the modal component with an image snippet.
+     *
+     * @param {string} imgId The identifier for the image.
+     * @param {string} imgSrc The image source URL.
+     * @returns {void} Opens the modal.
+     */
+    openImageModal(imgId: string, imgSrc: string): void {
+        const modalData: ModalData = {
+            type: 'image',
+            id: imgId,
+            title: `Abbildung: ${imgId}`,
+            content: imgSrc,
+        };
+
+        this._open(modalData);
+    }
+
+    /**
+     * Private method: _open.
+     *
+     * An internal helper method to open the ModalComponent via NgbModal
+     * and supply it with the required ModalData input signal.
+     *
+     * @param {ModalData} modalData The data for the modal.
+     * @returns {void} Opens the modal via NgBootstrap.
+     */
+    private _open(modalData: ModalData): void {
+        const modalRef = this._ngbModal.open(ModalComponent, {
+            size: 'xl',
+            centered: true,
+            ariaLabelledBy: 'awg-modal',
+        });
+
+        modalRef.componentInstance.modalData = modalData;
+
+        modalRef.result.then(
+            result => {
+                this.closeResult.set(`Closed with: ${result}`);
+            },
+            reason => {
+                this.closeResult.set(`Dismissed ${this._getDismissReason(reason)}`);
+            }
+        );
+    }
+
+    /**
+     * Private method: _getDismissReason.
+     *
+     * It returns a string describing the reason for modal dismissal.
+     *
+     * @param {any} reason The reason for dismissal.
+     * @returns {string} The dismissal reason as a string.
+     */
+    private _getDismissReason(reason: any): string {
+        switch (reason) {
+            case ModalDismissReasons.ESC:
+                return 'by pressing ESC';
+            case ModalDismissReasons.BACKDROP_CLICK:
+                return 'by clicking on a backdrop';
+            default:
+                return `with: ${reason}`;
+        }
     }
 }

--- a/src/app/shared/modal/modal.service.ts
+++ b/src/app/shared/modal/modal.service.ts
@@ -32,7 +32,7 @@ export class ModalService {
     /**
      * Public method: openTextModal.
      *
-     * It opens the modal component with a text snippet from MODAL_CONTENT_SNIPPETS.
+     * It opens the modal component with a text snippet from MODAL_TEXT_SNIPPETS.
      *
      * @param {string} snippetKey The key of the text snippet.
      * @returns {void} Opens the modal.
@@ -74,7 +74,7 @@ export class ModalService {
      * Private method: _open.
      *
      * An internal helper method to open the ModalComponent via NgbModal
-     * and supply it with the required ModalData input signal.
+     * and supply it with the required ModalData input.
      *
      * @param {ModalData} modalData The data for the modal.
      * @returns {void} Opens the modal via NgBootstrap.

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -66,6 +66,7 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
         LicenseComponent,
         LogoComponent,
         MetaIdentifierBadgesComponent,
+        ModalComponent,
         ScrollToTopButtonComponent,
         TwelveToneSpinnerComponent,
         ExternalLinkDirective,
@@ -74,7 +75,6 @@ import { OrderByPipe } from './order-by-pipe/order-by.pipe';
     declarations: [
         DisclaimerWorkeditionsComponent,
         JsonViewerComponent,
-        ModalComponent,
         RouterLinkButtonGroupComponent,
         TableComponent,
         TablePaginationComponent,


### PR DESCRIPTION
As another follow-up for #3302, this PR refactors the modal logic to be completely coordinated by the modal service, instead of only handing over the modal id. This encapsulates the logic in only one place and further reduces boilerplate logic in components.