### PR TITLE
refactor(shared): add fallback content for modal

### DIFF
--- a/src/app/shared/modal/modal-text-snippets.data.ts
+++ b/src/app/shared/modal/modal-text-snippets.data.ts
@@ -4,6 +4,7 @@
  * It provides the text snippets to be used in a modal.
  */
 export const MODAL_TEXT_SNIPPETS = {
+    CONTENTS_NOT_AVAILABLE: '<p>Diese Inhalte sind derzeit leider noch nicht verfügbar.</p>',
     OP12_SOURCE_NOT_AVAILABLE:
         '<p>Die Beschreibung der weiteren Quellenbestandteile von <strong>A</strong> sowie der Quellen <strong>C</strong> bis <strong>G<sup>H</sup></strong> einschließlich der darin gegebenenfalls enthaltenen Korrekturen erfolgt im Zusammenhang der vollständigen Edition der <em>Vier Lieder</em> op. 12 in AWG I/5.</p>',
     OP12_SHEET_COMING_SOON:

--- a/src/app/shared/modal/modal.component.spec.ts
+++ b/src/app/shared/modal/modal.component.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 type Spy = ReturnType<typeof vi.spyOn>;
 
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
 
 import { clickAndAwaitChanges } from '@testing/click-helper';
 import { expectSpyCall, expectToBe, getAndExpectDebugElementByCss } from '@testing/expect-helper';

--- a/src/app/shared/modal/modal.service.spec.ts
+++ b/src/app/shared/modal/modal.service.spec.ts
@@ -99,7 +99,7 @@ describe('ModalService (DONE)', () => {
                 expectSpyCall(openSpy, 1, [expectedTextModalData]);
             });
 
-            it('... should prepare ModalData with default content if snippetKey is undefined and trigger `_open`', () => {
+            it('... should prepare ModalData with default content if snippetKey is missing (undefined, null, or empty) and trigger `_open`', () => {
                 const defaultId = 'CONTENTS_NOT_AVAILABLE';
                 const defaultContent = MODAL_TEXT_SNIPPETS[defaultId];
 

--- a/src/app/shared/modal/modal.service.spec.ts
+++ b/src/app/shared/modal/modal.service.spec.ts
@@ -93,13 +93,37 @@ describe('ModalService (DONE)', () => {
                 expect(service.openTextModal).toBeDefined();
             });
 
-            it('... should prepare correct ModalData and call `_open`', () => {
+            it('... should prepare correct ModalData and trigger `_open`', () => {
                 service.openTextModal(expectedSnippetKey);
 
                 expectSpyCall(openSpy, 1, [expectedTextModalData]);
             });
 
-            it('... should prepare ModalData with empty content if snippetKey is unknown and forward it to `_open`', () => {
+            it('... should prepare ModalData with default content if snippetKey is undefined and trigger `_open`', () => {
+                const defaultId = 'CONTENTS_NOT_AVAILABLE';
+                const defaultContent = MODAL_TEXT_SNIPPETS[defaultId];
+
+                const expectedDefaultModalData = {
+                    type: 'text',
+                    id: defaultId,
+                    title: 'Hinweis',
+                    content: defaultContent,
+                };
+
+                service.openTextModal(undefined);
+
+                expectSpyCall(openSpy, 1, [expectedDefaultModalData]);
+
+                service.openTextModal(null);
+
+                expectSpyCall(openSpy, 2, [expectedDefaultModalData]);
+
+                service.openTextModal('');
+
+                expectSpyCall(openSpy, 3, [expectedDefaultModalData]);
+            });
+
+            it('... should prepare ModalData with empty content if snippetKey is unknown and trigger `_open`', () => {
                 const unknownKey = 'NON_EXISTING_KEY';
                 const expectedUnknownModalData = {
                     type: 'text',

--- a/src/app/shared/modal/modal.service.ts
+++ b/src/app/shared/modal/modal.service.ts
@@ -38,15 +38,15 @@ export class ModalService {
      * @returns {void} Opens the modal.
      */
     openTextModal(snippetKey: string): void {
-        const textSnippet = MODAL_TEXT_SNIPPETS[snippetKey] || '';
+        const id = snippetKey ? snippetKey : 'CONTENTS_NOT_AVAILABLE';
+        const textSnippet = MODAL_TEXT_SNIPPETS[id] || '';
 
         const modalData: ModalData = {
             type: 'text',
-            id: snippetKey,
+            id: id,
             title: 'Hinweis',
             content: textSnippet,
         };
-
         this._open(modalData);
     }
 

--- a/src/app/shared/modal/modal.service.ts
+++ b/src/app/shared/modal/modal.service.ts
@@ -34,10 +34,10 @@ export class ModalService {
      *
      * It opens the modal component with a text snippet from MODAL_TEXT_SNIPPETS.
      *
-     * @param {string} snippetKey The key of the text snippet.
+     * @param {string | null | undefined}  snippetKey The key of the text snippet.
      * @returns {void} Opens the modal.
      */
-    openTextModal(snippetKey: string): void {
+    openTextModal(snippetKey?: string | null): void {
         const id = snippetKey ? snippetKey : 'CONTENTS_NOT_AVAILABLE';
         const textSnippet = MODAL_TEXT_SNIPPETS[id] || '';
 


### PR DESCRIPTION
This PR is another follow-up for #3302 and adds a generic fallback content for modals, if no id is given.  